### PR TITLE
TIKA-2464: No PIL found when building docker file 'InceptionVideoRestDockerfile'

### DIFF
--- a/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionVideoRestDockerfile
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/recognition/tf/InceptionVideoRestDockerfile
@@ -65,7 +65,7 @@ WORKDIR /
 # Install tensorflow and other dependencies
 RUN \
   pip install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.0.1-cp27-none-linux_x86_64.whl --ignore-installed  && \
-  pip install flask requests
+  pip install flask requests pillow
 
 # Get the TF-slim dependencies
 # Downloading from a specific commit for future compatibility


### PR DESCRIPTION
Added 'pip install flask requests pillow' instead of 'pip install flask requests' 