### PR TITLE
TIKA-2896 Null check before releasing parser in MimeTypesReader

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReader.java
+++ b/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReader.java
@@ -142,7 +142,7 @@ public class MimeTypesReader extends DefaultHandler implements MimeTypesReaderMe
         } catch (SAXException e) {
             throw new MimeTypeException("Invalid type configuration", e);
         } finally {
-            if(parser != null) {
+            if (parser != null) {
                 releaseParser(parser);
             }
         }

--- a/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReader.java
+++ b/tika-core/src/main/java/org/apache/tika/mime/MimeTypesReader.java
@@ -142,7 +142,9 @@ public class MimeTypesReader extends DefaultHandler implements MimeTypesReaderMe
         } catch (SAXException e) {
             throw new MimeTypeException("Invalid type configuration", e);
         } finally {
-            releaseParser(parser);
+            if(parser != null) {
+                releaseParser(parser);
+            }
         }
     }
 


### PR DESCRIPTION
Prevents an NPE from spilling out of MimeTypesReader.read() when the calling thread is interrupted. See https://issues.apache.org/jira/projects/TIKA/issues/TIKA-2896 for more details.