### PR TITLE
Fixed TesseractOCRConfigTest and some TesseractOCRConfig refactoring

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRConfig.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRConfig.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
 
@@ -242,6 +243,7 @@ public class TesseractOCRConfig implements Serializable {
     /**
      * Set tesseract page segmentation mode.
      * Default is 1 = Automatic page segmentation with OSD (Orientation and Script Detection)
+     * Valid range is 1-10.
      */
     public void setPageSegMode(String pageSegMode) {
         if (!pageSegMode.matches("[1-9]|10")) {
@@ -374,8 +376,8 @@ public class TesseractOCRConfig implements Serializable {
      */
     public void setDepth(int depth) {
         int[] allowedValues = {2, 4, 8, 16, 32, 64, 256, 4096};
-        for (int i = 0; i < allowedValues.length; i++) {
-            if (depth == allowedValues[i]) {
+        for (int allowedValue : allowedValues) {
+            if (depth == allowedValue) {
                 this.depth = depth;
                 return;
             }
@@ -414,14 +416,16 @@ public class TesseractOCRConfig implements Serializable {
      *               Default value is triangle.
      */
     public void setFilter(String filter) {
-        if (filter.equals(null)) {
-            throw new IllegalArgumentException("Filter value cannot be null. Valid values are point, hermite, "
-                    + "cubic, box, gaussian, catrom, triangle, quadratic and mitchell.");
+        final String[] allowedFilters =
+                {"Point", "Hermite", "Cubic", "Box", "Gaussian", "Catrom", "Triangle", "Quadratic", "Mitchell"};
+
+        if (filter == null) {
+            throw new IllegalArgumentException(
+                    "Filter value cannot be null. Valid values are " + Arrays.toString(allowedFilters));
         }
 
-        String[] allowedFilters = {"Point", "Hermite", "Cubic", "Box", "Gaussian", "Catrom", "Triangle", "Quadratic", "Mitchell"};
-        for (int i = 0; i < allowedFilters.length; i++) {
-            if (filter.equalsIgnoreCase(allowedFilters[i])) {
+        for (String allowedFilter : allowedFilters) {
+            if (filter.equalsIgnoreCase(allowedFilter)) {
                 this.filter = filter;
                 return;
             }
@@ -456,7 +460,6 @@ public class TesseractOCRConfig implements Serializable {
      * @see #setImageMagickPath(String ImageMagickPath)
      */
     public String getImageMagickPath() {
-
         return ImageMagickPath;
     }
 
@@ -466,8 +469,10 @@ public class TesseractOCRConfig implements Serializable {
      * @param ImageMagickPath to ImageMagick file.
      */
     public void setImageMagickPath(String ImageMagickPath) {
-        if (!ImageMagickPath.isEmpty() && !ImageMagickPath.endsWith(File.separator))
+        if (!ImageMagickPath.isEmpty() &&
+                !ImageMagickPath.endsWith(File.separator)) {
             ImageMagickPath += File.separator;
+        }
 
         this.ImageMagickPath = ImageMagickPath;
     }

--- a/tika-parsers/src/test/java/org/apache/tika/parser/ocr/TesseractOCRConfigTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/ocr/TesseractOCRConfigTest.java
@@ -26,36 +26,35 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class TesseractOCRConfigTest extends TikaTest {
 
+    private TesseractOCRConfig config = new TesseractOCRConfig();
+
     @Test
-    public void testNoConfig() throws Exception {
-        TesseractOCRConfig config = new TesseractOCRConfig();
+    public void testDefaults() {
         assertEquals("Invalid default tesseractPath value", "", config.getTesseractPath());
         assertEquals("Invalid default tessdataPath value", "", config.getTessdataPath());
         assertEquals("Invalid default language value", "eng", config.getLanguage());
         assertEquals("Invalid default pageSegMode value", "1", config.getPageSegMode());
         assertEquals("Invalid default minFileSizeToOcr value", 0, config.getMinFileSizeToOcr());
         assertEquals("Invalid default maxFileSizeToOcr value", Integer.MAX_VALUE, config.getMaxFileSizeToOcr());
-        assertEquals("Invalid default timeout value", 120, config.getTimeout());  
+        assertEquals("Invalid default timeout value", 120, config.getTimeout());
         assertEquals("Invalid default ImageMagickPath value", "", config.getImageMagickPath());
-        assertEquals("Invalid default density value", 300 , config.getDensity());
-        assertEquals("Invalid default depth value", 4 , config.getDepth());
-        assertEquals("Invalid default colorpsace value", "gray" , config.getColorspace());
-        assertEquals("Invalid default filter value", "triangle" , config.getFilter());
-        assertEquals("Invalid default resize value", 900 , config.getResize());
+        assertEquals("Invalid default density value", 300, config.getDensity());
+        assertEquals("Invalid default depth value", 4, config.getDepth());
+        assertEquals("Invalid default colorpsace value", "gray", config.getColorspace());
+        assertEquals("Invalid default filter value", "triangle", config.getFilter());
+        assertEquals("Invalid default resize value", 900, config.getResize());
     }
 
     @Test
-    public void testPartialConfig() throws Exception {
-
+    public void partialConfig() {
         InputStream stream = TesseractOCRConfigTest.class.getResourceAsStream(
                 "/test-properties/TesseractOCRConfig-partial.properties");
 
-        TesseractOCRConfig config = new TesseractOCRConfig(stream);
+        config = new TesseractOCRConfig(stream);
         assertEquals("Invalid default tesseractPath value", "", config.getTesseractPath());
         assertEquals("Invalid default tessdataPath value", "", config.getTessdataPath());
         assertEquals("Invalid overridden language value", "fra+deu", config.getLanguage());
@@ -64,41 +63,38 @@ public class TesseractOCRConfigTest extends TikaTest {
         assertEquals("Invalid default maxFileSizeToOcr value", Integer.MAX_VALUE, config.getMaxFileSizeToOcr());
         assertEquals("Invalid overridden timeout value", 240, config.getTimeout());
         assertEquals("Invalid default ImageMagickPath value", "", config.getImageMagickPath());
-        assertEquals("Invalid overridden density value", 200 , config.getDensity());
-        assertEquals("Invalid overridden depth value", 8 , config.getDepth());
-        assertEquals("Invalid overridden filter value", "box" , config.getFilter());	
-        assertEquals("Invalid overridden resize value", 300 , config.getResize());
+        assertEquals("Invalid overridden density value", 200, config.getDensity());
+        assertEquals("Invalid overridden depth value", 8, config.getDepth());
+        assertEquals("Invalid overridden filter value", "box", config.getFilter());
+        assertEquals("Invalid overridden resize value", 300, config.getResize());
     }
 
     @Test
-    public void testFullConfig() throws Exception {
-
+    public void fullConfig() {
         InputStream stream = TesseractOCRConfigTest.class.getResourceAsStream(
                 "/test-properties/TesseractOCRConfig-full.properties");
 
-        TesseractOCRConfig config = new TesseractOCRConfig(stream);
-        if(SystemUtils.IS_OS_UNIX) {
-        	assertEquals("Invalid overridden tesseractPath value", "/opt/tesseract" + File.separator, config.getTesseractPath());
+        config = new TesseractOCRConfig(stream);
+        if (SystemUtils.IS_OS_UNIX) {
+            assertEquals("Invalid overridden tesseractPath value", "/opt/tesseract" + File.separator, config.getTesseractPath());
             assertEquals("Invalid overridden tesseractPath value", "/usr/local/share" + File.separator, config.getTessdataPath());
-        	assertEquals("Invalid overridden ImageMagickPath value", "/usr/local/bin/", config.getImageMagickPath());
+            assertEquals("Invalid overridden ImageMagickPath value", "/usr/local/bin/", config.getImageMagickPath());
         }
         assertEquals("Invalid overridden language value", "fra+deu", config.getLanguage());
         assertEquals("Invalid overridden pageSegMode value", "2", config.getPageSegMode());
         assertEquals("Invalid overridden minFileSizeToOcr value", 1, config.getMinFileSizeToOcr());
         assertEquals("Invalid overridden maxFileSizeToOcr value", 2000000, config.getMaxFileSizeToOcr());
         assertEquals("Invalid overridden timeout value", 240, config.getTimeout());
-        assertEquals("Invalid overridden density value", 200 , config.getDensity());
-        assertEquals("Invalid overridden depth value", 8 , config.getDepth());
-        assertEquals("Invalid overridden filter value", "box" , config.getFilter());
-        assertEquals("Invalid overridden resize value", 300 , config.getResize());
+        assertEquals("Invalid overridden density value", 200, config.getDensity());
+        assertEquals("Invalid overridden depth value", 8, config.getDepth());
+        assertEquals("Invalid overridden filter value", "box", config.getFilter());
+        assertEquals("Invalid overridden resize value", 300, config.getResize());
     }
 
     @Test
-    public void testValidateValidLanguage() {
+    public void validateValidLanguage() {
         List<String> validLanguages = Arrays.asList(
                 "eng", "slk_frak", "chi_tra", "eng+fra", "tgk+chi_tra+slk_frak");
-
-        TesseractOCRConfig config = new TesseractOCRConfig();
 
         for (String language : validLanguages) {
             config.setLanguage(language);
@@ -107,11 +103,9 @@ public class TesseractOCRConfigTest extends TikaTest {
     }
 
     @Test
-    public void testValidateInvalidLanguage() {
+    public void validateInvalidLanguage() {
         List<String> invalidLanguages = Arrays.asList(
                 "", "+", "en", "en+", "eng+fra+", "rm -rf *");
-
-        TesseractOCRConfig config = new TesseractOCRConfig();
 
         for (String language : invalidLanguages) {
             try {
@@ -123,49 +117,132 @@ public class TesseractOCRConfigTest extends TikaTest {
         }
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testValidatePageSegMode() {
-        TesseractOCRConfig config = new TesseractOCRConfig();
-        config.setPageSegMode("0");
-        config.setPageSegMode("10");
-        assertTrue("Couldn't set valid values", true);
-        config.setPageSegMode("11");
+    @Test
+    public void validateValidPageSegMode() {
+        List<String> validPageSegModes = Arrays.asList("1", "9", "10");
+
+        for (String pageSegMode : validPageSegModes) {
+            config.setPageSegMode(pageSegMode);
+            assertEquals("Valid page segmentation mode not set",
+                    pageSegMode, config.getPageSegMode());
+        }
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testValidateDensity() {
-    	TesseractOCRConfig config = new TesseractOCRConfig();
-    	config.setDensity(300);
-    	config.setDensity(400);
-    	assertTrue("Couldn't set valid values", true);
-    	config.setDensity(1);
+    @Test
+    public void validateInvalidPageSegMode() {
+        List<String> invalidPageSegModes = Arrays.asList("", "-1", "0", "11");
+
+        for (String pageSegMode : invalidPageSegModes) {
+            try {
+                config.setPageSegMode(pageSegMode);
+                fail("Invalid page segmentation mode set: " + pageSegMode);
+            } catch (IllegalArgumentException e) {
+                // expected exception thrown
+            }
+        }
     }
-    
-    @Test(expected=IllegalArgumentException.class)
-    public void testValidateDepth() {
-    	TesseractOCRConfig config = new TesseractOCRConfig();
-    	config.setDepth(4);
-    	config.setDepth(8);
-    	assertTrue("Couldn't set valid values", true);
-    	config.setDepth(6);
+
+    @Test
+    public void validateValidDensity() {
+        List<Integer> validDensities = Arrays.asList(150, 1200);
+
+        for (int density : validDensities) {
+            config.setDensity(density);
+            assertEquals("Valid density not set",
+                    density, config.getDensity());
+        }
     }
-    
-    @Test(expected=IllegalArgumentException.class)
-    public void testValidateFilter() {
-    	TesseractOCRConfig config = new TesseractOCRConfig();
-    	config.setFilter("Triangle");
-    	config.setFilter("box");
-    	assertTrue("Couldn't set valid values", true);
-    	config.setFilter("abc");
+
+    @Test
+    public void validateInvalidDensity() {
+        List<Integer> invalidDensities = Arrays.asList(149, 1201, -1, 0);
+
+        for (int density : invalidDensities) {
+            try {
+                config.setDensity(density);
+                fail("Invalid density set: " + density);
+            } catch (IllegalArgumentException e) {
+                // expected exception thrown
+            }
+        }
     }
-    
-    @Test(expected=IllegalArgumentException.class)
-    public void testValidateResize() {
-    	TesseractOCRConfig config = new TesseractOCRConfig();
-    	config.setResize(200);
-    	config.setResize(400);
-    	assertTrue("Couldn't set valid values", true);
-    	config.setResize(1000);
+
+    @Test
+    public void validateValidDepth() {
+        List<Integer> validDepths = Arrays.asList(2, 4, 8, 16, 32, 64, 256, 4096);
+
+        for (int depth : validDepths) {
+            config.setDepth(depth);
+            assertEquals("Valid depth not set",
+                    depth, config.getDepth());
+        }
+    }
+
+    @Test
+    public void validateInvalidDepth() {
+        List<Integer> invalidDepths = Arrays.asList(-1, 0, 1, 3, Integer.MAX_VALUE);
+
+        for (int depth : invalidDepths) {
+            try {
+                config.setDepth(depth);
+                fail("Invalid depth set: " + depth);
+            } catch (IllegalArgumentException e) {
+                // expected exception thrown
+            }
+        }
+    }
+
+    @Test
+    public void validateValidFilter() {
+        List<String> validFilters = Arrays.asList(
+                "POINT", "hermite", "CuBiC", "Box", "Gaussian",
+                "Catrom", "Triangle", "Quadratic", "Mitchell");
+
+        for (String filter : validFilters) {
+            config.setFilter(filter);
+            assertEquals("Valid filter not set",
+                    filter, config.getFilter());
+        }
+    }
+
+    @Test
+    public void validateInvalidFilter() {
+        List<String> invalidFilters = Arrays.asList("", "box ", "abc");
+
+        for (String filter : invalidFilters) {
+            try {
+                config.setFilter(filter);
+                fail("Invalid filter set: " + filter);
+            } catch (IllegalArgumentException e) {
+                // expected exception thrown
+            }
+        }
+    }
+
+    @Test
+    public void validateValidResize() {
+        // TODO: why only 100, 200, ..., 900?
+        List<Integer> validResizes = Arrays.asList(100, 500, 900);
+
+        for (int resize : validResizes) {
+            config.setResize(resize);
+            assertEquals("Valid resize not set",
+                    resize, config.getResize());
+        }
+    }
+
+    @Test
+    public void validateInvalidResize() {
+        List<Integer> invalidResizes = Arrays.asList(-1, 0, 1, 3, Integer.MAX_VALUE);
+
+        for (int resize : invalidResizes) {
+            try {
+                config.setResize(resize);
+                fail("Invalid resize set: " + resize);
+            } catch (IllegalArgumentException e) {
+                // expected exception thrown
+            }
+        }
     }
 
 }


### PR DESCRIPTION
I created a PR for a small bug in TesseractOCRConfig.java the other week (and it's been merged, thanks).
However, the existing tests don't seem to actually be able to detect errors; i.e. they pass even if the methods reject valid params.

I've re-written them but have some questions:

1. setResize(), the javadoc say "Valid range of values is 100-900." but the code seems to only to accept values to the nearest 100 i.e. 100, 200, ..., 800, 900.
Does anyone know if the current behaviour is intended?

2. setDensity(), the javadoc says 150-1200 but the [ImageMagick docs mention 72-1200](https://www.imagemagick.org/script/command-line-options.php#density)

Which is 'correct'/intended?

Please let me know.