### PR TITLE
Fix for TIKA-1664

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/gdal/GDALParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/gdal/GDALParser.java
@@ -103,7 +103,7 @@ public class GDALParser extends AbstractParser {
         types.add(MediaType.application("x-netcdf"));
         types.add(MediaType.application("vrt"));
         types.add(MediaType.image("geotiff"));
-        types.add(MediaType.image("ntif"));
+        types.add(MediaType.image("nitf"));
         types.add(MediaType.application("x-rpf-toc"));
         types.add(MediaType.application("x-ecrg-toc"));
         types.add(MediaType.image("hfa"));


### PR DESCRIPTION
Changed "ntif" to "nitf" in GDALParser's supported MediaTypes.