### PR TITLE
TIKA-1978 Invocation of java.net.URL.equals(Object), which blocks to do domain name resolution, in org.apache.tika.parser.geo.topic.GeoParser.initialize(URL) 2.x branch

### DIFF
--- a/tika-parser-modules/tika-parser-scientific-module/src/main/java/org/apache/tika/parser/geo/topic/GeoParserConfig.java
+++ b/tika-parser-modules/tika-parser-scientific-module/src/main/java/org/apache/tika/parser/geo/topic/GeoParserConfig.java
@@ -30,7 +30,7 @@ public class GeoParserConfig implements Serializable {
         this.nerModelUrl = GeoParserConfig.class.getResource("en-ner-location.bin");
     }
 
-    public void setNERModelPath(String path) {
+    public void setNERModelPath(String path) throws MalformedURLException {
         if (path == null)
             return;
         File file = new File(path);
@@ -40,7 +40,7 @@ public class GeoParserConfig implements Serializable {
         try {
             this.nerModelUrl = file.toURI().toURL();
         } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+            throw new MalformedURLException(e.getMessage());
         }
     }
 

--- a/tika-parser-modules/tika-parser-scientific-module/src/main/java/org/apache/tika/parser/geo/topic/GeoTag.java
+++ b/tika-parser-modules/tika-parser-scientific-module/src/main/java/org/apache/tika/parser/geo/topic/GeoTag.java
@@ -18,18 +18,19 @@
 package org.apache.tika.parser.geo.topic;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class GeoTag {
-	String Geographic_NAME;
-	String Geographic_LONGTITUDE;
-	String Geographic_LATITUDE;
-	ArrayList<GeoTag> alternatives = new ArrayList<GeoTag>();
+	String geoNAME;
+	String geoLONGTITUDE;
+	String geoLATITUDE;
+	ArrayList<GeoTag> alternatives = new ArrayList<>();
 
 	public void setMain(String name, String longitude, String latitude) {
-		Geographic_NAME = name;
-		Geographic_LONGTITUDE = longitude;
-		Geographic_LATITUDE = latitude;
+		geoNAME = name;
+		geoLONGTITUDE = longitude;
+		geoLATITUDE = latitude;
 	}
 
 	public void addAlternative(GeoTag geotag) {
@@ -44,20 +45,20 @@ public class GeoTag {
 	 * @param bestNER best name entity among all the extracted entities for the
 	 * input stream
 	 */
-	public void toGeoTag(HashMap<String, ArrayList<String>> resolvedGeonames,
+	public void toGeoTag(Map<String, ArrayList<String>> resolvedGeonames,
 			String bestNER) {
 
-		for (String key : resolvedGeonames.keySet()) {
+		for (Entry<String, ArrayList<String>> key : resolvedGeonames.entrySet()) {
 			ArrayList<String> cur = resolvedGeonames.get(key);
 			if (key.equals(bestNER)) {
-				this.Geographic_NAME = cur.get(0);
-				this.Geographic_LONGTITUDE = cur.get(1);
-				this.Geographic_LATITUDE = cur.get(2);
+				this.geoNAME = cur.get(0);
+				this.geoLONGTITUDE = cur.get(1);
+				this.geoLATITUDE = cur.get(2);
 			} else {
 				GeoTag alter = new GeoTag();
-				alter.Geographic_NAME = cur.get(0);
-				alter.Geographic_LONGTITUDE = cur.get(1);
-				alter.Geographic_LATITUDE = cur.get(2);
+				alter.geoNAME = cur.get(0);
+				alter.geoLONGTITUDE = cur.get(1);
+				alter.geoLATITUDE = cur.get(2);
 				this.addAlternative(alter);
 			}
 		}

--- a/tika-parser-modules/tika-parser-scientific-module/src/main/java/org/apache/tika/parser/geo/topic/NameEntityExtractor.java
+++ b/tika-parser-modules/tika-parser-scientific-module/src/main/java/org/apache/tika/parser/geo/topic/NameEntityExtractor.java
@@ -43,11 +43,11 @@ public class NameEntityExtractor {
     private final NameFinderME nameFinder;
 
     public NameEntityExtractor(URL modelUrl) throws IOException {
-        this.locationNameEntities = new ArrayList<String>();
+        this.locationNameEntities = new ArrayList<>();
         this.bestNameEntity = null;
         TokenNameFinderModel model = new TokenNameFinderModel(modelUrl);
         this.nameFinder = new NameFinderME(model);
-        this.tf = new HashMap<String, Integer>();
+        this.tf = new HashMap<>();
     }
 
     /*
@@ -59,7 +59,7 @@ public class NameEntityExtractor {
      */
     public void getAllNameEntitiesfromInput(InputStream stream) throws IOException {
         String[] in = IOUtils.toString(stream, UTF_8).split(" ");
-        Span nameE[];
+        Span[] nameE;
         
         //name finder is not thread safe https://opennlp.apache.org/documentation/1.5.2-incubating/manual/opennlp.html#tools.namefind
         synchronized (nameFinder) {
@@ -89,7 +89,7 @@ public class NameEntityExtractor {
      * ArrayList
      */
     public void getBestNameEntity() {
-        if (this.locationNameEntities.size() == 0)
+        if (this.locationNameEntities.isEmpty())
             return;
 
         for (int i = 0; i < this.locationNameEntities.size(); ++i) {
@@ -100,10 +100,11 @@ public class NameEntityExtractor {
                 tf.put(this.locationNameEntities.get(i), 1);
         }
         int max = 0;
-        List<Map.Entry<String, Integer>> list = new ArrayList<Map.Entry<String, Integer>>(
+        List<Map.Entry<String, Integer>> list = new ArrayList<>(
                 tf.entrySet());
         Collections.shuffle(list);
         Collections.sort(list, new Comparator<Map.Entry<String, Integer>>() {
+            @Override
             public int compare(Map.Entry<String, Integer> o1,
                     Map.Entry<String, Integer> o2) {
                 // Descending Order


### PR DESCRIPTION
This issue addresses https://issues.apache.org/jira/browse/TIKA-1978 for the 2.x branch.
It also makes a number of additional improvements such as using the diamond operator where possible, throwing and logging the correct exceptions and using the correct syntax for constants.