### PR TITLE
Bumps libpst version to fix TIKA-1350

### DIFF
--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -205,7 +205,7 @@
     <dependency>
     <groupId>com.pff</groupId>
       <artifactId>java-libpst</artifactId>
-      <version>0.7</version>
+      <version>0.8.1</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
When parsing some emails in a PST file I get the error "Unknown message type: IPM.Note" preventing them from being parsed. This is because of an extra null byte at the end of the message class string.
This has been fixed in version 0.8.1 of java-libpst so a version bump is all that is required. 
https://github.com/rjohnsondev/java-libpst/issues/14
