### PR TITLE
Fix for TIKA-2347 Adds underline extraction from word documents

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/microsoft/ooxml/XWPFWordExtractorDecorator.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/microsoft/ooxml/XWPFWordExtractorDecorator.java
@@ -33,6 +33,7 @@ import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.ICell;
 import org.apache.poi.xwpf.usermodel.IRunElement;
 import org.apache.poi.xwpf.usermodel.ISDTContent;
+import org.apache.poi.xwpf.usermodel.UnderlinePatterns;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFHeaderFooter;
 import org.apache.poi.xwpf.usermodel.XWPFHyperlink;
@@ -224,7 +225,7 @@ public class XWPFWordExtractorDecorator extends AbstractOOXMLExtractor {
             xhtml.endElement("a");
         }
 
-        TmpFormatting fmtg = new TmpFormatting(false, false);
+        TmpFormatting fmtg = new TmpFormatting(false, false, false);
 
         //hyperlinks may or may not have hyperlink ids
         String lastHyperlinkId = null;
@@ -328,6 +329,10 @@ public class XWPFWordExtractorDecorator extends AbstractOOXMLExtractor {
             xhtml.endElement("b");
             fmtg.setBold(false);
         }
+        if (fmtg.isUnderline()) {
+        	xhtml.endElement("u");
+        	fmtg.setUnderline(false);
+        }
         return fmtg;
     }
 
@@ -336,6 +341,10 @@ public class XWPFWordExtractorDecorator extends AbstractOOXMLExtractor {
             throws SAXException, XmlException, IOException {
         // True if we are currently in the named style tag:
         if (run.isBold() != tfmtg.isBold()) {
+            if (tfmtg.isUnderline()) {
+                xhtml.endElement("u");
+                tfmtg.setUnderline(false);
+            }
             if (tfmtg.isItalic()) {
                 xhtml.endElement("i");
                 tfmtg.setItalic(false);
@@ -349,12 +358,26 @@ public class XWPFWordExtractorDecorator extends AbstractOOXMLExtractor {
         }
 
         if (run.isItalic() != tfmtg.isItalic()) {
+            if (tfmtg.isUnderline()) {
+                xhtml.endElement("u");
+                tfmtg.setUnderline(false);
+            }
             if (run.isItalic()) {
                 xhtml.startElement("i");
             } else {
                 xhtml.endElement("i");
             }
             tfmtg.setItalic(run.isItalic());
+        }
+        
+        boolean isUnderline = run.getUnderline() != UnderlinePatterns.NONE;
+        if (isUnderline != tfmtg.isUnderline()) {
+            if (isUnderline) {
+                xhtml.startElement("u");
+            } else {
+                xhtml.endElement("u");
+            }
+            tfmtg.setUnderline(isUnderline);
         }
 
         xhtml.characters(run.toString());
@@ -484,10 +507,12 @@ public class XWPFWordExtractorDecorator extends AbstractOOXMLExtractor {
     private class TmpFormatting {
         private boolean bold = false;
         private boolean italic = false;
+        private boolean underline = false;
 
-        private TmpFormatting(boolean bold, boolean italic) {
+        private TmpFormatting(boolean bold, boolean italic, boolean underline) {
             this.bold = bold;
             this.italic = italic;
+            this.underline = underline;
         }
 
         public boolean isBold() {
@@ -504,6 +529,15 @@ public class XWPFWordExtractorDecorator extends AbstractOOXMLExtractor {
 
         public void setItalic(boolean italic) {
             this.italic = italic;
+        }
+        
+
+        public boolean isUnderline() {
+            return underline;
+        }
+
+        public void setUnderline(boolean underline) {
+            this.underline = underline;
         }
 
     }

--- a/tika-parsers/src/test/java/org/apache/tika/parser/microsoft/WordParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/microsoft/WordParserTest.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.tika.TikaTest;
+
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.Office;
@@ -109,7 +110,7 @@ public class WordParserTest extends TikaTest {
         assertTrue(xml.contains("<td>"));
         // TODO - Check for the nested table
         // Links
-        assertTrue(xml.contains("<a href=\"http://tika.apache.org/\">Tika</a>"));
+        assertTrue(xml.contains("<a href=\"http://tika.apache.org/\"><u>Tika</u></a>"));
         // Paragraphs with other styles
         assertTrue(xml.contains("<p class=\"signature\">This one"));
 
@@ -194,6 +195,17 @@ public class WordParserTest extends TikaTest {
             assertEquals("Nevin Nollop", metadata.get(Metadata.AUTHOR));
             assertContains("The quick brown fox jumps over the lazy dog", handler.toString());
         }
+    }
+    
+    @Test
+    public void testTextDecoration() throws Exception {
+      XMLResult result = getXML("testWORD_various.doc");
+      String xml = result.xml;
+
+      assertTrue(xml.contains("<b>Bold</b>"));
+      assertTrue(xml.contains("<i>italic</i>"));
+      assertTrue(xml.contains("<u>underline</u>"));
+
     }
 
     @Test
@@ -361,15 +373,15 @@ public class WordParserTest extends TikaTest {
         assertFalse(xml.contains("HYPERLINK"));
 
         // Check we do have the link
-        assertContains("<a href=\"http://tw-systemhaus.de\">http:", xml);
+        assertContains("<a href=\"http://tw-systemhaus.de\"><u>http:", xml);
 
         // Check we do have the email
-        assertContains("<a href=\"mailto:ab@example.com\">ab@", xml);
+        assertContains("<a href=\"mailto:ab@example.com\"><u>ab@", xml);
     }
 
     @Test
     public void testControlCharacter() throws Exception {
-        assertContains("1. Introduzione<b> </b></a> </p>", getXML("testControlCharacters.doc").xml.replaceAll("\\s+", " "));
+        assertContains("<u>1.</u> <u>Introduzione</u><b> </b></a><u> </u></p>", getXML("testControlCharacters.doc").xml.replaceAll("\\s+", " "));
     }
 
     @Test
@@ -383,7 +395,7 @@ public class WordParserTest extends TikaTest {
                 "application/msword",
                 metadata.get(Metadata.CONTENT_TYPE));
 
-        assertContains("<p>1. Organisering av vakten:</p>", xml);
+        assertContains("<p><u>1. Organisering av vakten:</u></p>", xml);
 
     }
 
@@ -521,8 +533,8 @@ public class WordParserTest extends TikaTest {
         //TIKA-1255
         String xml = getXML("testWORD_boldHyperlink.doc").xml;
         xml = xml.replaceAll("\\s+", " ");
-        assertContains("<a href=\"http://tika.apache.org/\">hyper <b>link</b></a>", xml);
-        assertContains("<a href=\"http://tika.apache.org/\"><b>hyper</b> link</a>; bold" , xml);
+        assertContains("<a href=\"http://tika.apache.org/\"><u>hyper </u><b><u>link</u></b></a>", xml);
+        assertContains("<a href=\"http://tika.apache.org/\"><b><u>hyper</u></b><u> link</u></a>; bold" , xml);
     }
 
     @Test

--- a/tika-parsers/src/test/java/org/apache/tika/parser/microsoft/ooxml/OOXMLParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/microsoft/ooxml/OOXMLParserTest.java
@@ -579,6 +579,17 @@ public class OOXMLParserTest extends TikaTest {
             assertEquals("Should have found some text", false, handler.toString().isEmpty());
         }
     }
+    
+    @Test
+    public void testTextDecoration() throws Exception {
+      XMLResult result = getXML("testWORD_various.docx");
+      String xml = result.xml;
+
+      assertTrue(xml.contains("<b>Bold</b>"));
+      assertTrue(xml.contains("<i>italic</i>"));
+      assertTrue(xml.contains("<u>underline</u>"));
+
+    }
 
     @Test
     public void testVarious() throws Exception {


### PR DESCRIPTION
Extracts underline for both doc and docx and assigns tag <u>.
Given lowest nesting among style tags.
Adds tests using testWORD_various.doc and testWord_various.docx
Updates affected output in other WordParserTests.