### PR TITLE
doesn't build with rome 0.9 - change to 1.0

### DIFF
--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>rome</groupId>
       <artifactId>rome</artifactId>
-      <version>0.9</version>
+      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>org.gagravarr</groupId>


### PR DESCRIPTION
Doesn't build on my machine at least (mac osx 10.7, JDK 1.6) with rome 0.9. Changing to rome 1.0 makes it build. Not sure if anybody else is having this issue but I sure am.
