### PR TITLE
TikaFix ---Contribution ny jerni-zu393

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -37,6 +37,13 @@
      you can here, then provide a Custom Detector for the rest
 -->
 <mime-info>
+<!--TIKAFIX by jerni-zu393 : Magicbits for keystore file is copied from MimeUtil- magic.mime to detect .keystore/.jks files -->
+  <mime-type type="application/x-java-keystore" >
+  <acronym>keystore</acronym>
+  <magic priority="50">
+  <match value="0xfeedfeed" type="string" offset="0"/>	
+  </magic>
+  </mime-type>	
 
   <mime-type type="application/activemessage"/>
   <mime-type type="application/andrew-inset">
@@ -271,6 +278,25 @@
 
   <mime-type type="application/vnd.android.package-archive">
     <sub-class-of type="application/java-archive"/>
+<!-- TIKAFIX by jerni-zu393: magic bits for apk is added here-->
+    <magic priority="50">	
+     <match value="PK\003\004" type="string" offset="0">
+        <match value="AndroidManifest.xml" type="string" offset="30"/>
+	<match value="assets/" type="string" offset="30"/>
+	<match value="res/" type="string" offset="30"/>
+      </match>
+      <match value="PK\005\006" type="string" offset="0">
+	<match value="AndroidManifest.xml" type="string" offset="30"/>
+	<match value="assets/" type="string" offset="30"/>
+	<match value="res/" type="string" offset="30"/>
+      </match>
+      <match value="PK\x07\x08" type="string" offset="0">
+        <match value="AndroidManifest.xml" type="string" offset="30"/>
+	<match value="assets/" type="string" offset="30"/>
+	<match value="res/" type="string" offset="30"/>
+      </match>
+    </magic>
+
     <glob pattern="*.apk"/>
   </mime-type>
   <mime-type type="application/x-tika-java-enterprise-archive">
@@ -4694,6 +4720,18 @@
   <mime-type type="audio/vnd.vmx.cvsd"/>
   <mime-type type="audio/vorbis-config"/>
   <mime-type type="audio/x-aac">
+<!--TIKAFIX by jerni-zu393: magic bits for "aac" file is added here-->
+  <magic priority="50">
+  <match value="P" type="string" offset="2">
+  <match value="libfaac" type="string" offset="11"/>
+  </match>
+  </magic>
+  <magic priority="50">
+  <match value="ID3" type="string" offset="0">
+  <match value="TPE" type="string" offset="10"/>
+  </match>
+  </magic>
+
     <glob pattern="*.aac"/>
   </mime-type>
 

--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -37,7 +37,7 @@
      you can here, then provide a Custom Detector for the rest
 -->
 <mime-info>
-<!--TIKAFIX by jerni-zu393 : Magicbits for keystore file is copied from MimeUtil- magic.mime to detect .keystore/.jks files -->
+<!--TIKAFIX  (this magic bits coppied from mimeutil) : Magicbits for keystore file is copied from MimeUtil- magic.mime to detect .keystore/.jks files -->
   <mime-type type="application/x-java-keystore" >
   <acronym>keystore</acronym>
   <magic priority="50">


### PR DESCRIPTION
I have added the magic bits for three files (*.keystore/.jks , *.apk , *.aac). It can be detect the file types even the files should not have "."extensions .

I have attached here below the sample files for testing purpose .

[keystore.tar.gz](https://github.com/apache/tika/files/1077097/keystore.tar.gz)

[apktest.zip](https://github.com/apache/tika/files/1077108/apktest.zip)
[aactest.zip](https://github.com/apache/tika/files/1077115/aactest.zip)
