### PR TITLE
TIKA-1292: Upping application/zip priority in XML

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -3499,7 +3499,7 @@
     <tika:link>http://en.wikipedia.org/wiki/ZIP_(file_format)</tika:link>
     <tika:uti>com.pkware.zip-archive</tika:uti>
     <alias type="application/x-zip-compressed"/>
-    <magic priority="40">
+    <magic priority="50">
       <match value="PK\003\004" type="string" offset="0"/>
       <match value="PK\005\006" type="string" offset="0"/>
       <match value="PK\x07\x08" type="string" offset="0"/>


### PR DESCRIPTION
To not clash with html and work for uncompressed
ZIP files having HTML entries.

This is the simplest fix that removes the problem described in issue for the com.intellij:annotations:7.0.3 artifact.

Issue
https://issues.apache.org/jira/browse/TIKA-1292
