### PR TITLE
Add parse(file, metadata) method

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/Tika.java
+++ b/tika-core/src/main/java/org/apache/tika/Tika.java
@@ -412,6 +412,21 @@ public class Tika {
 
     /**
      * Parses the given document and returns the extracted text content.
+     * Metadata information extracted from the document is returned in that
+     * same metadata instance.
+     * <p>
+     *
+     * @param file the document to be parsed
+     * @param metadata document metadata
+     * @return extracted text content
+     * @throws IOException if the document can not be read or parsed
+     */
+    public Reader parse(File file, Metadata metadata) throws IOException {
+        return parse(TikaInputStream.get(file.toPath(), metadata), metadata);
+    }
+
+    /**
+     * Parses the given document and returns the extracted text content.
      * <p>
      * The returned reader will be responsible for closing the given stream.
      * The stream and any associated resources will be closed at or before


### PR DESCRIPTION
The 'file' api is convenient to pass file extension information to the parser (especially when custom-mimetype for a glob pattern is configured)

> P.S. I was trying to activate `GeoParser` on `*.geot` files https://github.com/thammegowda/tika-geo-ner-model and it was helpful.