### PR TITLE
Update slf4j to 1.8.0-beta4

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -326,7 +326,7 @@
     <osgi.core.version>6.0.0</osgi.core.version>
 
     <cxf.version>3.3.0</cxf.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.8.0-beta4</slf4j.version>
     <jackson.version>2.9.8</jackson.version>
     <!-- when this is next upgraded, see if we can get rid of
          javax.activation dependency in tika-server -->


### PR DESCRIPTION
Because of [CVE-2018-8088](https://ossindex.sonatype.org/vuln/d33d3123-eac8-43d1-a5b1-4ebb82c88b77), we need to upgrade `slf4j` to `1.8.0-beta4`.

Hope this helps.
