### PR TITLE
TIKA-1868 tika-server split into clean and standalone jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
                         <include name="target/*-src.zip*" />
                         <include name="tika-app/target/tika-app-${project.version}.jar*" />
                         <include name="tika-server/target/tika-server-${project.version}.jar*" />
+                        <include name="tika-server/target/tika-server-${project.version}-standalone.jar*" />
                       </fileset>
                     </copy>
                     <checksum algorithm="MD5" fileext=".md5">

--- a/tika-server/Dockerfile
+++ b/tika-server/Dockerfile
@@ -17,21 +17,21 @@ FROM ubuntu:latest
 MAINTAINER Apache Tika Team
 
 ENV TIKA_VERSION 1.7
-ENV TIKA_SERVER_URL https://www.apache.org/dist/tika/tika-server-$TIKA_VERSION.jar
+ENV TIKA_SERVER_URL https://www.apache.org/dist/tika/tika-server-$TIKA_VERSION-standalone.jar
 
 RUN	apt-get update \
 	&& apt-get install openjdk-7-jre-headless curl gdal-bin tesseract-ocr \
 		tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu -y \
 	&& curl -sSL https://people.apache.org/keys/group/tika.asc -o /tmp/tika.asc \
 	&& gpg --import /tmp/tika.asc \
-	&& curl -sSL "$TIKA_SERVER_URL.asc" -o /tmp/tika-server-${TIKA_VERSION}.jar.asc \
+	&& curl -sSL "$TIKA_SERVER_URL.asc" -o /tmp/tika-server-${TIKA_VERSION}-standalone.jar.asc \
 	&& NEAREST_TIKA_SERVER_URL=$(curl -sSL http://www.apache.org/dyn/closer.cgi/${TIKA_SERVER_URL#https://www.apache.org/dist/}\?asjson\=1 \
 		| awk '/"path_info": / { pi=$2; }; /"preferred":/ { pref=$2; }; END { print pref " " pi; };' \
 		| sed -r -e 's/^"//; s/",$//; s/" "//') \
 	&& echo "Nearest mirror: $NEAREST_TIKA_SERVER_URL" \
-	&& curl -sSL "$NEAREST_TIKA_SERVER_URL" -o /tika-server-${TIKA_VERSION}.jar \
-	&& gpg --verify /tmp/tika-server-${TIKA_VERSION}.jar.asc /tika-server-${TIKA_VERSION}.jar \
+	&& curl -sSL "$NEAREST_TIKA_SERVER_URL" -o /tika-server-${TIKA_VERSION}-standalone.jar \
+	&& gpg --verify /tmp/tika-server-${TIKA_VERSION}-standalone.jar.asc /tika-server-${TIKA_VERSION}-standalone.jar \
 	&& apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 9998
-ENTRYPOINT java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0
+ENTRYPOINT java -jar /tika-server-${TIKA_VERSION}-standalone.jar -h 0.0.0.0

--- a/tika-server/pom.xml
+++ b/tika-server/pom.xml
@@ -163,6 +163,12 @@
               <createDependencyReducedPom>
                 false
               </createDependencyReducedPom>
+              <shadedArtifactAttached>
+                true
+              </shadedArtifactAttached>
+              <shadedClassifierName>
+                standalone
+              </shadedClassifierName>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>


### PR DESCRIPTION
Understand based upon mailing email and jira defect this might be rejected.

But this the change I was intending to do, my original email was to understand if tika-server meant to be a shaded jar, which it appears to was intended to be.

But if you need to use classes that only live within tika-server it does make it harder to write custom code. If the guts of tika-server where put into another module maybe tika-server-internals then those that really need to used classes that just live in tika-server can use tika-server-internals and tika-server can be a simply shaded jar. Just a thought.