### PR TITLE
SUPPORTED_TYPES is immutable

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/microsoft/xml/WordMLParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/microsoft/xml/WordMLParser.java
@@ -73,7 +73,7 @@ public class WordMLParser extends AbstractXML2003Parser {
 
     private static final MediaType MEDIA_TYPE = MediaType.application("vnd.ms-wordml");
     private static final Set<MediaType> SUPPORTED_TYPES =
-            Collections.singleton(MEDIA_TYPE);
+            Collections.singleton(MEDIA_TYPE); //immutable
 
     @Override
     public Set<MediaType> getSupportedTypes(ParseContext context) {


### PR DESCRIPTION
In case SUPPORTED_TYPES is ever changed back to a set containing more than one value, a reminder to use an immutable container such as `Collections.unmodifiableSet(set)`.

This is a continuation of #193.