### PR TITLE
Fix for TIKA-2303 contributed by ppalazon.

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
@@ -16,9 +16,6 @@
  */
 package org.apache.tika.parser.pdf;
 
-import static org.apache.tika.parser.pdf.PDFParserConfig.OCR_STRATEGY.NO_OCR;
-
-import javax.xml.stream.XMLStreamException;
 import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -38,7 +35,7 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-
+import javax.xml.stream.XMLStreamException;
 import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -94,6 +91,8 @@ import org.apache.tika.sax.XHTMLContentHandler;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
+
+import static org.apache.tika.parser.pdf.PDFParserConfig.OCR_STRATEGY.NO_OCR;
 
 class AbstractPDF2XHTML extends PDFTextStripper {
 
@@ -523,7 +522,8 @@ class AbstractPDF2XHTML extends PDFTextStripper {
     protected void endDocument(PDDocument pdf) throws IOException {
         try {
             // Extract text for any bookmarks:
-            extractBookmarkText();
+			if(config.getExtractBookmarksText())
+            	extractBookmarkText();
             try {
                 extractEmbeddedDocuments(pdf);
             } catch (IOException e) {

--- a/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParser.java
@@ -645,6 +645,11 @@ public class PDFParser extends AbstractParser {
         defaultConfig.setOcrImageFormatName(formatName);
     }
 
+	@Field
+	void setExtractBookmarksText(boolean extractBookmarksText) {
+		defaultConfig.setExtractBookmarksText(extractBookmarksText);
+	}
+
     @Field
     void setExtractInlineImages(boolean extractInlineImages) {
         defaultConfig.setExtractInlineImages(extractInlineImages);

--- a/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParserConfig.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParserConfig.java
@@ -96,6 +96,9 @@ public class PDFParserConfig implements Serializable {
     //True if acroform content should be extracted
     private boolean extractAcroFormContent = true;
 
+	//True if bookmarks content should be extracted
+    private boolean extractBookmarksText = true;
+
     //True if inline PDXImage objects should be extracted
     private boolean extractInlineImages = false;
 
@@ -178,6 +181,9 @@ public class PDFParserConfig implements Serializable {
         setExtractAcroFormContent(
                 getBooleanProp(props.getProperty("extractAcroFormContent"),
                         getExtractAcroFormContent()));
+		setExtractBookmarksText(
+				getBooleanProp(props.getProperty("extractBookmarksText"),
+						getExtractBookmarksText()));
         setExtractInlineImages(
                 getBooleanProp(props.getProperty("extractInlineImages"),
                         getExtractInlineImages()));
@@ -275,8 +281,24 @@ public class PDFParserConfig implements Serializable {
         this.ifXFAExtractOnlyXFA = ifXFAExtractOnlyXFA;
     }
 
+	/**
+	 * @see #setExtractBookmarksText(boolean)
+	 */
+	public boolean getExtractBookmarksText() {
+		return extractBookmarksText;
+	}
 
-    /**
+	/**
+	 * If true, extract bookmarks (document outline) text.
+	 * <p/>
+	 * Te default is <code>true</code>
+	 * @param extractBookmarksText
+	 */
+	public void setExtractBookmarksText(boolean extractBookmarksText) {
+		this.extractBookmarksText = extractBookmarksText;
+	}
+
+	/**
      * @see #setExtractInlineImages(boolean)
      */
     public boolean getExtractInlineImages() {
@@ -644,6 +666,7 @@ public class PDFParserConfig implements Serializable {
         if (getExtractAnnotationText() != config.getExtractAnnotationText()) return false;
         if (getSortByPosition() != config.getSortByPosition()) return false;
         if (getExtractAcroFormContent() != config.getExtractAcroFormContent()) return false;
+		if (getExtractBookmarksText() != config.getExtractBookmarksText()) return false;
         if (getExtractInlineImages() != config.getExtractInlineImages()) return false;
         if (getExtractUniqueInlineImagesOnly() != config.getExtractUniqueInlineImagesOnly()) return false;
         if (getIfXFAExtractOnlyXFA() != config.getIfXFAExtractOnlyXFA()) return false;
@@ -666,6 +689,7 @@ public class PDFParserConfig implements Serializable {
         result = 31 * result + (getExtractAnnotationText() ? 1 : 0);
         result = 31 * result + (getSortByPosition() ? 1 : 0);
         result = 31 * result + (getExtractAcroFormContent() ? 1 : 0);
+		result = 31 * result + (getExtractBookmarksText() ? 1 : 0);
         result = 31 * result + (getExtractInlineImages() ? 1 : 0);
         result = 31 * result + (getExtractUniqueInlineImagesOnly() ? 1 : 0);
         result = 31 * result + getAverageCharTolerance().hashCode();
@@ -689,6 +713,7 @@ public class PDFParserConfig implements Serializable {
                 ", extractAnnotationText=" + extractAnnotationText +
                 ", sortByPosition=" + sortByPosition +
                 ", extractAcroFormContent=" + extractAcroFormContent +
+				", extractBookmarksText=" + extractBookmarksText +
                 ", extractInlineImages=" + extractInlineImages +
                 ", extractUniqueInlineImagesOnly=" + extractUniqueInlineImagesOnly +
                 ", averageCharTolerance=" + averageCharTolerance +

--- a/tika-parsers/src/main/resources/org/apache/tika/parser/pdf/PDFParser.properties
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/pdf/PDFParser.properties
@@ -18,6 +18,7 @@ extractAnnotationText true
 sortByPosition	false
 suppressDuplicateOverlappingText	false
 extractAcroFormContent	true
+extractBookmarksText true
 extractInlineImages false
 extractUniqueInlineImagesOnly true
 checkExtractAccessPermission false


### PR DESCRIPTION
Added a new option parameter on PDFParserConfig for
extract bookmarks from a PDF. Its name is extractBookmarksText.