### PR TITLE
Use try-with-resources

### DIFF
--- a/tika-core/src/test/java/org/apache/tika/TestRereadableInputStream.java
+++ b/tika-core/src/test/java/org/apache/tika/TestRereadableInputStream.java
@@ -40,9 +40,7 @@ public class TestRereadableInputStream {
     public void test() throws IOException {
 
         InputStream is = createTestInputStream();
-        RereadableInputStream ris = new RereadableInputStream(is,
-                MEMORY_THRESHOLD, true, true);
-        try {
+        try (RereadableInputStream ris = new RereadableInputStream(is, MEMORY_THRESHOLD, true, true)) {
             for (int pass = 0; pass < NUM_PASSES; pass++) {
                 for (int byteNum = 0; byteNum < TEST_SIZE; byteNum++) {
                     int byteRead = ris.read();
@@ -52,10 +50,6 @@ public class TestRereadableInputStream {
                 }
                 ris.rewind();
             }
-        } finally {
-            // The RereadableInputStream should close the original input
-            // stream (if it hasn't already).
-            ris.close();
         }
     }
 

--- a/tika-core/src/test/java/org/apache/tika/fork/ForkParserTest.java
+++ b/tika-core/src/test/java/org/apache/tika/fork/ForkParserTest.java
@@ -66,10 +66,7 @@ public class ForkParserTest extends TikaTest {
 
     @Test
     public void testHelloWorld() throws Exception {
-        ForkParser parser = new ForkParser(
-                ForkParserTest.class.getClassLoader(),
-                new ForkTestParser());
-        try {
+        try (ForkParser parser = new ForkParser(ForkParserTest.class.getClassLoader(), new ForkTestParser())) {
             Metadata metadata = new Metadata();
             ContentHandler output = new BodyContentHandler();
             InputStream stream = new ByteArrayInputStream(new byte[0]);
@@ -77,17 +74,12 @@ public class ForkParserTest extends TikaTest {
             parser.parse(stream, output, metadata, context);
             assertEquals("Hello, World!", output.toString().trim());
             assertEquals("text/plain", metadata.get(Metadata.CONTENT_TYPE));
-        } finally {
-            parser.close();
         }
     }
 
     @Test
     public void testSerialParsing() throws Exception {
-        ForkParser parser = new ForkParser(
-                ForkParserTest.class.getClassLoader(),
-                new ForkTestParser());
-        try {
+        try (ForkParser parser = new ForkParser(ForkParserTest.class.getClassLoader(), new ForkTestParser())) {
             ParseContext context = new ParseContext();
             for (int i = 0; i < 10; i++) {
                 ContentHandler output = new BodyContentHandler();
@@ -95,17 +87,12 @@ public class ForkParserTest extends TikaTest {
                 parser.parse(stream, output, new Metadata(), context);
                 assertEquals("Hello, World!", output.toString().trim());
             }
-        } finally {
-            parser.close();
         }
     }
 
     @Test
     public void testParallelParsing() throws Exception {
-        final ForkParser parser = new ForkParser(
-                ForkParserTest.class.getClassLoader(),
-                new ForkTestParser());
-        try {
+        try (ForkParser parser = new ForkParser(ForkParserTest.class.getClassLoader(), new ForkTestParser())) {
             final ParseContext context = new ParseContext();
 
             Thread[] threads = new Thread[10];
@@ -131,17 +118,12 @@ public class ForkParserTest extends TikaTest {
                 threads[i].join();
                 assertEquals("Hello, World!", output[i].toString().trim());
             }
-        } finally {
-            parser.close();
         }
     }
 
     @Test
     public void testPoolSizeReached() throws Exception {
-        final ForkParser parser = new ForkParser(
-                ForkParserTest.class.getClassLoader(),
-                new ForkTestParser());
-        try {
+        try (ForkParser parser = new ForkParser(ForkParserTest.class.getClassLoader(), new ForkTestParser())) {
             final Semaphore barrier = new Semaphore(0);
 
             Thread[] threads = new Thread[parser.getPoolSize()];
@@ -202,8 +184,6 @@ public class ForkParserTest extends TikaTest {
 
             blocked.join();
             assertEquals("Hello, World!", o.toString().trim());
-        } finally {
-            parser.close();
         }
     }
 
@@ -249,10 +229,8 @@ public class ForkParserTest extends TikaTest {
 
     @Test
     public void testPackageCanBeAccessed() throws Exception {
-        ForkParser parser = new ForkParser(
-                ForkParserTest.class.getClassLoader(),
-                new ForkTestParser.ForkTestParserAccessingPackage());
-        try {
+        try (ForkParser parser = new ForkParser(ForkParserTest.class.getClassLoader(),
+                new ForkTestParser.ForkTestParserAccessingPackage())) {
             Metadata metadata = new Metadata();
             ContentHandler output = new BodyContentHandler();
             InputStream stream = new ByteArrayInputStream(new byte[0]);
@@ -260,8 +238,6 @@ public class ForkParserTest extends TikaTest {
             parser.parse(stream, output, metadata, context);
             assertEquals("Hello, World!", output.toString().trim());
             assertEquals("text/plain", metadata.get(Metadata.CONTENT_TYPE));
-        } finally {
-            parser.close();
         }
     }
 

--- a/tika-langdetect/src/test/java/org/apache/tika/langdetect/LanguageDetectorTest.java
+++ b/tika-langdetect/src/test/java/org/apache/tika/langdetect/LanguageDetectorTest.java
@@ -66,12 +66,9 @@ public abstract class LanguageDetectorTest {
     }
 
     protected void writeTo(String language, Writer writer, int limit) throws IOException {
-        InputStream stream = LanguageDetectorTest.class.getResourceAsStream("/language-tests/" + language + ".test");
-        
-        try {
+        try (InputStream stream = LanguageDetectorTest.class
+                .getResourceAsStream("/language-tests/" + language + ".test")) {
         	copyAtMost(new InputStreamReader(stream, UTF_8), writer, limit);
-        } finally {
-            stream.close();
         }
     }
 

--- a/tika-parsers/src/main/java/org/apache/tika/parser/crypto/Pkcs7Parser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/crypto/Pkcs7Parser.java
@@ -62,9 +62,8 @@ public class Pkcs7Parser extends AbstractParser {
         try {
             DigestCalculatorProvider digestCalculatorProvider =
                     new JcaDigestCalculatorProviderBuilder().setProvider("BC").build();
-            CMSSignedDataParser parser =
-                    new CMSSignedDataParser(digestCalculatorProvider, new CloseShieldInputStream(stream));
-            try {
+            try (CMSSignedDataParser parser = new CMSSignedDataParser(digestCalculatorProvider,
+                    new CloseShieldInputStream(stream))) {
                 CMSTypedStream content = parser.getSignedContent();
                 if (content == null) {
                     throw new TikaException("cannot parse detached pkcs7 signature (no signed data to parse)");
@@ -74,8 +73,6 @@ public class Pkcs7Parser extends AbstractParser {
                             context.get(Parser.class, EmptyParser.INSTANCE);
                     delegate.parse(input, handler, metadata, context);
                 }
-            } finally {
-                parser.close();
             }
         } catch (OperatorCreationException e) {
             throw new TikaException("Unable to create DigestCalculatorProvider", e);

--- a/tika-parsers/src/test/java/org/apache/tika/parser/fork/ForkParserIntegrationTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/fork/ForkParserIntegrationTest.java
@@ -63,11 +63,7 @@ public class ForkParserIntegrationTest extends MultiThreadedTikaTest {
      */
     @Test
     public void testForkedTextParsing() throws Exception {
-        ForkParser parser = new ForkParser(
-                ForkParserIntegrationTest.class.getClassLoader(),
-                tika.getParser());
-
-       try {
+        try (ForkParser parser = new ForkParser(ForkParserIntegrationTest.class.getClassLoader(), tika.getParser())) {
           ContentHandler output = new BodyContentHandler();
           InputStream stream = ForkParserIntegrationTest.class.getResourceAsStream(
                   "/test-documents/testTXT.txt");
@@ -77,8 +73,6 @@ public class ForkParserIntegrationTest extends MultiThreadedTikaTest {
           String content = output.toString();
           assertContains("Test d'indexation", content);
           assertContains("http://www.apache.org", content);
-       } finally {
-          parser.close();
        }
     }
    
@@ -257,10 +251,7 @@ public class ForkParserIntegrationTest extends MultiThreadedTikaTest {
      */
     @Test
     public void testForkedPDFParsing() throws Exception {
-        ForkParser parser = new ForkParser(
-                ForkParserIntegrationTest.class.getClassLoader(),
-                tika.getParser());
-        try {
+        try (ForkParser parser = new ForkParser(ForkParserIntegrationTest.class.getClassLoader(), tika.getParser())) {
             ContentHandler output = new BodyContentHandler();
             InputStream stream = ForkParserIntegrationTest.class.getResourceAsStream(
                     "/test-documents/testPDF.pdf");
@@ -273,24 +264,18 @@ public class ForkParserIntegrationTest extends MultiThreadedTikaTest {
             assertContains("Tika - Content Analysis Toolkit", content);
             assertContains("incubator", content);
             assertContains("Apache Software Foundation", content);
-        } finally {
-            parser.close();
         }
     }
 
     @Test
     public void testForkedPackageParsing() throws Exception {
-        ForkParser parser = new ForkParser(ForkParserIntegrationTest.class.getClassLoader(),
-            tika.getParser());
-        try {
+        try (ForkParser parser = new ForkParser(ForkParserIntegrationTest.class.getClassLoader(), tika.getParser())) {
             ContentHandler output = new BodyContentHandler();
             InputStream stream = ForkParserIntegrationTest.class.getResourceAsStream(
                 "/test-documents/moby.zip");
             ParseContext context = new ParseContext();
             parser.parse(stream, output, new Metadata(), context);
             assertContains("Moby Dick", output.toString());
-        } finally {
-            parser.close();
         }
     }
 

--- a/tika-parsers/src/test/java/org/apache/tika/parser/pkg/CompressParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/pkg/CompressParserTest.java
@@ -40,12 +40,8 @@ public class CompressParserTest extends AbstractPkgTest {
         ContentHandler handler = new BodyContentHandler();
         Metadata metadata = new Metadata();
 
-        InputStream stream = TarParserTest.class.getResourceAsStream(
-                "/test-documents/test-documents.tar.Z");
-        try {
+        try (InputStream stream = TarParserTest.class.getResourceAsStream("/test-documents/test-documents.tar.Z")) {
             parser.parse(stream, handler, metadata, recursingContext);
-        } finally {
-            stream.close();
         }
 
         assertEquals("application/x-compress", metadata.get(Metadata.CONTENT_TYPE));
@@ -80,12 +76,8 @@ public class CompressParserTest extends AbstractPkgTest {
        ContentHandler handler = new BodyContentHandler();
        Metadata metadata = new Metadata();
 
-       InputStream stream = ZipParserTest.class.getResourceAsStream(
-               "/test-documents/test-documents.tar.Z");
-       try {
+        try (InputStream stream = ZipParserTest.class.getResourceAsStream("/test-documents/test-documents.tar.Z")) {
            parser.parse(stream, handler, metadata, trackingContext);
-       } finally {
-           stream.close();
        }
        
        // Should find a single entry, for the (compressed) tar file

--- a/tika-parsers/src/test/java/org/apache/tika/parser/solidworks/SolidworksParserTest.java
+++ b/tika-parsers/src/test/java/org/apache/tika/parser/solidworks/SolidworksParserTest.java
@@ -117,9 +117,8 @@ public class SolidworksParserTest extends TikaTest {
      */
     @Test
     public void testAssembly2014SP0Parser() throws Exception {
-        InputStream input = SolidworksParserTest.class.getResourceAsStream(
-                "/test-documents/testsolidworksAssembly2014SP0.SLDASM");
-        try {
+        try (InputStream input = SolidworksParserTest.class
+                .getResourceAsStream("/test-documents/testsolidworksAssembly2014SP0.SLDASM")) {
             ContentHandler handler = new BodyContentHandler();
             Metadata metadata = new Metadata();
             new OfficeParser().parse(input, handler, metadata, new ParseContext());
@@ -137,8 +136,6 @@ public class SolidworksParserTest extends TikaTest {
             assertEquals(null, metadata.get(TikaCoreProperties.SOURCE));
             assertEquals("", metadata.get(TikaCoreProperties.TITLE));
             assertEquals("", metadata.get(TikaCoreProperties.SUBJECT));
-        } finally {
-            input.close();
         }    	
     }
 


### PR DESCRIPTION
This pull request was created automatically as part of our ongoing efforts
at https://diffblue.com to implement refactorings. Feel free to leave feedback
here or contact us directly for any enquiries.

The developer in charge is @krobelus.

**Changes**:

- Replace try statements that close a resource in the finally block with a
try-with-resources statement [1].

[1] https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html
