### PR TITLE
TIKA-1169: Adding other Mach-O magic bytes for jnilib files.

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -244,7 +244,10 @@
     <_comment>Java Native Library for OSX</_comment>
     <magic priority="50">
       <match value="0xcafebabe" type="string" offset="0">
-         <match value="0xfeedface" type="string" offset="4096"/>
+        <match value="0xfeedface" type="string" offset="4096"/>
+        <match value="0xfeedfacf" type="string" offset="4096"/>
+        <match value="0xcefaedfe" type="string" offset="4096"/>
+        <match value="0xcffaedfe" type="string" offset="4096"/>
       </match>
     </magic>
     <glob pattern="*.jnilib"/>


### PR DESCRIPTION
Adding remaining Mach-o binary signatures to fix TIKA-1169
