### PR TITLE
Mapping PDF document TextPosition to XHTML span attributes, Lucene queries

### DIFF
--- a/tika-app/pom.xml
+++ b/tika-app/pom.xml
@@ -73,6 +73,16 @@
       <artifactId>tika-batch</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+      <version>6.4.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-queryparser</artifactId>
+      <version>6.4.1</version>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/tika-app/src/main/java/org/apache/tika/gui/TikaGUI.java
+++ b/tika-app/src/main/java/org/apache/tika/gui/TikaGUI.java
@@ -25,7 +25,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
-import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
 import javax.swing.ProgressMonitorInputStream;
@@ -39,7 +39,6 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
-import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Toolkit;
@@ -61,6 +60,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.Scene;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
 import org.apache.commons.io.IOUtils;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
@@ -148,19 +152,33 @@ public class TikaGUI extends JFrame
     private final ImageSavingParser imageParser;
 
     /**
-     * The card layout for switching between different views.
+     * Container for the editor tabs.
      */
-    private final CardLayout layout = new CardLayout();
+    private final JTabbedPane tabs;
 
     /**
-     * Container for the editor cards.
+     * Tabs definitions.
      */
-    private final JPanel cards;
+    private enum TabDef {
+        WELCOME("Welcome", ""),
+        METADATA("Metadata", "text/plain"),
+        XHTML("Formatted XHTML", ""),
+        TEXT("Plain text", "text/plain"),
+        TEXT_MAIN("Main content", "text/plain"),
+        XML("Structured XML", "text/plain"),
+        JSON("Recursive JSON", "text/plain");
+
+        String title, content;
+        TabDef(String title, String content) {
+            this.title=title;
+            this.content=content;
+        }
+    }
 
     /**
      * Formatted XHTML output.
      */
-    private final JEditorPane html;
+    private final JFXPanel xhtml;
 
     /**
      * Plain text output.
@@ -198,16 +216,15 @@ public class TikaGUI extends JFrame
 
         addMenuBar();
 
-        cards = new JPanel(layout);
-        addWelcomeCard(cards, "welcome");
-        metadata = addCard(cards, "text/plain", "metadata");
-        html = addCard(cards, "text/html", "html");
-        text = addCard(cards, "text/plain", "text");
-        textMain = addCard(cards, "text/plain", "main");
-        xml = addCard(cards, "text/plain", "xhtml");
-        json = addCard(cards, "text/plain", "json");
-        add(cards);
-        layout.show(cards, "welcome");
+        tabs = new JTabbedPane();
+        addWelcomeTab(tabs, TabDef.WELCOME);
+        metadata = addTab(tabs, TabDef.METADATA);
+        xhtml = addWebViewTab(tabs, TabDef.XHTML);
+        text = addTab(tabs, TabDef.TEXT);
+        textMain = addTab(tabs, TabDef.TEXT_MAIN);
+        xml = addTab(tabs, TabDef.XML);
+        json = addTab(tabs, TabDef.JSON);
+        add(tabs);
 
         setPreferredSize(new Dimension(640, 480));
         pack();
@@ -230,16 +247,6 @@ public class TikaGUI extends JFrame
         file.addSeparator();
         addMenuItem(file, "Exit", "exit", KeyEvent.VK_X);
         bar.add(file);
-
-        JMenu view = new JMenu("View");
-        view.setMnemonic(KeyEvent.VK_V);
-        addMenuItem(view, "Metadata", "metadata", KeyEvent.VK_M);
-        addMenuItem(view, "Formatted text", "html", KeyEvent.VK_F);
-        addMenuItem(view, "Plain text", "text", KeyEvent.VK_P);
-        addMenuItem(view, "Main content", "main", KeyEvent.VK_C);
-        addMenuItem(view, "Structured text", "xhtml", KeyEvent.VK_S);
-        addMenuItem(view, "Recursive JSON", "json", KeyEvent.VK_J);
-        bar.add(view);
 
         bar.add(Box.createHorizontalGlue());
         JMenu help = new JMenu("Help");
@@ -279,18 +286,6 @@ public class TikaGUI extends JFrame
                             "Invalid URL", JOptionPane.ERROR_MESSAGE);
                 }
             }
-        } else if ("html".equals(command)) {
-            layout.show(cards, command);
-        } else if ("text".equals(command)) {
-            layout.show(cards, command);
-        } else if ("main".equals(command)) {
-            layout.show(cards, command);
-        } else if ("xhtml".equals(command)) {
-            layout.show(cards, command);
-        } else if ("metadata".equals(command)) {
-            layout.show(cards, command);
-        } else if ("json".equals(command)) {
-            layout.show(cards, command);
         } else if ("about".equals(command)) {
             textDialog(
                     "About Apache Tika",
@@ -378,10 +373,10 @@ public class TikaGUI extends JFrame
         setText(xml, xmlBuffer.toString());
         setText(text, textBuffer.toString());
         setText(textMain, textMainBuffer.toString());
-        setText(html, htmlBuffer.toString());
+        setHtml(xhtml, htmlBuffer.toString());
         if (!input.markSupported()) {
             setText(json, "InputStream does not support mark/reset for Recursive Parsing");
-            layout.show(cards, "metadata");
+            selectTab(TabDef.JSON);
             return;
         }
         boolean isReset = false;
@@ -404,7 +399,7 @@ public class TikaGUI extends JFrame
             JsonMetadataList.toJson(wrapper.getMetadata(), jsonBuffer);
             setText(json, jsonBuffer.toString());
         }
-        layout.show(cards, "metadata");
+        selectTab(TabDef.XHTML);
     }
 
     private void handleError(String name, Throwable t) {
@@ -427,7 +422,7 @@ public class TikaGUI extends JFrame
         dialog.setVisible(true);
     }
 
-    private void addWelcomeCard(JPanel panel, String name) {
+    private void addWelcomeTab(JTabbedPane panel, TabDef tabDef) {
         try {
             JEditorPane editor =
                 new JEditorPane(TikaGUI.class.getResource("welcome.html"));
@@ -436,20 +431,34 @@ public class TikaGUI extends JFrame
             editor.setBackground(Color.WHITE);
             editor.setTransferHandler(new ParsingTransferHandler(
                     editor.getTransferHandler(), this));
-            panel.add(new JScrollPane(editor), name);
+            panel.addTab(tabDef.title, new JScrollPane(editor));
+            selectTab(tabDef);
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
-    private JEditorPane addCard(JPanel panel, String type, String name) {
+    private JEditorPane addTab(JTabbedPane panel, TabDef tabDef) {
         JEditorPane editor = new JTextPane();
         editor.setBackground(Color.WHITE);
-        editor.setContentType(type);
+        editor.setContentType(tabDef.content);
         editor.setTransferHandler(new ParsingTransferHandler(
                 editor.getTransferHandler(), this));
-        panel.add(new JScrollPane(editor), name);
+        panel.addTab(tabDef.title, new JScrollPane(editor));
         return editor;
+    }
+
+    private JFXPanel addWebViewTab(final JTabbedPane panel, final TabDef tabDef){
+        final JFXPanel jfxPanel = new JFXPanel();
+        Platform.runLater(new Runnable() {
+            @Override
+            public void run() {
+                WebView webView = new WebView();
+                jfxPanel.setScene( new Scene( webView ) );
+                panel.addTab(tabDef.title,jfxPanel);
+            }
+        });
+        return jfxPanel;
     }
 
     private void textDialog(String title, URL resource) {
@@ -498,6 +507,23 @@ public class TikaGUI extends JFrame
     private void setText(JEditorPane editor, String text) {
         editor.setText(text);
         editor.setCaretPosition(0);
+    }
+
+    private void setHtml(final JFXPanel htmlPanel, final String html) {
+        Platform.runLater(new Runnable() {
+            @Override
+            public void run() {
+                WebView webView = (WebView)htmlPanel.getScene().getRoot();
+                WebEngine engine = webView.getEngine();
+                //webView.getEngine().setUserStyleSheetLocation();
+                engine.loadContent(html);
+            }
+        });
+    }
+
+    private void selectTab(TabDef tabDef){
+        tabs.setSelectedIndex(tabs.indexOfTab(tabDef.title));
+
     }
 
     /**

--- a/tika-app/src/main/java/org/apache/tika/lucene/DocumentIndexer.java
+++ b/tika-app/src/main/java/org/apache/tika/lucene/DocumentIndexer.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.lucene;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.queryparser.classic.QueryParser;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Document index in RAM.
+ */
+public class DocumentIndexer {
+    private final Directory dir;
+    private final Analyzer analyzer;
+
+    public DocumentIndexer() throws IOException {
+        this.dir = new RAMDirectory();
+        this.analyzer = new StandardAnalyzer();
+    }
+
+    public void addDocument(String filename, String contents) throws IOException {
+        Document doc = new Document();
+        doc.add(new StringField("filename", filename, Store.YES));
+        doc.add(new TextField("contents", contents, Store.NO));
+        IndexWriterConfig iwc = new IndexWriterConfig(analyzer);
+        IndexWriter writer = new IndexWriter(dir, iwc);
+        writer.addDocument(doc);
+        writer.close();
+    }
+
+
+    public List<FoundItem> searchDocuments(String queryString) throws ParseException, IOException {
+        IndexReader reader = DirectoryReader.open(dir);
+        IndexSearcher searcher = new IndexSearcher(reader);
+        // Build a Query object
+        QueryParser parser = new QueryParser("contents", analyzer);
+        Query query = parser.parse(queryString);
+        TopDocs topDocs = searcher.search(query, 10);
+        List<FoundItem> fi = new ArrayList<>(topDocs.scoreDocs.length);
+        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+            fi.add(new FoundItem(scoreDoc,reader.document(scoreDoc.doc)));
+        }
+        reader.close();
+        return fi;
+    }
+
+}

--- a/tika-app/src/main/java/org/apache/tika/lucene/FoundItem.java
+++ b/tika-app/src/main/java/org/apache/tika/lucene/FoundItem.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.lucene;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.search.ScoreDoc;
+
+/**
+ * Info about one found item.
+ */
+public class FoundItem {
+    private final ScoreDoc scoreDoc;
+    private final Document document;
+
+    public FoundItem(ScoreDoc scoreDoc, Document document) {
+        this.scoreDoc = scoreDoc;
+        this.document = document;
+    }
+
+    public ScoreDoc getScoreDoc() {
+        return scoreDoc;
+    }
+
+    public Document getDocument() {
+        return document;
+    }
+}

--- a/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDF2XHTML.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDF2XHTML.java
@@ -16,19 +16,6 @@
  */
 package org.apache.tika.parser.pdf;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Writer;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
@@ -54,6 +41,10 @@ import org.apache.tika.sax.EmbeddedContentHandler;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
+
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.util.*;
 
 /**
  * Utility class that overrides the {@link PDFTextStripper} functionality
@@ -335,14 +326,16 @@ class PDF2XHTML extends AbstractPDF2XHTML {
     }
 
     private AttributesImpl extractSpanAttrs(List<TextPosition> textPositions) {
-        float fontResizeFactor = 0.8f;
+        float fontResizeFactor = 0.7f;
         AttributesImpl attrs = new AttributesImpl();
         if (textPositions.size() > 0) {
             TextPosition startPos = textPositions.get(0);
-            attrs.addAttribute("", "", "pdfFontName", null, startPos.getFont().getName());
-            attrs.addAttribute("", "", "pdfPageNo", null, getCurrentPageNo() + "");
-            attrs.addAttribute("", "", "style", null,
-                    "position: absolute; top: " + startPos.getY() + "px; left: " + startPos.getX() + "px; " +
+            int pageNo = getCurrentPageNo();
+            float x = startPos.getX();
+            float y = startPos.getY();
+            attrs.addAttribute("", "coordinates", "coordinates", null, pageNo+"-"+x+"-"+y);
+            attrs.addAttribute("", "style", "style", null,
+                    "position: absolute; top: "+y+"px; left: "+x+"px; " +
                             "font-size: " + (startPos.getFontSize()*fontResizeFactor) + "em"
             );
         }


### PR DESCRIPTION
Mapping PDF document TextPosition to XHTML span attributes (e.g. coordinates to style). 
Rendering  XHTML using JFX WebView (it looks like parsed PDF).
I've changed Tika App GUI card layout to JTabbedPane, it's easier to use.

Screen with parsed sample invoice found here: https://slicedinvoices.com/pdf/wordpress-pdf-invoice-plugin-sample.pdf

![image](https://cloud.githubusercontent.com/assets/2461648/23103024/4c3129ac-f6b4-11e6-9b43-3875d36eb48a.png)

Lucene queries UI, auto-indexing (in RAM) tested documents:

![image](https://cloud.githubusercontent.com/assets/2461648/23108126/c3a12970-f708-11e6-8683-b9cbfb21c5fa.png)
