### PR TITLE
Update forbiddenapis to version 2.5 and remove commons-io hack

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -327,7 +327,7 @@
         <groupId>de.thetaphi</groupId>
         <artifactId>forbiddenapis</artifactId>
         <!-- if this version contains commons-io 2.6, remove hard-coded commons-io version below -->
-        <version>2.4.1</version>
+        <version>2.5</version>
         <configuration>
           <targetVersion>${maven.compiler.target}</targetVersion>
           <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
@@ -337,11 +337,7 @@
             <bundledSignature>jdk-deprecated</bundledSignature>
             <bundledSignature>jdk-non-portable</bundledSignature>
             <bundledSignature>jdk-internal</bundledSignature>
-            <!--2.6 is the same as 2.5
-              TODO: change back to the following when we upgrade forbidden apis
-              <bundledSignature>commons-io-unsafe-${commons.io.version}</bundledSignature>
-            -->
-            <bundledSignature>commons-io-unsafe-2.5</bundledSignature>
+            <bundledSignature>commons-io-unsafe-${commons.io.version}</bundledSignature>
           </bundledSignatures>
         </configuration>
         <executions>


### PR DESCRIPTION
Hi,
as TIKA is my Maven test project for new versions of forbiddenapis and the local test build already succeeded (before my release), here is a PR that updates to new version. It also removes the commons-io hack in the parent pom.