### PR TITLE
TIKA-1916: NPE in OpenDocumentParser

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/odf/OpenDocumentParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/odf/OpenDocumentParser.java
@@ -152,7 +152,9 @@ public class OpenDocumentParser extends AbstractParser {
         ZipEntry entry = null;
         if (zipFile != null) {
             entry = zipFile.getEntry(META_NAME);
-            handleZipEntry(entry, zipFile.getInputStream(entry), metadata, context, handler);
+            if (entry != null) {
+                handleZipEntry(entry, zipFile.getInputStream(entry), metadata, context, handler);
+            }
 
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {


### PR DESCRIPTION
NPE in OpenDocumentParser when no "meta.xml" file exists