### PR TITLE
TIKA-2648 : detect interpreted server-side scripting languages

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/mime/MimeType.java
+++ b/tika-core/src/main/java/org/apache/tika/mime/MimeType.java
@@ -111,6 +111,12 @@ public final class MimeType implements Comparable<MimeType>, Serializable {
     private List<String> extensions = null;
 
     /**
+     * Whether this mime-type is used for server-side scripts,
+     * and thus cannot reliably be used for filename-based type detection
+     */
+    private boolean isInterpreted = false;
+
+    /**
      * Creates a media type with the give name and containing media type
      * registry. The name is expected to be valid and normalized to lower
      * case. This constructor should only be called by
@@ -300,6 +306,17 @@ public final class MimeType implements Comparable<MimeType>, Serializable {
 
     public boolean matches(byte[] data) {
         return matchesMagic(data);
+    }
+
+    /**
+     * whether the type is used as a server-side scripting technology
+     */
+    boolean isInterpreted() {
+        return isInterpreted;
+    }
+
+    void setInterpreted(boolean interpreted) {
+        isInterpreted = interpreted;
     }
 
     /**

--- a/tika-core/src/main/java/org/apache/tika/mime/MimeTypes.java
+++ b/tika-core/src/main/java/org/apache/tika/mime/MimeTypes.java
@@ -502,10 +502,13 @@ public final class MimeTypes implements Detector, Serializable {
         String resourceName = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
         if (resourceName != null) {
             String name = null;
+            boolean isHttp = false;
 
             // Deal with a URI or a path name in as the resource  name
             try {
                 URI uri = new URI(resourceName);
+                String scheme = uri.getScheme();
+                isHttp = scheme != null && scheme.startsWith("http"); // http or https
                 String path = uri.getPath();
                 if (path != null) {
                     int slash = path.lastIndexOf('/');
@@ -519,11 +522,14 @@ public final class MimeTypes implements Detector, Serializable {
 
             if (name != null) {
                 MimeType hint = getMimeType(name);
-                
-                // If we have some types based on mime magic, try to specialise
-                //  and/or select the type based on that
-                // Otherwise, use the type identified from the name
-                possibleTypes = applyHint(possibleTypes, hint);
+
+                // For server-side scripting languages, we cannot rely on the filename to detect the mime type
+                if (!(isHttp && hint.isInterpreted())) {
+                    // If we have some types based on mime magic, try to specialise
+                    //  and/or select the type based on that
+                    // Otherwise, use the type identified from the name
+                    possibleTypes = applyHint(possibleTypes, hint);
+                }
             }
         }
 

--- a/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReader.java
+++ b/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReader.java
@@ -169,8 +169,11 @@ public class MimeTypesReader extends DefaultHandler implements MimeTypesReaderMe
         if (type == null) {
             if (MIME_TYPE_TAG.equals(qName)) {
                 String name = attributes.getValue(MIME_TYPE_TYPE_ATTR);
+                String interpretedAttr = attributes.getValue(INTERPRETED_ATTR);
+                boolean interpreted = "true".equals(interpretedAttr);
                 try {
                     type = types.forName(name);
+                    type.setInterpreted(interpreted);
                 } catch (MimeTypeException e) {
                     handleMimeError(name, e, qName, attributes);
                 }

--- a/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReaderMetKeys.java
+++ b/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReaderMetKeys.java
@@ -27,6 +27,8 @@ public interface MimeTypesReaderMetKeys {
 
     String MIME_TYPE_TYPE_ATTR = "type";
 
+    String INTERPRETED_ATTR = "interpreted";
+
     String ACRONYM_TAG = "acronym";
 
     String COMMENT_TAG = "_comment";

--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5987,13 +5987,13 @@
     <sub-class-of type="text/plain"/>
   </mime-type>
 
-  <mime-type type="text/asp">
+  <mime-type type="text/asp" interpreted="true">
     <_comment>Active Server Page</_comment>
     <glob pattern="*.asp"/>
     <sub-class-of type="text/plain"/>
   </mime-type>
 
-  <mime-type type="text/aspdotnet">
+  <mime-type type="text/aspdotnet" interpreted="true">
     <_comment>ASP .NET</_comment>
     <glob pattern="*.aspx"/>
     <sub-class-of type="text/plain"/>
@@ -6414,7 +6414,7 @@
     <sub-class-of type="text/plain"/>
   </mime-type>
 
-  <mime-type type="text/x-cgi">
+  <mime-type type="text/x-cgi" interpreted="true">
     <_comment>CGI script</_comment>
     <glob pattern="*.cgi"/>
     <sub-class-of type="text/plain"/>
@@ -6468,7 +6468,7 @@
     <sub-class-of type="text/plain"/>
   </mime-type>
 
-  <mime-type type="text/x-coldfusion">
+  <mime-type type="text/x-coldfusion" interpreted="true">
     <_comment>ColdFusion source code</_comment>
     <glob pattern="*.cfm"/>
     <glob pattern="*.cfml"/>
@@ -6584,7 +6584,7 @@
     <sub-class-of type="text/plain"/>
   </mime-type>
 
-  <mime-type type="text/x-jsp">
+  <mime-type type="text/x-jsp" interpreted="true">
     <_comment>Java Server Page</_comment>
     <alias type="application/x-httpd-jsp"/>
     <sub-class-of type="text/plain"/>
@@ -6712,7 +6712,7 @@
     <sub-class-of type="text/plain"/>
   </mime-type>
 
-  <mime-type type="text/x-php">
+  <mime-type type="text/x-php" interpreted="true">
     <_comment>PHP script</_comment>
     <magic priority="50">
       <match value="&lt;?php" type="string" offset="0"/>

--- a/tika-core/src/test/java/org/apache/tika/mime/CustomReaderTest.java
+++ b/tika-core/src/test/java/org/apache/tika/mime/CustomReaderTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -89,6 +90,7 @@ public class CustomReaderTest {
     assertEquals(1, reader.ignorePatterns.size());
     assertEquals(another.toString()+">>*"+hello.getExtension(), 
         reader.ignorePatterns.get(0));
+    assertTrue("Server-side script type not detected", another.isInterpreted());
     
     //System.out.println( mimeTypes.getMediaTypeRegistry().getTypes() );
   }

--- a/tika-core/src/test/resources/org/apache/tika/mime/custom-mimetypes2.xml
+++ b/tika-core/src/test/resources/org/apache/tika/mime/custom-mimetypes2.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 -->
 <mime-info>
-  <mime-type type="another/world-file">
+  <mime-type type="another/world-file" interpreted="true">
      <hello>kittens</hello>
      <glob pattern="*.hello.world" /> <!-- Will collide with 'hello/world-file'  -->
      <sub-class-of type="hello/world" />


### PR DESCRIPTION
mime detection based on resource name used to detect
the mime-type of "http://example.com/test.php" as being "text/x-php"
whereas given such an URL, the file extension doesn't give
us any information about the mime type that will be returned
by the server