### PR TITLE
Added argLine value for maven-surefire-plugin

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -322,6 +322,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.12</version>
+          <configuration>
+            <argLine>-Xmx2048m</argLine>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Setting a higher maximum amount of memory prevents TestChmExtraction
from generating an OutOfMemory error from running out of heap space
when running parser tests and trying to install Tika 1.7 on OS X
10.10.2. This is to address issue TIKA-1537.