### PR TITLE
lower priority on magic for application/xhtml+xml 

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -3937,7 +3937,9 @@
   </mime-type>
 
   <mime-type type="application/xhtml+xml">
-    <magic priority="50">
+    <!-- The magic priority for xhtml+xml needs to be lower than that of -->
+    <!--  files that contain HTML within them, e.g. mime emails -->
+    <magic priority="40">
       <match value="&lt;html xmlns=" type="string" offset="0:8192"/>
     </magic>
     <root-XML namespaceURI="http://www.w3.org/1999/xhtml" localName="html"/>


### PR DESCRIPTION
to avoid misdetecting xhtml-containing emails as XHTML docs.

Emails I have (happy to share if you want) contain XHTML, as one part of a multipart email. Prior to this pull request, the priority on the `application/xhtml+xml` magic detector was 50, equal to the priority on the `message/rfc822` detector. Because of the relative position of the two detectors in `tika-mimetypes.xml`, the emails were incorrectly detected as XHTML documents.

With this PR, by downgrading the priority of `application/xhtml+xml` to 40, the more-sensitive email magic detectors take precedence, causing the emails to be properly detected as `message/rfc822`.

I have not run this thru the govdocs tester or anything other than my own documents, so, full disclosure, this could cause false negative xhtml-detections elsewhere.