### PR TITLE
Fix for TIKA-1763

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/image/ImageMetadataExtractor.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/image/ImageMetadataExtractor.java
@@ -96,8 +96,10 @@ public class ImageMetadataExtractor {
     private static String trimPixels(String s) {
         //if height/width appears as "100 pixels", trim " pixels"
         if (s != null) {
-            int i = s.lastIndexOf(" pixels");
-            s = s.substring(0, i);
+            int i = s.lastIndexOf("pixels");
+            if (i > -1) {
+                s = s.substring(0, i).trim();
+            }
         }
         return s;
     }


### PR DESCRIPTION
-Prevents a StringIndexOutOfBoundsException by checking the result of a
call to lastIndexOf() before using it in a call to substring().
-Adds unit tests.