### PR TITLE
When running in --verbose mode, log the parameters to Tesseract

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRParser.java
@@ -524,6 +524,8 @@ public class TesseractOCRParser extends AbstractParser implements Initializable 
                 (config.getPreserveInterwordSpacing())? "preserve_interword_spaces=1" : "preserve_interword_spaces=0",
                 config.getOutputType().name().toLowerCase(Locale.US)
         ));
+        LOG.debug("Tesseract command: " + String.join(" ", cmd));
+        
         ProcessBuilder pb = new ProcessBuilder(cmd);
         setEnv(config, pb);
         final Process process = pb.start();


### PR DESCRIPTION
Figuring out what is going on when you call out to third party processsors can be hard, provide some extra detail when the user runs in --verbose mode.