### PR TITLE
Fix for TIKA-2402

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/recognition/tf/TensorflowRESTRecogniser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/recognition/tf/TensorflowRESTRecogniser.java
@@ -25,6 +25,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -60,6 +63,13 @@ import org.xml.sax.SAXException;
 public class TensorflowRESTRecogniser implements ObjectRecogniser {
     private static final Logger LOG = LoggerFactory.getLogger(TensorflowRESTRecogniser.class);
 
+    private static final Set<MediaType> SUPPORTED_MIMES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(new MediaType[]{
+                    MediaType.image("jpeg"),
+                    MediaType.image("png"),
+                    MediaType.image("gif")
+            })));
+
     /**
      * Maximum buffer size for image
      */
@@ -78,7 +88,7 @@ public class TensorflowRESTRecogniser implements ObjectRecogniser {
     
     @Override
     public Set<MediaType> getSupportedMimes() {
-        return TensorflowImageRecParser.SUPPORTED_MIMES;
+        return SUPPORTED_MIMES;
     }
 
     @Override

--- a/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionRestDockerfile
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionRestDockerfile
@@ -33,7 +33,7 @@ RUN wget https://github.com/tensorflow/models/archive/c15fada28113eca32dc98d6e3b
 	unzip c15fada28113eca32dc98d6e3bec4755d0d5b4c2.zip 
 
 RUN \
-  wget https://raw.githubusercontent.com/apache/ThejanW/master/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py -O /usr/bin/inceptionapi.py && \
+  wget https://raw.githubusercontent.com/ThejanW/tika/master/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py -O /usr/bin/inceptionapi.py && \
   chmod +x /usr/bin/inceptionapi.py
 
 # clean up cache, so we can publish smaller image to hub

--- a/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionRestDockerfile
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionRestDockerfile
@@ -33,7 +33,7 @@ RUN wget https://github.com/tensorflow/models/archive/c15fada28113eca32dc98d6e3b
 	unzip c15fada28113eca32dc98d6e3bec4755d0d5b4c2.zip 
 
 RUN \
-  wget https://raw.githubusercontent.com/apache/tika/master/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py -O /usr/bin/inceptionapi.py && \
+  wget https://raw.githubusercontent.com/apache/ThejanW/master/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py -O /usr/bin/inceptionapi.py && \
   chmod +x /usr/bin/inceptionapi.py
 
 # clean up cache, so we can publish smaller image to hub

--- a/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionRestDockerfile
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionRestDockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 # Install tensorflow and other dependencies
 RUN \
   pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.0.1-cp27-none-linux_x86_64.whl && \
-  pip install flask requests
+  pip install flask requests pillow
 
 # Get the TF-slim dependencies 
 # Downloading from a specific commit for future compatibility

--- a/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py
@@ -390,7 +390,7 @@ def classify_image():
         rgb_image = image.convert("RGB")
         # convert the RGB image to jpeg
         image_bytes = BytesIO()
-        rgb_image.save(image_bytes, format="jpeg")
+        rgb_image.save(image_bytes, format="jpeg", quality=95)
         jpg_image = image_bytes.getvalue()
         image_bytes.close()
 

--- a/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/inceptionapi.py
@@ -58,8 +58,8 @@ import json
 json.encoder.FLOAT_REPR = lambda o: format(
     o, '.2f')  # JSON serialization of floats
 from time import time
-
-
+from PIL import Image
+from io import BytesIO
 import tempfile
 import flask
 
@@ -363,6 +363,8 @@ def classify_image():
     """
     API to classify images
     """
+    image_format = "not jpeg"
+
     st = current_time()
     topk = int(request.args.get("topk", "10"))
     human = request.args.get("human", "true").lower() in ("true", "1", "yes")
@@ -373,12 +375,29 @@ def classify_image():
         c_type, image_data = get_remotefile(url)
         if not image_data:
             return flask.Response(status=400, response=jsonify(error="Couldnot HTTP GET %s" % url))
-        if 'image/jpeg' not in c_type:
-            return flask.Response(status=400, response=jsonify(error="Content of %s is not JPEG" % url))
+        if 'image/jpeg' in c_type:
+            image_format = "jpeg"
+
+    # use c_type to find whether image_format is jpeg or not
+    # if jpeg, don't convert
+    if image_format == "jpeg":
+        jpg_image = image_data
+    # if not jpeg
+    else:
+        # open the image from raw bytes
+        image = Image.open(BytesIO(image_data))
+        # convert the image to RGB format, otherwise will give errors when converting to jpeg, if the image isn't RGB
+        rgb_image = image.convert("RGB")
+        # convert the RGB image to jpeg
+        image_bytes = BytesIO()
+        rgb_image.save(image_bytes, format="jpeg")
+        jpg_image = image_bytes.getvalue()
+        image_bytes.close()
+
     read_time = current_time() - st
     st = current_time()  # reset start time
     try:
-        classes = app.classify(image_string=image_data, topk=topk)
+        classes = app.classify(image_string=jpg_image, topk=topk)
     except Exception as e:
         app.logger.error(e)
         return Response(status=400, response=str(e))

--- a/tika-parsers/src/test/java/org/apache/tika/parser/recognition/ObjectRecognitionParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/recognition/ObjectRecognitionParserTest.java
@@ -48,6 +48,9 @@ public class ObjectRecognitionParserTest {
 
     // Test images
     private static final String CAT_IMAGE_JPEG = "test-documents/testJPEG.jpg";
+    private static final String CAT_IMAGE_PNG = "test-documents/testPNG.png";
+    private static final String CAT_IMAGE_GIF = "test-documents/testGIF.gif";
+
     private static final String BASEBALL_IMAGE_JPEG = "test-documents/baseball.jpg";
     private static final String BASEBALL_IMAGE_PNG = "test-documents/baseball.png";
     private static final String BASEBALL_IMAGE_GIF = "test-documents/baseball.gif";
@@ -92,6 +95,38 @@ public class ObjectRecognitionParserTest {
         Assume.assumeTrue(available);
         String[] expectedObjects = {"Egyptian cat", "tabby, tabby cat"};
         doRecognize(CONFIG_REST_FILE_OBJ_REC, CAT_IMAGE_JPEG,
+                ObjectRecognitionParser.MD_KEY_OBJ_REC, expectedObjects);
+    }
+
+    @Test
+    public void pngRESTObjRecTest() throws Exception {
+        String apiUrl = "http://localhost:8764/inception/v4/ping";
+        boolean available = false;
+        int status = 500;
+        try{
+            status = WebClient.create(apiUrl).get().getStatus();
+            available = status == 200;
+        }
+        catch(Exception ignore){}
+        Assume.assumeTrue(available);
+        String[] expectedObjects = {"Egyptian cat", "tabby, tabby cat"};
+        doRecognize(CONFIG_REST_FILE_OBJ_REC, CAT_IMAGE_PNG,
+                ObjectRecognitionParser.MD_KEY_OBJ_REC, expectedObjects);
+    }
+
+    @Test
+    public void gifRESTObjRecTest() throws Exception {
+        String apiUrl = "http://localhost:8764/inception/v4/ping";
+        boolean available = false;
+        int status = 500;
+        try{
+            status = WebClient.create(apiUrl).get().getStatus();
+            available = status == 200;
+        }
+        catch(Exception ignore){}
+        Assume.assumeTrue(available);
+        String[] expectedObjects = {"Egyptian cat"};
+        doRecognize(CONFIG_REST_FILE_OBJ_REC, CAT_IMAGE_GIF,
                 ObjectRecognitionParser.MD_KEY_OBJ_REC, expectedObjects);
     }
 

--- a/tika-parsers/src/test/resources/org/apache/tika/parser/recognition/tika-config-tflow-rest.xml
+++ b/tika-parsers/src/test/resources/org/apache/tika/parser/recognition/tika-config-tflow-rest.xml
@@ -20,6 +20,8 @@
     <parsers>
         <parser class="org.apache.tika.parser.recognition.ObjectRecognitionParser">
             <mime>image/jpeg</mime>
+            <mime>image/png</mime>
+            <mime>image/gif</mime>
             <params>
                 <param name="topN" type="int">2</param>
                 <param name="minConfidence" type="double">0.015</param>


### PR DESCRIPTION
**Support all image formats in Object Recognition REST Parser**
Currently object recognition REST parser only supports parsing jpeg image type. Objective of this task is to add all image format support to it by converting any image into jpeg format at the server's end.