### PR TITLE
TIKA-2393 Fix Sentiment parser model URLs

### DIFF
--- a/tika-parsers/src/test/resources/org/apache/tika/parser/sentiment/analysis/tika-config-sentiment-opennlp-cat.xml
+++ b/tika-parsers/src/test/resources/org/apache/tika/parser/sentiment/analysis/tika-config-sentiment-opennlp-cat.xml
@@ -20,7 +20,7 @@
             <mime>text/plain</mime>
             <mime>application/sentiment</mime>
             <params>
-                <param name="modelPath" type="string">https://raw.githubusercontent.com/USCDataScience/SentimentAnalysisParser/master/sentiment-models/ht-sentiment-categ.bin</param>
+                <param name="modelPath" type="string">https://raw.githubusercontent.com/USCDataScience/SentimentAnalysisParser/3859302f4c07c9c7a7cdee7c9da23117f333c2f8/sentiment-models/src/main/resources/edu/usc/irds/sentiment/ht-sentiment-categ.bin</param>
                 <!--This can also be relative path sentiment-models/en-stanford-sentiment.bin-->
             </params>
         </parser>

--- a/tika-parsers/src/test/resources/org/apache/tika/parser/sentiment/analysis/tika-config-sentiment-opennlp.xml
+++ b/tika-parsers/src/test/resources/org/apache/tika/parser/sentiment/analysis/tika-config-sentiment-opennlp.xml
@@ -21,7 +21,7 @@
             <mime>text/plain</mime>
             <mime>application/sentiment</mime>
             <params>
-                <param name="modelPath" type="string">https://raw.githubusercontent.com/USCDataScience/SentimentAnalysisParser/master/sentiment-models/en-netflix-sentiment.bin</param>
+                <param name="modelPath" type="string">https://raw.githubusercontent.com/USCDataScience/SentimentAnalysisParser/3859302f4c07c9c7a7cdee7c9da23117f333c2f8/sentiment-models/src/main/resources/edu/usc/irds/sentiment/en-netflix-sentiment.bin</param>
                 <!--This can also be relative path sentiment-models/en-stanford-sentiment.bin-->
             </params>
         </parser>


### PR DESCRIPTION
Sentiment parser test models URLs are pointed to a specific commit in git instead of HEAD of the master.