### PR TITLE
TIKA-2565 Upgrade edu.ucar dependencies to 4.6.11

### DIFF
--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -44,13 +44,21 @@
     <vorbis.version>0.8</vorbis.version>
     <pdfbox.version>2.0.8</pdfbox.version>
     <jempbox.version>1.8.13</jempbox.version>
-    <netcdf-java.version>4.5.5</netcdf-java.version>
+    <netcdf-java.version>4.6.11</netcdf-java.version>
     <sis.version>0.8</sis.version>
     <!-- used by POI, PDFBox and Jackcess ...try to sync -->
     <bouncycastle.version>1.54</bouncycastle.version>
     <commonsexec.version>1.3</commonsexec.version>
     <httpcomponents.version>4.5.4</httpcomponents.version>
   </properties>
+
+  <repositories>
+    <repository>
+        <id>unidata-all</id>
+        <name>Unidata All</name>
+        <url>https://artifacts.unidata.ucar.edu/repository/unidata-all/</url>
+    </repository>
+  </repositories>
 
   <dependencies>
     <!-- Optional OSGi dependency, used only when running within OSGi -->


### PR DESCRIPTION
This issue addresses https://issues.apache.org/jira/browse/TIKA-2565 and supersedes https://github.com/apache/tika/pull/212

@med-ali-bannour FYI