### PR TITLE
TIKA-1369 Avoid ThreadLocal usage from Memory Leak

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/image/ImageMetadataExtractor.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/image/ImageMetadataExtractor.java
@@ -380,25 +380,21 @@ public class ImageMetadataExtractor {
                 throws MetadataException {
             // Date/Time Original overrides value from ExifDirectory.TAG_DATETIME
             Date original = null;
-            if (directory.containsTag(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)) {
-                original = directory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
-                // Unless we have GPS time we don't know the time zone so date must be set
-                // as ISO 8601 datetime without timezone suffix (no Z or +/-)
-                if (original != null) {
-                    try {
+            try {
+	            if (directory.containsTag(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)) {
+	                original = directory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
+	                // Unless we have GPS time we don't know the time zone so date must be set
+	                // as ISO 8601 datetime without timezone suffix (no Z or +/-)
+	                if (original != null) {
                         String datetimeNoTimeZone = DATE_UNSPECIFIED_TZ.get().format(original); // Same time zone as Metadata Extractor uses
                         metadata.set(TikaCoreProperties.CREATED, datetimeNoTimeZone);
                         metadata.set(Metadata.ORIGINAL_DATE, datetimeNoTimeZone);
                     }
-                    finally {
-                        DATE_UNSPECIFIED_TZ.remove();
-                    }
                 }
-            }
-            if (directory.containsTag(ExifIFD0Directory.TAG_DATETIME)) {
-                Date datetime = directory.getDate(ExifIFD0Directory.TAG_DATETIME);
-                if (datetime != null) {
-                    try {
+
+                if (directory.containsTag(ExifIFD0Directory.TAG_DATETIME)) {
+                    Date datetime = directory.getDate(ExifIFD0Directory.TAG_DATETIME);
+                    if (datetime != null) {
                         String datetimeNoTimeZone = DATE_UNSPECIFIED_TZ.get().format(datetime);
                         metadata.set(TikaCoreProperties.MODIFIED, datetimeNoTimeZone);
                         // If Date/Time Original does not exist this might be creation date
@@ -406,10 +402,10 @@ public class ImageMetadataExtractor {
                             metadata.set(TikaCoreProperties.CREATED, datetimeNoTimeZone);
                         }
                     }
-                    finally {
-                        DATE_UNSPECIFIED_TZ.remove();
-                    }
                 }
+            }
+            finally {
+                DATE_UNSPECIFIED_TZ.remove();
             }
         }
     }


### PR DESCRIPTION
Hi @chrismattmann ,

Based on our discussion from https://github.com/apache/tika/pull/15 I've added the ThreadLocal clean up part, so theoretically it won't suffer from the scenario that @grossws mentioned.

Cheers,
Vilmos
