### PR TITLE
Fix for TIKA-2624 contributed by ewanmellor.

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
@@ -326,12 +326,13 @@ class AbstractPDF2XHTML extends PDFTextStripper {
         TemporaryResources tmp = new TemporaryResources();
         try {
 
-            BufferedImage image = renderer.renderImage(pageIndex, config.getOcrImageScale(), config.getOcrImageType());
+            int dpi = config.getOcrDPI();
+            BufferedImage image = renderer.renderImageWithDPI(pageIndex, dpi, config.getOcrImageType());
             Path tmpFile = tmp.createTempFile();
             try (OutputStream os = Files.newOutputStream(tmpFile)) {
                 //TODO: get output format from TesseractConfig
                 ImageIOUtil.writeImage(image, config.getOcrImageFormatName(),
-                        os, config.getOcrDPI(), config.getOcrImageQuality());
+                        os, dpi, config.getOcrImageQuality());
             }
             try (InputStream is = TikaInputStream.get(tmpFile)) {
                 tesseractOCRParser.parseInline(is, xhtml, tesseractConfig);

--- a/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParser.java
@@ -659,11 +659,6 @@ public class PDFParser extends AbstractParser implements Initializable {
         defaultConfig.setOcrImageFormatName(formatName);
     }
 
-    @Field
-    void setOcrImageScale(float imageScale) {
-        defaultConfig.setOcrImageScale(imageScale);
-    }
-
 	@Field
 	void setExtractBookmarksText(boolean extractBookmarksText) {
 		defaultConfig.setExtractBookmarksText(extractBookmarksText);

--- a/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParserConfig.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pdf/PDFParserConfig.java
@@ -123,7 +123,6 @@ public class PDFParserConfig implements Serializable {
     private ImageType ocrImageType = ImageType.GRAY;
     private String ocrImageFormatName = "png";
     private float ocrImageQuality = 1.0f;
-    private float ocrImageScale = 2.0f;
 
     private AccessChecker accessChecker;
 
@@ -212,8 +211,6 @@ public class PDFParserConfig implements Serializable {
         setOcrImageFormatName(props.getProperty("ocrImageFormatName"));
 
         setOcrImageType(parseImageType(props.getProperty("ocrImageType")));
-
-        setOcrImageScale(getFloatProp(props.getProperty("ocrImageScale"), getOcrImageScale()));
 
         setExtractActions(getBooleanProp(props.getProperty("extractActions"), false));
 
@@ -643,19 +640,6 @@ public class PDFParserConfig implements Serializable {
      */
     public void setOcrImageQuality(float ocrImageQuality) {
         this.ocrImageQuality = ocrImageQuality;
-    }
-
-    /**
-     * Scale to use if rendering a page and then running OCR on that rendered image.
-     * Default is 2.0f.
-     * @return
-     */
-    public float getOcrImageScale() {
-        return ocrImageScale;
-    }
-
-    public void setOcrImageScale(float ocrImageScale) {
-        this.ocrImageScale = ocrImageScale;
     }
 
     /**

--- a/tika-parsers/src/main/resources/org/apache/tika/parser/pdf/PDFParser.properties
+++ b/tika-parsers/src/main/resources/org/apache/tika/parser/pdf/PDFParser.properties
@@ -33,8 +33,6 @@ ocrDPI 300
 ocrImageFormatName png
 #options: argb, binary, gray, rgb
 ocrImageType gray
-#scale to use when rendering a page image for OCR
-ocrImageScale 2.0
 # Use up to 500MB when loading a pdf into a PDDocument
 maxMainMemoryBytes 524288000
 #whether or not to set KCMS for faster (but legacy/unsupported) image rendering

--- a/tika-parsers/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
@@ -1329,7 +1329,6 @@ public class PDFParserTest extends TikaTest {
             assertEquals(false, pdfParserConfig.getExtractUniqueInlineImagesOnly());
             assertEquals(314, pdfParserConfig.getOcrDPI());
             assertEquals(2.1f, pdfParserConfig.getOcrImageQuality(), .01f);
-            assertEquals(1.3f, pdfParserConfig.getOcrImageScale(), .01f);
             assertEquals("jpeg", pdfParserConfig.getOcrImageFormatName());
             assertEquals(524288000, pdfParserConfig.getMaxMainMemoryBytes());
             assertEquals(false, pdfParserConfig.getCatchIntermediateIOExceptions());


### PR DESCRIPTION
Change AbstractPDF2XHTML.doOCROnCurrentPage to use the same DPI value
(PDFParserConfig.ocrDPI) for both the PDF rendering and the image metadata.

Previously, the PDF was being rendered using ocrImageScale (default 2.0 ==
144dpi) and then putting ocrDPI (default 300) in the image metadata.  Having
these two things be independent makes no sense, and is surely going to
confuse Tesseract when the image metadata does not match the data.

This change means that ocrDPI drives both values, and ocrImageScale is
removed.  This also switches from PDFRenderer.renderImage to
PDFRenderer.renderImageWithDPI, but that's just a stub to make it clearer
what's going on.

This change will have the side-effect that the temporary images between the
PDF rendering and Tesseract will be 4x larger (144dpi to 300dpi).  This will
have a memory and temporary disk space impact, but it will ensure that the
whole pipeline uses 300dpi by default.  People who have memory constraints
will need to reduce ocrDPI and make the corresponding changes on the
Tesseract side.