### PR TITLE
WIP TIKA-1292: Fixing the MimeTypes class to consider "clusters" of magics by priority

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/mime/MimeTypes.java
+++ b/tika-core/src/main/java/org/apache/tika/mime/MimeTypes.java
@@ -473,18 +473,20 @@ public final class MimeTypes implements Detector, Serializable {
             if (name != null) {
                 MimeType hint = getMimeType(name);
                 if (magicMatches.isEmpty()) {
-                  magicMatches.add(hint);
+                    magicMatches.add(hint);
                 } else {
-                    for (final ListIterator<MimeType> i = magicMatches.listIterator(); i.hasNext(); ) {
-                        final MimeType magicMatch = i.next();
+                    boolean hintMatched = false;
+                    for (final MimeType magicMatch : magicMatches) {
                         // do this if differs only
                         if (!hint.getType().equals(magicMatch.getType())) {
                             if (registry.isSpecializationOf(hint.getType(), magicMatch.getType())) {
-                                i.set(hint);
-                            } else if (!registry.isSpecializationOf(magicMatch.getType(), hint.getType())) {
-                                i.remove();
+                                hintMatched = true;
+                                break;
                             }
                         }
+                    }
+                    if (hintMatched) {
+                        magicMatches.add(0, hint);
                     }
                 }
             }
@@ -496,18 +498,20 @@ public final class MimeTypes implements Detector, Serializable {
             try {
                 MimeType hint = forName(typeName);
                 if (magicMatches.isEmpty()) {
-                  magicMatches.add(hint);
+                    magicMatches.add(hint);
                 } else {
-                    for (final ListIterator<MimeType> i = magicMatches.listIterator(); i.hasNext(); ) {
-                        final MimeType magicMatch = i.next();
+                    boolean hintMatched = false;
+                    for (final MimeType magicMatch : magicMatches) {
                         // do this if differs only
                         if (!hint.getType().equals(magicMatch.getType())) {
                             if (registry.isSpecializationOf(hint.getType(), magicMatch.getType())) {
-                                i.set(hint);
-                            } else if (!registry.isSpecializationOf(magicMatch.getType(), hint.getType())) {
-                                i.remove();
+                                hintMatched = true;
+                                break;
                             }
                         }
+                    }
+                    if (hintMatched) {
+                        magicMatches.add(0, hint);
                     }
                 }
             } catch (MimeTypeException e) {


### PR DESCRIPTION
This changes MimeTypes class to consider "clusters" of magics instead of "first found" to resolve priority clashes like those described in issue.

This is WIP, as the tika-core module builds okay, but tika-parsers module has one test failure, that am somewhat uncertain why. I'd like someone to take a peek and comment. Thanks.

Issue
https://issues.apache.org/jira/browse/TIKA-1292
