### PR TITLE
TIKA-2675 OpenDocumentParser should fail on invalid zip files

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/odf/OpenDocumentParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/odf/OpenDocumentParser.java
@@ -26,6 +26,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
@@ -175,10 +176,13 @@ public class OpenDocumentParser extends AbstractParser {
 
     private void handleZipStream(ZipInputStream zipStream, Metadata metadata, ParseContext context, EndDocumentShieldingContentHandler handler) throws IOException, TikaException, SAXException {
         ZipEntry entry = zipStream.getNextEntry();
-        while (entry != null) {
+		if (entry == null) {
+			throw new IOException("No entries found in ZipInputStream");
+		}
+        do {
             handleZipEntry(entry, zipStream, metadata, context, handler);
             entry = zipStream.getNextEntry();
-        }
+        } while (entry != null);
     }
 
     private void handleZipFile(ZipFile zipFile, Metadata metadata,

--- a/tika-parsers/src/test/java/org/apache/tika/parser/odf/ODFParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/odf/ODFParserTest.java
@@ -19,6 +19,7 @@ package org.apache.tika.parser.odf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -404,6 +405,28 @@ public class ODFParserTest extends TikaTest {
     public void testEmbedded() throws Exception {
         List<Metadata> metadataList = getRecursiveMetadata("testODTEmbedded.odt");
         assertEquals(3, metadataList.size());
+    }
+
+    @Test(expected = IOException.class)
+    public void testInvalidFromStream() throws Exception {
+        try (InputStream is = this.getClass().getResource(
+                "/test-documents/testODTnotaZipFile.odt").openStream()) {
+            OpenDocumentParser parser = new OpenDocumentParser();
+            Metadata metadata = new Metadata();
+            ContentHandler handler = new BodyContentHandler();
+            parser.parse(is, handler, metadata, new ParseContext());
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testInvalidFromFile() throws Exception {
+        try (TikaInputStream tis = TikaInputStream.get(this.getClass().getResource(
+                "/test-documents/testODTnotaZipFile.odt"))) {
+            OpenDocumentParser parser = new OpenDocumentParser();
+            Metadata metadata = new Metadata();
+            ContentHandler handler = new BodyContentHandler();
+            parser.parse(tis, handler, metadata, new ParseContext());
+        }
     }
 
     private ParseContext getNonRecursingParseContext() {

--- a/tika-parsers/src/test/resources/test-documents/testODTnotaZipFile.odt
+++ b/tika-parsers/src/test/resources/test-documents/testODTnotaZipFile.odt
@@ -1,0 +1,1 @@
+This is not a zip file!


### PR DESCRIPTION
- throw IOException if ZipInputStream is invalid or does not contain any entries

Note: now the behavior on empty zip files is different, if called on a local file (succeeds, empty document) or not (fails). The OpenDocument format spec ([section 17.2](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1.pdf), cf. [wikipedia article](https://en.wikipedia.org/wiki/OpenDocument_technical_specification#Format_internals)) does not state anything about empty zip files.