### PR TITLE
Make Tika recognize empty and spanning ZIP files too

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -3437,25 +3437,10 @@
     <alias type="application/x-zip-compressed"/>
     <magic priority="40">
       <match value="PK\003\004" type="string" offset="0"/>
-    </magic>
-    <glob pattern="*.zip"/>
-  </mime-type>
-
-  <mime-type type="application/vnd.zip.empty">
-    <_comment>Empty Compressed Archive File</_comment>
-    <sub-class-of type="application/zip"/>
-    <magic priority="40">
       <match value="PK\005\006" type="string" offset="0"/>
-    </magic>
-    <glob pattern="*.zip"/>
-  </mime-type>
-
-  <mime-type type="application/vnd.zip.spanning">
-    <_comment>Spanning Compressed Archive File</_comment>
-    <sub-class-of type="application/zip"/>
-    <magic priority="40">
       <match value="PK\007\008" type="string" offset="0"/>
     </magic>
+    <glob pattern="*.zip"/>
   </mime-type>
 
   <mime-type type="application/x-7z-compressed">


### PR DESCRIPTION
As it turns out, magic differs for non-empty, empty and
spanning ZIP files. Tika recognizes only the non-empty ZIP files.

Magic for empty ZIP file is validated with hexdump:
https://gist.github.com/cstamas/6e90ae73f83c8e4a3f42

Also described on Wikipedia
http://en.wikipedia.org/wiki/Zip_(file_format)
(see sidebar with Magic Numbers)

Issue
https://issues.apache.org/jira/browse/TIKA-1241
