### PR TITLE
bump read timeout for downloading file to 60s (1min) in tika-dl

### DIFF
--- a/tika-dl/src/main/java/org/apache/tika/dl/imagerec/DL4JInceptionV3Net.java
+++ b/tika-dl/src/main/java/org/apache/tika/dl/imagerec/DL4JInceptionV3Net.java
@@ -213,7 +213,7 @@ public class DL4JInceptionV3Net implements ObjectRecogniser {
             }
             LOG.info("Cache doesn't exist. Going to make a copy");
             LOG.info("This might take a while! GET {}", uri);
-            FileUtils.copyURLToFile(uri.toURL(), cacheFile, 5000, 5000);
+            FileUtils.copyURLToFile(uri.toURL(), cacheFile, 5000, 60000);
             //restore the success flag again
             FileUtils.write(successFlag,
                     "CopiedAt:" + System.currentTimeMillis(),


### PR DESCRIPTION
cfr. discussion at https://github.com/apache/tika/pull/182#issuecomment-324757211

cc @chrismattmann 