### PR TITLE
TIKA-1530: Include parsed mp4 duration in metadata

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 Release 1.8 - Current Development
 
+  * Include media duration in metadata parsed by MP4Parser (TIKA-1530).
+
   * Support password protected 7zip files (using a PasswordProvider,
     in keeping with the other password supporting formats) (TIKA-1521)
 

--- a/tika-parsers/src/main/java/org/apache/tika/parser/mp4/MP4Parser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/mp4/MP4Parser.java
@@ -164,6 +164,7 @@ public class MP4Parser extends AbstractParser {
 
                // Get the duration
                double durationSeconds = ((double)mHeader.getDuration()) / mHeader.getTimescale();
+               metadata.set(XMPDM.DURATION, durationSeconds);
                // TODO Use this
 
                // The timescale is normally the sampling rate

--- a/tika-parsers/src/test/java/org/apache/tika/parser/mp4/MP4ParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/mp4/MP4ParserTest.java
@@ -90,6 +90,8 @@ public class MP4ParserTest {
         assertEquals("44100", metadata.get(XMPDM.AUDIO_SAMPLE_RATE));
         assertEquals("Stereo", metadata.get(XMPDM.AUDIO_CHANNEL_TYPE));
         assertEquals("M4A", metadata.get(XMPDM.AUDIO_COMPRESSOR));
+        // Only compare two decimals to avoid floating point comparison error.
+        assertEquals("0.06", metadata.get(XMPDM.DURATION).substring(0, 4));
         
         assertEquals("iTunes 10.5.3.3", metadata.get(XMP.CREATOR_TOOL));
         


### PR DESCRIPTION
Note that I couldn't get all tests working in the project (https://issues.apache.org/jira/browse/TIKA-1521?focusedCommentId=14288719&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14288719) so I have only run `org.apache.tika.parser.mp4.MP4ParserTest`.

If someone with a working build could try this perhaps?