### PR TITLE
TIKA-2949 - Update Jackson to 2.9.10

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -344,8 +344,8 @@
 
     <cxf.version>3.3.2</cxf.version>
     <slf4j.version>1.7.26</slf4j.version>
-    <jackson.version>2.9.9</jackson.version>
-    <jackson.databind.version>2.9.9.2</jackson.databind.version>
+    <jackson.version>2.9.10</jackson.version>
+    <jackson.databind.version>2.9.10</jackson.databind.version>
     <!-- when this is next upgraded, see if we can get rid of
          javax.activation dependency in tika-server -->
     <jaxb.version>2.3.2</jaxb.version>


### PR DESCRIPTION
Jackson should be updated to the latest 2.9.10 version to pick up fixes for some CVEs (e.g. CVE-2019-14540)