### PR TITLE
Switch to using Files.createTempFile

### DIFF
--- a/tika-app/src/main/java/org/apache/tika/gui/TikaGUI.java
+++ b/tika-app/src/main/java/org/apache/tika/gui/TikaGUI.java
@@ -56,6 +56,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -632,7 +633,7 @@ public class TikaGUI extends JFrame
          this.downstreamParser = downstreamParser;
          
          try {
-            File t = File.createTempFile("tika", ".test");
+            File t = Files.createTempFile("tika", ".test").toFile();
             tmpDir = t.getParentFile();
          } catch(IOException e) {}
       }
@@ -645,7 +646,7 @@ public class TikaGUI extends JFrame
             embeddedName.substring(splitAt);
          }
          
-         File tmp = File.createTempFile("tika-embedded-", suffix);
+         File tmp = Files.createTempFile("tika-embedded-", suffix).toFile();
          wanted.put(embeddedName, tmp);
          return tmp;
       }

--- a/tika-core/src/main/java/org/apache/tika/fork/ForkClient.java
+++ b/tika-core/src/main/java/org/apache/tika/fork/ForkClient.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.NotSerializableException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -309,7 +310,7 @@ class ForkClient {
      * @throws IOException if the bootstrap archive could not be created
      */
     private static File createBootstrapJar() throws IOException {
-        File file = File.createTempFile("apache-tika-fork-", ".jar");
+        File file = Files.createTempFile("apache-tika-fork-", ".jar").toFile();
         boolean ok = false;
         try {
             fillBootstrapJar(file);

--- a/tika-core/src/main/java/org/apache/tika/utils/RereadableInputStream.java
+++ b/tika-core/src/main/java/org/apache/tika/utils/RereadableInputStream.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 
 /**
@@ -245,7 +246,7 @@ public class RereadableInputStream extends InputStream {
         if (!bufferIsInFile) {
             boolean switchToFile = (size == (maxBytesInMemory));
             if (switchToFile) {
-                storeFile = File.createTempFile("TIKA_streamstore_", ".tmp");
+                storeFile = Files.createTempFile("TIKA_streamstore_", ".tmp").toFile();
                 bufferIsInFile = true;
                 storeOutputStream = new BufferedOutputStream(
                         new FileOutputStream(storeFile));

--- a/tika-parsers/src/main/java/org/apache/tika/parser/microsoft/ooxml/OOXMLExtractorFactory.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/microsoft/ooxml/OOXMLExtractorFactory.java
@@ -20,6 +20,7 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Locale;
 
 import org.apache.commons.io.input.CloseShieldInputStream;
@@ -95,7 +96,7 @@ public class OOXMLExtractorFactory {
                 try {
                     pkg = OPCPackage.open(tis.getFile().getPath(), PackageAccess.READ);
                 } catch (InvalidOperationException e) {
-                    tmpRepairedCopy = File.createTempFile("tika-ooxml-repair-", "");
+                    tmpRepairedCopy = Files.createTempFile("tika-ooxml-repair-", "").toFile();
                     ZipSalvager.salvageCopy(tis.getFile(), tmpRepairedCopy);
                     pkg = OPCPackage.open(tmpRepairedCopy, PackageAccess.READ);
                 }
@@ -110,7 +111,7 @@ public class OOXMLExtractorFactory {
                         pkg = OPCPackage.open(rereadableInputStream);
                     } catch (EOFException e) {
                         rereadableInputStream.rewind();
-                        tmpRepairedCopy = File.createTempFile("tika-ooxml-repair-", "");
+                        tmpRepairedCopy = Files.createTempFile("tika-ooxml-repair-", "").toFile();
                         ZipSalvager.salvageCopy(rereadableInputStream, tmpRepairedCopy);
                         //if there isn't enough left to be opened as a package
                         //throw an exception -- we may want to fall back to streaming


### PR DESCRIPTION
According to the Javadoc for File.createTempFile:

The Files.createTempFile method provides an alternative method to create an empty file in the temporary-file directory. Files created by that method may have more restrictive access permissions to files created by this method and so may be more suited to security-sensitive applications.