### PR TITLE
TIKA-1914: ExecutableParser doesn't call start document

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/executable/ExecutableParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/executable/ExecutableParser.java
@@ -65,6 +65,7 @@ public class ExecutableParser extends AbstractParser implements MachineMetadata 
             throws IOException, SAXException, TikaException {
         // We only do metadata, for now
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
+        xhtml.startDocument();
 
         // What kind is it?
         byte[] first4 = new byte[4];


### PR DESCRIPTION
ExecutableParser doesn't call start document which causes errors when producing XHTML