### PR TITLE
fix for TIKA-2731 contributed by @jkakavas

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/utils/XMLReaderUtils.java
+++ b/tika-core/src/main/java/org/apache/tika/utils/XMLReaderUtils.java
@@ -80,14 +80,13 @@ public class XMLReaderUtils implements Serializable {
     private static int MAX_ENTITY_EXPANSIONS = determineMaxEntityExpansions();
 
     private static int determineMaxEntityExpansions() {
-        Properties properties = System.getProperties();
-        if (properties != null && properties.containsKey(JAXP_ENTITY_EXPANSION_LIMIT_KEY)) {
+        String expansionLimit = System.getProperty(JAXP_ENTITY_EXPANSION_LIMIT_KEY);
+        if (expansionLimit != null) {
             try {
-                return Integer.parseInt(properties.getProperty(JAXP_ENTITY_EXPANSION_LIMIT_KEY));
+                return Integer.parseInt(expansionLimit);
             } catch (NumberFormatException e) {
-                LOG.log(Level.WARNING, "Couldn't parse an integer for the entity expansion limit:"+
-                        properties.getProperty(JAXP_ENTITY_EXPANSION_LIMIT_KEY)+
-                        "; backing off to default: "+DEFAULT_MAX_ENTITY_EXPANSIONS);
+                LOG.log(Level.WARNING, "Couldn't parse an integer for the entity expansion limit:" + expansionLimit +
+                        "; backing off to default: " + DEFAULT_MAX_ENTITY_EXPANSIONS);
             }
         }
         return DEFAULT_MAX_ENTITY_EXPANSIONS;


### PR DESCRIPTION
As part of the changes introduced in 1.19 `determineMaxEntityExpansions` needs to read the `jdk.xml.entityExpansionLimit` System Property in order to overwrite the default value of 20, if it is set.
This is however by reading all System Properties with `System#getProperties()` and attempting to find the relevant key in the properties Object. The issue with this approach is that `System#getProperties()` requires:
```
java.util.PropertyPermission "*", "read,write"
```
which is an overly permissive one to allow for the given use case.

A more sane approach, following the least privilege design principal would be to use `System.getProperty()` for the specific property that only requires
```
java.util.PropertyPermission "jdk.xml.entityExpansionLimit", "read"
```
