### PR TITLE
Fix for TIKA-2581 contributed by ewanmellor.

### DIFF
--- a/tika-core/src/test/java/org/apache/tika/TikaTest.java
+++ b/tika-core/src/test/java/org/apache/tika/TikaTest.java
@@ -107,6 +107,11 @@ public abstract class TikaTest {
         assertTrue(needle + " not found in:\n" + haystack, haystack.contains(needle));
     }
 
+    public static void assertContainsEither(String needle1, String needle2, String haystack) {
+        assertTrue("neither " + needle1 + " nor " + needle2 + " found in:\n" + haystack,
+                haystack.contains(needle1) || haystack.contains(needle2));
+    }
+
     public static void assertNotContained(String needle, String haystack) {
         assertFalse(needle + " unexpectedly found in:\n" + haystack, haystack.contains(needle));
     }

--- a/tika-parsers/src/test/java/org/apache/tika/parser/ocr/TesseractOCRParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/ocr/TesseractOCRParserTest.java
@@ -139,7 +139,9 @@ public class TesseractOCRParserTest extends TikaTest {
                 TesseractOCRConfig.OUTPUT_TYPE.HOCR);
 
         assertContains("<span class=\"ocrx_word\" id=\"word_1_1\"", contents);
-        assertContains("Happy</span>", contents);
+        // Tesseract 3.x tags this with just a <span>.
+        // Tesseract 4.0 tags this with <span><strong>.
+        assertContainsEither("Happy</span>", "Happy</strong></span>", contents);
 
     }
 


### PR DESCRIPTION
TesseractOCRParserTest.testOCROutputsHOCR fails with Tesseract 4.0.

With 3.x, the output is <span>Happy</span> but with 4.0 the output is
<span><strong>Happy</strong></span>.  Both these seem reasonable to me,
so update the test to accept either of them.