### PR TITLE
fix for TIKA-2545 contributed by genekhart

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/utils/RereadableInputStream.java
+++ b/tika-core/src/main/java/org/apache/tika/utils/RereadableInputStream.java
@@ -190,7 +190,7 @@ public class RereadableInputStream extends InputStream {
         firstPass = false;
         boolean newStreamIsInMemory = (size < maxBytesInMemory);
         inputStream = newStreamIsInMemory
-                ? new ByteArrayInputStream(byteBuffer)
+                ? new ByteArrayInputStream(byteBuffer, 0, size)
                 : new BufferedInputStream(new FileInputStream(storeFile));
     }
 


### PR DESCRIPTION
For original inputstreams smaller than buffersize, should create bytearrayinputstream with bounds determined by size of original input, not pass in entire buffer.