### PR TITLE
Fix for TIKA-2570 contributed by ewanmellor.

### DIFF
--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -587,7 +587,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.2</version>
+      <version>2.9.4</version>
     </dependency>
 
     <!-- Java ImageIO plugin for JBIG2 support (often used in PDF)

--- a/tika-translate/pom.xml
+++ b/tika-translate/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.9.2</version>
+      <version>2.9.4</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Upgrade use of jackson to 2.9.4.  Versions 2.9.2 and 2.9.3 allow
unauthenticated remote code execution, labeled CVE-2017-17485.