### PR TITLE
Update cxf-rt-rs-client to 3.3.5 to fix CVE-2019-17573

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -342,7 +342,7 @@
     <guava.version>28.1-jre</guava.version>
     <osgi.core.version>6.0.0</osgi.core.version>
 
-    <cxf.version>3.3.4</cxf.version>
+    <cxf.version>3.3.5</cxf.version>
     <slf4j.version>1.7.28</slf4j.version>
     <jackson.version>2.10.1</jackson.version>
     <jackson.databind.version>2.10.1</jackson.databind.version>


### PR DESCRIPTION
Please update the used cxf-rt-rs-client version to 3.3.5 to fix CVE-2019-17573.