### PR TITLE
Extend the TesseractOCRParser with PDF output

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRConfig.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRConfig.java
@@ -55,7 +55,8 @@ public class TesseractOCRConfig implements Serializable {
 
     public enum OUTPUT_TYPE {
         TXT,
-        HOCR
+        HOCR,
+        PDF
     }
 
     // Path to tesseract installation folder, if not on system path.
@@ -384,8 +385,10 @@ public class TesseractOCRConfig implements Serializable {
             setOutputType(OUTPUT_TYPE.TXT);
         } else if ("hocr".equals(lc)) {
             setOutputType(OUTPUT_TYPE.HOCR);
+        } else if ("pdf".equals(lc)) {
+            setOutputType(OUTPUT_TYPE.PDF);
         } else {
-            throw new IllegalArgumentException("outputType must be either 'txt' or 'hocr'");
+            throw new IllegalArgumentException("outputType must be either 'txt' or 'hocr' or 'pdf'");
         }
 
 

--- a/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRParser.java
@@ -443,6 +443,7 @@ public class TesseractOCRParser extends AbstractParser implements Initializable 
                         if (config.getOutputType().equals(TesseractOCRConfig.OUTPUT_TYPE.HOCR)) {
                             extractHOCROutput(is, parseContext, xhtml);
                         } else {
+                        	// for output type txt and pdf it should be the same extract method
                             extractOutput(is, xhtml);
                         }
                     }


### PR DESCRIPTION
Currently the TesseractOCRParser supports two output formats: plain text and HOCR. The second was recently added by Eric Pugh (https://github.com/apache/tika/pull/133). My question is if we should add the third output option 'PDF' which is provided by Tesseract?

I am not sure if it is enough to add the output type as I did in the TesseractOCRConfig. 

The other discussion point is if this feature fits the focus of the Tika Project. See the discussion here:
https://lists.apache.org/thread.html/d1c65367a8bfe13ebc977f6aff8abdfc3e9e09dbce429411dd554840@%3Cuser.tika.apache.org%3E

