### PR TITLE
[TIKA-1788] RFC822Parser: provide email attachment filenames when available

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/mail/MailContentHandler.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/mail/MailContentHandler.java
@@ -27,6 +27,8 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -154,9 +156,21 @@ class MailContentHandler implements ContentHandler {
 
         if (body instanceof MaximalBodyDescriptor) {
             MaximalBodyDescriptor maximalBody = (MaximalBodyDescriptor) body;
-            String contentDispositionFileName = maximalBody.getContentDispositionFilename();
-            if (contentDispositionFileName != null) {
-                submd.set(Metadata.RESOURCE_NAME_KEY, contentDispositionFileName);
+            String contentDispositionType = maximalBody.getContentDispositionType();
+            if (contentDispositionType != null && !contentDispositionType.isEmpty()) {
+                StringBuilder contentDisposition = new StringBuilder( contentDispositionType );
+                Map<String, String> contentDispositionParameters = maximalBody.getContentDispositionParameters();
+                for ( Entry<String, String> param : contentDispositionParameters.entrySet() ) {
+                    contentDisposition.append("; ")
+                                      .append(param.getKey()).append("=\"").append(param.getValue()).append('"');
+                }
+
+                String contentDispositionFileName = maximalBody.getContentDispositionFilename();
+                if ( contentDispositionFileName != null ) {
+                    submd.set( Metadata.RESOURCE_NAME_KEY, contentDispositionFileName );
+                }
+
+                submd.set( Metadata.CONTENT_DISPOSITION, contentDisposition.toString() );
             }
         }
 

--- a/tika-parsers/src/main/java/org/apache/tika/parser/mail/MailContentHandler.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/mail/MailContentHandler.java
@@ -44,6 +44,7 @@ import org.apache.james.mime4j.dom.field.MailboxListField;
 import org.apache.james.mime4j.dom.field.ParsedField;
 import org.apache.james.mime4j.dom.field.UnstructuredField;
 import org.apache.james.mime4j.field.LenientFieldParser;
+import org.apache.james.mime4j.message.MaximalBodyDescriptor;
 import org.apache.james.mime4j.parser.ContentHandler;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
@@ -150,6 +151,14 @@ class MailContentHandler implements ContentHandler {
         Metadata submd = new Metadata();
         submd.set(Metadata.CONTENT_TYPE, body.getMimeType());
         submd.set(Metadata.CONTENT_ENCODING, body.getCharset());
+
+        if (body instanceof MaximalBodyDescriptor) {
+            MaximalBodyDescriptor maximalBody = (MaximalBodyDescriptor) body;
+            String contentDispositionFileName = maximalBody.getContentDispositionFilename();
+            if (contentDispositionFileName != null) {
+                submd.set(Metadata.RESOURCE_NAME_KEY, contentDispositionFileName);
+            }
+        }
 
         try {
             if (extractor.shouldParseEmbedded(submd)) {

--- a/tika-parsers/src/main/java/org/apache/tika/parser/mail/RFC822Parser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/mail/RFC822Parser.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.message.DefaultBodyDescriptorBuilder;
 import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.MimeConfig;
 import org.apache.tika.exception.TikaException;
@@ -67,7 +68,7 @@ public class RFC822Parser extends AbstractParser {
 
         config = context.get(MimeConfig.class, config);
 
-        MimeStreamParser parser = new MimeStreamParser(config);
+        MimeStreamParser parser = new MimeStreamParser(config, null, new DefaultBodyDescriptorBuilder());
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
 
         MailContentHandler mch = new MailContentHandler(

--- a/tika-parsers/src/test/java/org/apache/tika/parser/mail/RFC822ParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/mail/RFC822ParserTest.java
@@ -425,7 +425,8 @@ public class RFC822ParserTest extends TikaTest {
         // No filenames available
         assertEquals(null, tracker.filenames.get(0));
         assertEquals(null, tracker.filenames.get(1));
-        assertEquals(null, tracker.filenames.get(2));
+        // Except for this using Content-Disposition filename field
+        assertEquals("logo.gif", tracker.filenames.get(2));
         // Types are available
         assertEquals(MediaType.TEXT_PLAIN, tracker.mediaTypes.get(0));
         assertEquals(MediaType.TEXT_HTML, tracker.mediaTypes.get(1));
@@ -560,6 +561,7 @@ public class RFC822ParserTest extends TikaTest {
         final Parser extParser = new AutoDetectParser();
         final List<MediaType> seenTypes = new ArrayList<MediaType>();
         final List<String> seenText = new ArrayList<String>();
+        final List<String> seenNames = new ArrayList<String>();
         EmbeddedDocumentExtractor ext = new EmbeddedDocumentExtractor() {
             @Override
             public boolean shouldParseEmbedded(Metadata metadata) {
@@ -570,6 +572,7 @@ public class RFC822ParserTest extends TikaTest {
             public void parseEmbedded(InputStream stream, ContentHandler handler,
                     Metadata metadata, boolean outputHtml) throws SAXException,
                     IOException {
+                seenNames.add( metadata.get(Metadata.RESOURCE_NAME_KEY) );
                 seenTypes.add( detector.detect(stream, metadata) );
                 
                 ContentHandler h = new BodyContentHandler();
@@ -596,6 +599,7 @@ public class RFC822ParserTest extends TikaTest {
         assertEquals(2, seenText.size());
         assertEquals("text/plain", seenTypes.get(0).toString());
         assertEquals("image/png", seenTypes.get(1).toString());
+        assertEquals("testPNG.png", seenNames.get(1));
         assertEquals("This email has a PNG attachment included in it\n\n", seenText.get(0));
     }
 }

--- a/tika-parsers/src/test/java/org/apache/tika/parser/mail/RFC822ParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/mail/RFC822ParserTest.java
@@ -562,6 +562,7 @@ public class RFC822ParserTest extends TikaTest {
         final List<MediaType> seenTypes = new ArrayList<MediaType>();
         final List<String> seenText = new ArrayList<String>();
         final List<String> seenNames = new ArrayList<String>();
+        final List<String> seenContentDisposition = new ArrayList<String>();
         EmbeddedDocumentExtractor ext = new EmbeddedDocumentExtractor() {
             @Override
             public boolean shouldParseEmbedded(Metadata metadata) {
@@ -574,6 +575,7 @@ public class RFC822ParserTest extends TikaTest {
                     IOException {
                 seenNames.add( metadata.get(Metadata.RESOURCE_NAME_KEY) );
                 seenTypes.add( detector.detect(stream, metadata) );
+                seenContentDisposition.add( metadata.get(Metadata.CONTENT_DISPOSITION) );
                 
                 ContentHandler h = new BodyContentHandler();
                 try {
@@ -601,5 +603,50 @@ public class RFC822ParserTest extends TikaTest {
         assertEquals("image/png", seenTypes.get(1).toString());
         assertEquals("testPNG.png", seenNames.get(1));
         assertEquals("This email has a PNG attachment included in it\n\n", seenText.get(0));
+        assertEquals(null, seenContentDisposition.get(0));
+        assertEquals("attachment; filename=\"testPNG.png\"", seenContentDisposition.get(1));
+    }
+
+    @Test
+    public void testEmbeddedMetadata() throws Exception {
+        Metadata metadata = new Metadata();
+        Parser p = new RFC822Parser();
+        ParseContext context = new ParseContext();
+        final Parser extParser = new AutoDetectParser();
+        final List<Metadata> seenMetadata = new ArrayList<>();
+        EmbeddedDocumentExtractor ext = new EmbeddedDocumentExtractor() {
+            @Override
+            public boolean shouldParseEmbedded(Metadata metadata) {
+                return true;
+            }
+
+            @Override
+            public void parseEmbedded(InputStream stream, ContentHandler handler,
+                                      Metadata metadata, boolean outputHtml) throws SAXException,
+                                                                                    IOException {
+                seenMetadata.add( metadata );
+                try {
+                    extParser.parse(stream, new DefaultHandler(), metadata, new ParseContext());
+                } catch (TikaException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        context.set(EmbeddedDocumentExtractor.class, ext);
+
+        try(InputStream stream = getStream( "test-documents/testRFC822-multipart" )) {
+            p.parse(stream, new DefaultHandler(), metadata, context);
+        }
+
+        assertEquals(3, seenMetadata.size());
+        assertEquals(null, seenMetadata.get(0).get(Metadata.CONTENT_DISPOSITION));
+        assertEquals("text/plain; charset=UTF-8", seenMetadata.get(0).get(Metadata.CONTENT_TYPE));
+        assertEquals("UTF-8", seenMetadata.get(0).get(Metadata.CONTENT_ENCODING));
+        assertEquals(null, seenMetadata.get(1).get(Metadata.CONTENT_DISPOSITION));
+        assertEquals("text/html; charset=UTF-8", seenMetadata.get(1).get(Metadata.CONTENT_TYPE));
+        assertEquals("UTF-8", seenMetadata.get(1).get(Metadata.CONTENT_ENCODING));
+        assertEquals("attachment; filename=\"logo.gif\"", seenMetadata.get(2).get(Metadata.CONTENT_DISPOSITION));
+        assertEquals("logo.gif", seenMetadata.get(2).get(Metadata.RESOURCE_NAME_KEY));
+        assertEquals("image/gif", seenMetadata.get(2).get(Metadata.CONTENT_TYPE));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TIKA-1788 old case but had the solution in it. Not sure why it never made it in.

There is other info available in `MaximalBodyDescriptor`. However I am not sure how they would map to fields in `Metadata` or if most files would even have that info*.

One piece of info that I would like to make available is either the whole `Content-Disposition` line which I am not sure how to get, or flags for `attachment`/`inline` that are almost always available with filename. Looking at the source code, it is parsed but hidden away behind a `private` field.😢 