### PR TITLE
directly compare stderr to empty string in testRedirectionOfStreams to obtain more meaningful messages if test fails

### DIFF
--- a/tika-batch/src/test/java/org/apache/tika/batch/fs/BatchProcessTest.java
+++ b/tika-batch/src/test/java/org/apache/tika/batch/fs/BatchProcessTest.java
@@ -232,7 +232,7 @@ public class BatchProcessTest extends FSBatchTestBase {
         assertEquals(1, countChildren(outputDir));
         assertContains("System.out", streamStrings.getOutString());
         assertContains("System.err", streamStrings.getOutString());
-        assertEquals(0, streamStrings.getErrString().length());
+        assertEquals("", streamStrings.getErrString());
 
     }
 


### PR DESCRIPTION
While installing Tika 1.16, I was running into this cryptic test failure:

```
java.lang.AssertionError: expected:<0> but was:<42>
```

At first, I was a bit confused, since `42` is clearly a superior result compared to `0`... [1]

After doing some digging, it turns out that I had `$_JAVA_OPTIONS` defined, which results in a message like this to stderr every time `java` is called:

```
Picked up _JAVA_OPTIONS: ...
```

I had to change the failing test to directly compare the stderr output with the empty string rather than checking the length of the strings to figure out what was wrong, so I propose to change this.

[1] https://en.wikipedia.org/wiki/42_(number)#The_Hitchhiker.27s_Guide_to_the_Galaxy