### PR TITLE
TrueTypeParser Close Open Fonts

### DIFF
--- a/tika-parsers/src/test/java/org/apache/tika/parser/font/FontParsersTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/font/FontParsersTest.java
@@ -16,16 +16,8 @@
  */
 package org.apache.tika.parser.font;
 
-import static org.apache.tika.TikaTest.assertContains;
-import static org.apache.tika.parser.font.AdobeFontMetricParser.MET_FONT_FAMILY_NAME;
-import static org.apache.tika.parser.font.AdobeFontMetricParser.MET_FONT_FULL_NAME;
-import static org.apache.tika.parser.font.AdobeFontMetricParser.MET_FONT_NAME;
-import static org.apache.tika.parser.font.AdobeFontMetricParser.MET_FONT_SUB_FAMILY_NAME;
-import static org.apache.tika.parser.font.AdobeFontMetricParser.MET_FONT_VERSION;
-import static org.apache.tika.parser.font.AdobeFontMetricParser.MET_FONT_WEIGHT;
-import static org.apache.tika.parser.font.AdobeFontMetricParser.MET_PS_NAME;
-import static org.junit.Assert.assertEquals;
-
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.reflect.MethodUtils;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
@@ -35,6 +27,17 @@ import org.apache.tika.parser.Parser;
 import org.apache.tika.sax.BodyContentHandler;
 import org.junit.Test;
 import org.xml.sax.ContentHandler;
+
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.apache.tika.TikaTest.assertContains;
+import static org.apache.tika.parser.font.AdobeFontMetricParser.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Test case for parsing various different font files.
@@ -55,11 +58,11 @@ public class FontParsersTest {
         assertEquals("application/x-font-adobe-metric", metadata.get(Metadata.CONTENT_TYPE));
         assertEquals("TestFullName", metadata.get(TikaCoreProperties.TITLE));
         assertEquals("Fri Jul 15 17:50:51 2011", metadata.get(Metadata.CREATION_DATE));
-        
+
         assertEquals("TestFontName", metadata.get(MET_FONT_NAME));
         assertEquals("TestFullName", metadata.get(MET_FONT_FULL_NAME));
         assertEquals("TestSymbol",   metadata.get(MET_FONT_FAMILY_NAME));
-        
+
         assertEquals("Medium",  metadata.get(MET_FONT_WEIGHT));
         assertEquals("001.008", metadata.get(MET_FONT_VERSION));
 
@@ -70,14 +73,14 @@ public class FontParsersTest {
         assertContains("This is a comment in a sample file", content);
         assertContains("UniqueID 12345", content);
     }
-    
+
     @Test
     public void testTTFParsing() throws Exception {
         Parser parser = new AutoDetectParser(); // Should auto-detect!
         ContentHandler handler = new BodyContentHandler();
         Metadata metadata = new Metadata();
         ParseContext context = new ParseContext();
-        //Open Sans font is ASL 2.0 according to 
+        //Open Sans font is ASL 2.0 according to
         //http://www.google.com/fonts/specimen/Open+Sans
         //...despite the copyright in the file's metadata.
 
@@ -92,15 +95,15 @@ public class FontParsersTest {
         assertEquals("2010-12-30T11:04:00Z", metadata.get(Metadata.CREATION_DATE));
         assertEquals("2010-12-30T11:04:00Z", metadata.get(TikaCoreProperties.CREATED));
         assertEquals("2011-05-05T12:37:53Z", metadata.get(TikaCoreProperties.MODIFIED));
-        
+
         assertEquals("Open Sans Bold", metadata.get(MET_FONT_NAME));
         assertEquals("Open Sans", metadata.get(MET_FONT_FAMILY_NAME));
         assertEquals("Bold", metadata.get(MET_FONT_SUB_FAMILY_NAME));
         assertEquals("OpenSans-Bold", metadata.get(MET_PS_NAME));
-        
+
         assertEquals("Digitized", metadata.get("Copyright").substring(0, 9));
         assertEquals("Open Sans", metadata.get("Trademark").substring(0, 9));
-        
+
         // Not extracted
         assertEquals(null, metadata.get(MET_FONT_FULL_NAME));
         assertEquals(null, metadata.get(MET_FONT_WEIGHT));
@@ -109,5 +112,41 @@ public class FontParsersTest {
         // Currently, the parser doesn't extract any contents
         String content = handler.toString();
         assertEquals("", content);
+    }
+
+    @Test
+    public void testTTFParsingNoLeaks() throws Exception {
+        Parser parser = new AutoDetectParser(); // Should auto-detect!
+        ContentHandler handler = new BodyContentHandler();
+        Metadata metadata = new Metadata();
+        ParseContext context = new ParseContext();
+
+        // Attempt to detect file leaks on unix systems.
+        OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+        if (MethodUtils.getMatchingAccessibleMethod(os.getClass(), "getOpenFileDescriptorCount", null) == null) {
+            return;
+        }
+
+        // Clone the font to a temporary file on disk, was having trouble reliably reproducing the leak with resources.
+        InputStream input = FontParsersTest.class.getResourceAsStream("/test-documents/testTrueType3.ttf");
+        Path tempDir = Files.createTempDirectory("fonts");
+        Path tempFont = tempDir.resolve("testTrueType3.ttf");
+        Files.copy(input, tempFont);
+        input.close();
+
+        // Record the expected file handle count.
+        long initialFileCount = (long)MethodUtils.invokeMethod(os, "getOpenFileDescriptorCount", null);
+        try (TikaInputStream stream = TikaInputStream.get(tempFont)) {
+            parser.parse(stream, handler, metadata, context);
+        }
+
+        // Check is any file handles leaked.
+        long finalFileCount = (long)MethodUtils.invokeMethod(os, "getOpenFileDescriptorCount", null);
+        if (initialFileCount != finalFileCount) {
+            fail("File leak detected. " + initialFileCount + " " + finalFileCount);
+        }
+
+        // Clean up temporary files.
+        FileUtils.deleteQuietly(tempDir.toFile());
     }
 }


### PR DESCRIPTION
The TrueTypeParser opens fonts during parsing, however it never closes
these resources. This causes a slow file handle leak that causes
problems when processing large amounts of fonts.

This change wraps the font resource in a try-finally block to ensure
that the resource is closed after parsing has occurred.