### PR TITLE
add magic detector for 'Status: ' standards-noncompliant header on message/rfc822

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5059,6 +5059,7 @@
 
   <mime-type type="message/rfc822">
     <magic priority="50">
+      <match value="Status:" type="string" offset="0"/>       <!-- added custom by Jeremy B. Merril 4/10/14 -->
       <match value="Relay-Version:" type="stringignorecase" offset="0"/>
       <match value="#!\ rnews" type="string" offset="0"/>
       <match value="N#!\ rnews" type="string" offset="0"/>


### PR DESCRIPTION
allows Tika to properly detect certain slightly standards-non-compliant email messages (dumped from certain US public officials' email servers) that begin with a `Status: ` header.

Jira ticket: [TIKA-1602](https://issues.apache.org/jira/browse/TIKA-1602)
See discussion on users mailing list for more details.

Passes unit tests; haven't tried Tika Batch yet.