### PR TITLE
Creation of TIKA-2298 contributed by asmehra95- Import of vgg16 via Deeplearning4j

### DIFF
--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -506,6 +506,52 @@
         <version>1.6.5</version>
         <scope>test</scope>
     </dependency>
+     <!--Deeplearning4j Dependencies for DL4JImageRecogniser-->
+    <dependency>
+      <groupId>org.deeplearning4j</groupId>
+      <artifactId>deeplearning4j-modelimport</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deeplearning4j</groupId>
+      <artifactId>deeplearning4j-core</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.nd4j</groupId>
+      <artifactId>nd4j-native-platform</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deeplearning4j</groupId>
+      <artifactId>deeplearning4j-nn</artifactId>
+      <version>0.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deeplearning4j</groupId>
+      <artifactId>dl4j-spark-ml</artifactId>
+      <version>0.4-rc3.8</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <version>3.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -507,50 +507,20 @@
         <scope>test</scope>
     </dependency>
      <!--Deeplearning4j Dependencies for DL4JImageRecogniser-->
-    <dependency>
+     <dependency>
       <groupId>org.deeplearning4j</groupId>
       <artifactId>deeplearning4j-modelimport</artifactId>
       <version>0.8.0</version>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.deeplearning4j</groupId>
-      <artifactId>deeplearning4j-core</artifactId>
+      <groupId>org.datavec</groupId>
+      <artifactId>datavec-data-image</artifactId>
       <version>0.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.nd4j</groupId>
       <artifactId>nd4j-native-platform</artifactId>
       <version>0.8.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.deeplearning4j</groupId>
-      <artifactId>deeplearning4j-nn</artifactId>
-      <version>0.8.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.deeplearning4j</groupId>
-      <artifactId>dl4j-spark-ml</artifactId>
-      <version>0.4-rc3.8</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-math3</artifactId>
-      <version>3.6.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.5</version>
     </dependency>
   </dependencies>
 

--- a/tika-parsers/src/main/java/org/apache/tika/parser/recognition/dl4j/DL4JImageRecogniser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/recognition/dl4j/DL4JImageRecogniser.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.parser.recognition.dl4j;
+
+import org.apache.tika.config.Field;
+import org.apache.tika.config.Param;
+import org.apache.tika.exception.TikaConfigException;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.io.IOUtils;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.external.ExternalParser;
+import org.apache.tika.parser.recognition.ObjectRecogniser;
+import org.apache.tika.parser.recognition.RecognisedObject;
+import org.apache.tika.parser.recognition.tf.TensorflowRESTRecogniser;
+import org.datavec.image.loader.NativeImageLoader;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+import org.deeplearning4j.nn.modelimport.keras.KerasModelImport;
+import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModelHelper;
+import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.preprocessor.DataNormalization;
+import org.nd4j.linalg.dataset.api.preprocessor.VGG16ImagePreProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+
+public class DL4JImageRecogniser extends ExternalParser implements ObjectRecogniser {
+	
+    private static final Logger LOG = LoggerFactory.getLogger(DL4JImageRecogniser.class);
+    public static final Set<MediaType> SUPPORTED_MIMES = Collections.singleton(MediaType.image("jpeg"));
+       private static final LineConsumer IGNORED_LINE_LOGGER = new LineConsumer() {
+        @Override
+        public void consume(String line) {
+            LOG.debug(line);
+        }
+    };
+	 private static final String HOME_DIR = System.getProperty("user.home");
+    private static final String BASE_DIR = ".dl4j/trainedmodels";
+    private static String MODEL_DIR=HOME_DIR+File.separator+BASE_DIR;
+    private static String MODEL_DIR_PREPROCESSED=MODEL_DIR+File.separator+"tikaPreprocessed"+File.separator;
+    @Field private String modelType="VGG16";
+    @Field private File modelFile;
+    @Field private String outPattern = "(.*) \\(score = ([0-9]+\\.[0-9]+)\\)$";
+	File locationToSave ;
+    private boolean available = false;
+    ComputationGraph model;
+    public Set<MediaType> getSupportedMimes() {
+        return SUPPORTED_MIMES;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return available;
+    }
+
+    @Override
+    public void initialize(Map<String, Param> params) throws TikaConfigException {
+        try {
+        	if(modelType.equals("VGG16NOTOP"))
+            {
+        		throw new TikaConfigException("VGG16NOTOP is not supported right now");
+				/*# TODO hookup VGGNOTOP by uncommenting following code once the issue is resolved by dl4j team
+				modelFile = new File(MODEL_DIR_PREPROCESSED+File.separator+"vgg16_notop.zip");
+				locationToSave= new File(MODEL_DIR+File.separator+"tikaPreprocessed"+File.separator+"vgg16.zip");*/
+            }else if(modelType.equals("VGG16"))
+            {
+            	modelFile = new File(MODEL_DIR_PREPROCESSED+File.separator+"vgg16.zip");
+				locationToSave= new File(MODEL_DIR+File.separator+"tikaPreprocessed"+File.separator+"vgg16.zip");
+            }
+        	if(!modelFile.exists())
+    		{
+                    modelFile.getParentFile().mkdirs();
+                    LOG.warn("Preprocessed Model doesn't exist at {}", modelFile);
+                    TrainedModelHelper helper;
+                   if(modelType.equals("VGG16NOTOP"))
+                    {
+                    	helper = new TrainedModelHelper(TrainedModels.VGG16NOTOP);
+                    }else if(modelType.equals("VGG16"))
+                    {
+                    	helper = new TrainedModelHelper(TrainedModels.VGG16);
+                    }else
+                    {
+                    	throw new TikaConfigException("Unknown or unsupported model");
+                    }
+                    model = helper.loadModel();
+    				/*model= KerasModelImport.importKerasModelAndWeights(MODEL_DIR+File.separator+"VGG16NoTop.json",MODEL_DIR+File.separator+"vgg16_weights_th_dim_ordering_th_kernels_notop",false);*/
+    				LOG.info("Saving the Loaded model for future use. Saved models are more optimised to consume less resource.");
+    				ModelSerializer.writeModel(model,locationToSave,true);
+    				available=true;
+    		}else
+    		{
+    			model = ModelSerializer.restoreComputationGraph(locationToSave);
+    			LOG.info("Preprocessed Model Loaded from {}",locationToSave);
+    			available=true;
+    		}
+        	
+            LOG.debug("Available? {}", available);
+            if (!available) {
+                return;
+            }
+           HashMap<Pattern, String> patterns = new HashMap<>();
+            patterns.put(Pattern.compile(outPattern), null);
+            setMetadataExtractionPatterns(patterns);
+            setIgnoredLineConsumer(IGNORED_LINE_LOGGER);
+        } catch (Exception e) {
+        	LOG.warn("exception occured");
+            throw new TikaConfigException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<RecognisedObject> recognise(InputStream stream, ContentHandler handler,
+                                            Metadata metadata, ParseContext context)
+            throws IOException, SAXException, TikaException {
+		NativeImageLoader loader = new NativeImageLoader(224, 224, 3);
+		INDArray image = loader.asMatrix(stream);
+		DataNormalization scaler = new VGG16ImagePreProcessor();
+		scaler.transform(image);
+		INDArray[] output = model.output(false,image);
+		String modelOutput =TrainedModels.VGG16.decodePredictions(output[0]);
+		modelOutput=modelOutput.replace("Predictions for batch  :\n", "");
+		modelOutput=modelOutput.replace("%","");
+		String objs[]=modelOutput.split("\n");
+		List<RecognisedObject> objects = new ArrayList<>();
+		for(String obj : objs)
+		{
+			String data[];
+			data=obj.split(",");
+			 double confidence = Double.parseDouble(data[0]);
+	         objects.add(new RecognisedObject(data[1].trim(), "eng",data[1].trim(), confidence));
+		}
+        return objects;
+    }
+}

--- a/tika-parsers/src/main/java/org/apache/tika/parser/recognition/dl4j/DL4JImageRecogniser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/recognition/dl4j/DL4JImageRecogniser.java
@@ -5,15 +5,16 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.tika.parser.recognition.dl4j;
 
 import org.apache.tika.config.Field;
@@ -38,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,27 +51,30 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-
 public class DL4JImageRecogniser extends ExternalParser implements ObjectRecogniser {
-	
+
     private static final Logger LOG = LoggerFactory.getLogger(DL4JImageRecogniser.class);
     public static final Set<MediaType> SUPPORTED_MIMES = Collections.singleton(MediaType.image("jpeg"));
-       private static final LineConsumer IGNORED_LINE_LOGGER = new LineConsumer() {
+    private static final LineConsumer IGNORED_LINE_LOGGER = new LineConsumer() {
         @Override
         public void consume(String line) {
             LOG.debug(line);
         }
     };
-	 private static final String HOME_DIR = System.getProperty("user.home");
+    private static final String HOME_DIR = System.getProperty("user.home");
     private static final String BASE_DIR = ".dl4j/trainedmodels";
-    private static String MODEL_DIR=HOME_DIR+File.separator+BASE_DIR;
-    private static String MODEL_DIR_PREPROCESSED=MODEL_DIR+File.separator+"tikaPreprocessed"+File.separator;
-    @Field private String modelType="VGG16";
-    @Field private File modelFile;
-    @Field private String outPattern = "(.*) \\(score = ([0-9]+\\.[0-9]+)\\)$";
-	File locationToSave ;
+    private static String MODEL_DIR = HOME_DIR + File.separator + BASE_DIR;
+    private static String MODEL_DIR_PREPROCESSED = MODEL_DIR + File.separator + "tikaPreprocessed" + File.separator;
+    @Field
+    private String modelType = "VGG16";
+    @Field
+    private File modelFile;
+    @Field
+    private String outPattern = "(.*) \\(score = ([0-9]+\\.[0-9]+)\\)$";
+    private File locationToSave;
     private boolean available = false;
-    ComputationGraph model;
+    private ComputationGraph model;
+
     public Set<MediaType> getSupportedMimes() {
         return SUPPORTED_MIMES;
     }
@@ -82,46 +87,48 @@ public class DL4JImageRecogniser extends ExternalParser implements ObjectRecogni
     @Override
     public void initialize(Map<String, Param> params) throws TikaConfigException {
         try {
-        	if(modelType.equals("VGG16NOTOP")) {
-        		throw new TikaConfigException("VGG16NOTOP is not supported right now");
-				/*# TODO hookup VGGNOTOP by uncommenting following code once the issue is resolved by dl4j team
-				modelFile = new File(MODEL_DIR_PREPROCESSED+File.separator+"vgg16_notop.zip");
+            if (modelType.equals("VGG16NOTOP")) {
+                throw new TikaConfigException("VGG16NOTOP is not supported right now");
+                /*# TODO hookup VGGNOTOP by uncommenting following code once the issue is resolved by dl4j team
+                modelFile = new File(MODEL_DIR_PREPROCESSED+File.separator+"vgg16_notop.zip");
 				locationToSave= new File(MODEL_DIR+File.separator+"tikaPreprocessed"+File.separator+"vgg16.zip");*/
-            }else if(modelType.equals("VGG16")) {
-            	modelFile = new File(MODEL_DIR_PREPROCESSED+File.separator+"vgg16.zip");
-				locationToSave= new File(MODEL_DIR+File.separator+"tikaPreprocessed"+File.separator+"vgg16.zip");
+            } else if (modelType.equals("VGG16")) {
+                modelFile = new File(MODEL_DIR_PREPROCESSED + File.separator + "vgg16.zip");
+                locationToSave = new File(MODEL_DIR + File.separator + "tikaPreprocessed" + File.separator + "vgg16.zip");
             }
-        	if(!modelFile.exists()) {
-                    modelFile.getParentFile().mkdirs();
-                    LOG.warn("Preprocessed Model doesn't exist at {}", modelFile);
-                    TrainedModelHelper helper;
-                   if(modelType.equals("VGG16NOTOP")) {
-                    	helper = new TrainedModelHelper(TrainedModels.VGG16NOTOP);
-                    }else if(modelType.equals("VGG16")) {
-                    	helper = new TrainedModelHelper(TrainedModels.VGG16);
-                    }else {
-                    	throw new TikaConfigException("Unknown or unsupported model");
-                    }
-                    model = helper.loadModel();
-    				LOG.info("Saving the Loaded model for future use. Saved models are more optimised to consume less resource.");
-    				ModelSerializer.writeModel(model,locationToSave,true);
-    				available=true;
-    		}else {
-    			model = ModelSerializer.restoreComputationGraph(locationToSave);
-    			LOG.info("Preprocessed Model Loaded from {}",locationToSave);
-    			available=true;
-    		}
-        	
-            LOG.debug("Available? {}", available);
+            if (!modelFile.exists()) {
+                modelFile.getParentFile().mkdirs();
+                LOG.warn("Preprocessed Model doesn't exist at {}", modelFile);
+                TrainedModelHelper helper;
+                switch (modelType) {
+                    case "VGG16NOTOP":
+                        helper = new TrainedModelHelper(TrainedModels.VGG16NOTOP);
+                        break;
+                    case "VGG16":
+                        helper = new TrainedModelHelper(TrainedModels.VGG16);
+                        break;
+                    default:
+                        throw new TikaConfigException("Unknown or unsupported model");
+                }
+                model = helper.loadModel();
+                LOG.info("Saving the Loaded model for future use. Saved models are more optimised to consume less resource.");
+                ModelSerializer.writeModel(model, locationToSave, true);
+                available = true;
+            } else {
+                model = ModelSerializer.restoreComputationGraph(locationToSave);
+                LOG.info("Preprocessed Model Loaded from {}", locationToSave);
+                available = true;
+            }
+
             if (!available) {
                 return;
             }
-           HashMap<Pattern, String> patterns = new HashMap<>();
+            HashMap<Pattern, String> patterns = new HashMap<>();
             patterns.put(Pattern.compile(outPattern), null);
             setMetadataExtractionPatterns(patterns);
             setIgnoredLineConsumer(IGNORED_LINE_LOGGER);
         } catch (Exception e) {
-        	LOG.warn("exception occured");
+            LOG.warn("exception occured");
             throw new TikaConfigException(e.getMessage(), e);
         }
     }
@@ -130,22 +137,22 @@ public class DL4JImageRecogniser extends ExternalParser implements ObjectRecogni
     public List<RecognisedObject> recognise(InputStream stream, ContentHandler handler,
                                             Metadata metadata, ParseContext context)
             throws IOException, SAXException, TikaException {
-		NativeImageLoader loader = new NativeImageLoader(224, 224, 3);
-		INDArray image = loader.asMatrix(stream);
-		DataNormalization scaler = new VGG16ImagePreProcessor();
-		scaler.transform(image);
-		INDArray[] output = model.output(false,image);
-		String modelOutput =TrainedModels.VGG16.decodePredictions(output[0]);
-		modelOutput=modelOutput.replace("Predictions for batch  :\n", "");
-		modelOutput=modelOutput.replace("%","");
-		String objs[]=modelOutput.split("\n");
-		List<RecognisedObject> objects = new ArrayList<>();
-		for(String obj : objs) {
-			String data[];
-			data=obj.split(",");
-			 double confidence = Double.parseDouble(data[0]);
-	         objects.add(new RecognisedObject(data[1].trim(), "eng",data[1].trim(), confidence));
-		}
+        NativeImageLoader loader = new NativeImageLoader(224, 224, 3);
+        INDArray image = loader.asMatrix(stream);
+        DataNormalization scaler = new VGG16ImagePreProcessor();
+        scaler.transform(image);
+        INDArray[] output = model.output(false, image);
+        String modelOutput = TrainedModels.VGG16.decodePredictions(output[0]);
+        modelOutput = modelOutput.replace("Predictions for batch  :\n", "");
+        modelOutput = modelOutput.replace("%", "");
+        String objs[] = modelOutput.split("\n");
+        List<RecognisedObject> objects = new ArrayList<>();
+        for (String obj : objs) {
+            String data[];
+            data = obj.split(",");
+            double confidence = Double.parseDouble(data[0]);
+            objects.add(new RecognisedObject(data[1].trim(), "eng", data[1].trim(), confidence));
+        }
         return objects;
     }
 }


### PR DESCRIPTION
I have imported VGG16 model into Apache tika using deeplearning4j.
The usage of this recogniser is very similar to TensorFlowRESTrecogniser but it doesn't require any external setup, like running  RESTservice in as in case of TensorFlowRESTrecogniser.
You can read more about TensorFlowRESTrecogniser at https://wiki.apache.org/tika/TikaAndVision

To use the DL4JImageRecogniser set
class param to org.apache.tika.parser.recognition.dl4j.DL4JImageRecogniser
modelType to VGG16
sample configuration is given below for refference. 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<properties>
    <parsers>
        <parser class="org.apache.tika.parser.recognition.ObjectRecognitionParser">
            <mime>image/jpeg</mime>
            <params>
                <param name="topN" type="int">5</param>
                <param name="minConfidence" type="double">0.015</param>
                <param name="class" type="string">org.apache.tika.parser.recognition.dl4j.DL4JImageRecogniser</param>
				        <param name="modelType" type="string">VGG16</param> 
            </params>
        </parser>
    </parsers>
</properties>
```
Save the configuration at : `tika-parsers/src/test/resources/org/apache/tika/parser/recognition/tika-config-tflow-rest`

To run it, build the project and move to root directory of the project and run the command

`java -Xmx3G -jar tika-app/target/tika-app-1.14.jar --config=tika-parsers/src/test/resources/org/apache/tika/parser/recognition/tika-config-tflow-rest.xml <path to your image file>`

-Xmx3G is required because VGG16 model requires quite a lot of memory to run. If your system is not able to run it, you may try to pump up the memory further

Once the model runs, it automatically downloads the model file using helper functions of DL4J locally at .dl4j/trainedModels
To speed up the process in future, once the model is loaded from original hash files, it is serialized and saved on disk at .dl4j/trainedModels/tikaPreprocessed which significantly reduces
the resource usage (specially memory consumption) for future loads.
For more details you can red this gist: https://gist.github.com/asmehra95/a16c49ec91f7f0d7b39c5bf6c2483e4d
 Issue Link:
https://issues.apache.org/jira/browse/TIKA-2298