### PR TITLE
iWork Pages: recognize multi-paragraph placeholders

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/iwork/PagesContentHandler.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/iwork/PagesContentHandler.java
@@ -180,7 +180,7 @@ class PagesContentHandler extends DefaultHandler {
               xhtml.characters(annotationText);
               xhtml.endElement("div");
            }
-        } else if ("sf:ghost-text".equals(qName)) {
+        } else if ("sf:ghost-text".equals(qName) || "sf:ghost-text-ref".equals(qName)) {
             ghostText = true;
         }
 
@@ -216,7 +216,7 @@ class PagesContentHandler extends DefaultHandler {
             annotations.end();
         } else if ("sf:annotation-field".equals(qName) && inPart == DocumentPart.PARSABLE_TEXT) {
             xhtml.endElement("div");
-        } else if ("sf:ghost-text".equals(qName)) {
+        } else if ("sf:ghost-text".equals(qName) || "sf:ghost-text-ref".equals(qName)) {
             ghostText = false;
         }
     }


### PR DESCRIPTION
If a placeholder spans across a paragraph break, the first `<sf:ghost-text>` element contains an `sfa:ID` attribute, which references a later `<sf:ghost-text-ref>` element by its matching `sfa:IDREF` attribute.