### PR TITLE
fix for TIKA-3003 contributed by cesarsotovalero

### DIFF
--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -540,13 +540,6 @@
       <version>5.5.0</version>
     </dependency>
 
-    <!-- grib's current jsoup is vulnerable to xss
-         exclude and import a more modern version TIKA-2561-->
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.12.1</version>
-    </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
@@ -588,6 +581,10 @@
         <exclusion>
           <groupId>org.quartz-scheduler</groupId>
           <artifactId>quartz</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sf.ehcache</groupId>
+          <artifactId>ehcache-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
I'm making this pull reques because I noticed that dependency `org.jsoup:jsoup:1.12.1` is declared in module `tika-parsers` to prevent from having a vulnerable version from edu.ucar:grib. However, this dependency is not used and, therefore, it can be removed to make the ` pom` clearer and the dependency tree of this module less complex.

In addition, dependency `net.sf.ehcache:ehcache-core`, induced transitively from `edu.ucar:cdm:4.5.5`, is not used and can be excluded safely. Notice that the size of the `jar` of `ehcache-core` is around 1.3MB, thus removing it has a positive impact on the size of module `tika-parsers`.