### PR TITLE
Fix for TIKA-2580 contributed by ewanmellor.

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/sax/SafeContentHandler.java
+++ b/tika-core/src/main/java/org/apache/tika/sax/SafeContentHandler.java
@@ -31,7 +31,8 @@ import org.xml.sax.helpers.AttributesImpl;
  * ({@link #characters(char[], int, int)} or
  * {@link #ignorableWhitespace(char[], int, int)}) passed to the decorated
  * content handler contain only valid XML characters. All invalid characters
- * are replaced with spaces.
+ * are replaced with the Unicode replacement character U+FFFD (though a
+ * subclass may change this by overriding the writeReplacement method).
  * <p>
  * The XML standard defines the following Unicode character ranges as
  * valid XML characters:


### PR DESCRIPTION
Fix doc comment regarding the replacement character used by
SafeContentHandler.  This comment has been incorrect since TIKA-698
(Sep 2011).