### PR TITLE
fix for TIKA-2817 contributed by tombrisland

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/pkg/CompressorParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/pkg/CompressorParser.java
@@ -272,6 +272,8 @@ public class CompressorParser extends AbstractParser {
                     name = GzipUtils.getUncompressedFilename(name);
                 }
                 entrydata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+            } else if (cis instanceof GzipCompressorInputStream) {
+                entrydata.set(TikaCoreProperties.RESOURCE_NAME_KEY, ((GzipCompressorInputStream) cis).getMetaData().getFilename());
             }
 
             // Use the delegate parser to parse the compressed document


### PR DESCRIPTION
Add original filename from Gzip headers to Tika metadata when parsing