### PR TITLE
Allows Tesseract PSM up to 13

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRConfig.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRConfig.java
@@ -244,8 +244,8 @@ public class TesseractOCRConfig implements Serializable {
      * Default is 1 = Automatic page segmentation with OSD (Orientation and Script Detection)
      */
     public void setPageSegMode(String pageSegMode) {
-        if (!pageSegMode.matches("[1-9]|10")) {
-            throw new IllegalArgumentException("Invalid language code");
+        if (!pageSegMode.matches("[0-9]|10|11|12|13")) {
+            throw new IllegalArgumentException("Invalid page segmentation mode");
         }
         this.pageSegMode = pageSegMode;
     }

--- a/tika-parsers/src/test/java/org/apache/tika/parser/ocr/TesseractOCRConfigTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/ocr/TesseractOCRConfigTest.java
@@ -129,7 +129,7 @@ public class TesseractOCRConfigTest extends TikaTest {
         config.setPageSegMode("0");
         config.setPageSegMode("10");
         assertTrue("Couldn't set valid values", true);
-        config.setPageSegMode("11");
+        config.setPageSegMode("14");
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
This also includes allowing mode 0 which was previously not matched by the regex
Changed wording on exception to clearly reference page segmentation