### PR TITLE
fix for TIKA-1938 contributed by naegelejd

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/html/HtmlHandler.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/html/HtmlHandler.java
@@ -121,6 +121,9 @@ class HtmlHandler extends TextContentHandler {
             } else if ("LINK".equals(name)) {
                 startElementWithSafeAttributes("link", atts);
                 xhtml.endElement("link");
+            } else if ("SCRIPT".equals(name) && atts.getValue("src") != null) {
+                startElementWithSafeAttributes("script", atts);
+                xhtml.endElement("script");
             }
         }
 


### PR DESCRIPTION
Adds HtmlParser support for `<script>` tags within `<head>`.