### PR TITLE
TIKA-1191 fix package access in ForkParser

### DIFF
--- a/tika-core/src/test/java/org/apache/tika/fork/ForkParserTest.java
+++ b/tika-core/src/test/java/org/apache/tika/fork/ForkParserTest.java
@@ -218,4 +218,21 @@ public class ForkParserTest {
         }
     }
 
+    @Test
+    public void testPackageCanBeAccessed() throws Exception {
+        ForkParser parser = new ForkParser(
+                ForkParserTest.class.getClassLoader(),
+                new ForkTestParser.ForkTestParserAccessingPackage());
+        try {
+            Metadata metadata = new Metadata();
+            ContentHandler output = new BodyContentHandler();
+            InputStream stream = new ByteArrayInputStream(new byte[0]);
+            ParseContext context = new ParseContext();
+            parser.parse(stream, output, metadata, context);
+            assertEquals("Hello, World!", output.toString().trim());
+            assertEquals("text/plain", metadata.get(Metadata.CONTENT_TYPE));
+        } finally {
+            parser.close();
+        }
+    }
 }

--- a/tika-core/src/test/java/org/apache/tika/fork/ForkTestParser.java
+++ b/tika-core/src/test/java/org/apache/tika/fork/ForkTestParser.java
@@ -22,11 +22,13 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.fork.unusedpackage.ClassInUnusedPackage;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.XHTMLContentHandler;
+import org.junit.Assert;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
@@ -54,4 +56,12 @@ class ForkTestParser extends AbstractParser {
         xhtml.endDocument();
     }
 
+    static class ForkTestParserAccessingPackage extends ForkTestParser {
+        @Override
+        public void parse(InputStream stream, ContentHandler handler, Metadata metadata,
+                ParseContext context) throws IOException, SAXException, TikaException {
+            Assert.assertNotNull(ClassInUnusedPackage.class.getPackage());
+            super.parse(stream, handler, metadata, context);
+        }
+    }
 }

--- a/tika-core/src/test/java/org/apache/tika/fork/unusedpackage/ClassInUnusedPackage.java
+++ b/tika-core/src/test/java/org/apache/tika/fork/unusedpackage/ClassInUnusedPackage.java
@@ -1,0 +1,4 @@
+package org.apache.tika.fork.unusedpackage;
+
+public class ClassInUnusedPackage {
+}


### PR DESCRIPTION
`ForkParser` can not be used right now when using `AutoDetectParser` together with the optional `jai-imageio-core` dependency.

This fix enhances the patch provided in TIKA-1191 with unit tests.

Thanks for the great work with Apache Tika! It would be really helpful for us to be able to use `ForkParser` with all optional dependencies in a future version.