### PR TITLE
TIKA-3037 Update docs for Tika Server

### DIFF
--- a/tika-server/README.md
+++ b/tika-server/README.md
@@ -1,6 +1,6 @@
-# Apache Tika JAX-RS Server
+# Apache Tika Server
 
-https://issues.apache.org/jira/browse/TIKA-593
+https://cwiki.apache.org/confluence/display/TIKA/TikaJAXRS
 
 Running
 -------
@@ -21,29 +21,32 @@ Assuming you have Docker installed, you can build you own local image using the:
 
 `mvn dockerfile:build`
 
-The image will be named apache/tika with the tag being the version being built.
-For example, building Apache Tika Server 1.17 will result in an image of `apache/tika-server:1.17`
+The image will be named `apache/tika` with the tag being the version being built.
+For example, building Apache Tika Server 1.24 will result in an image of `apache/tika-server:1.24`
 
-You can then run this image by executing the following, replacing `1.17` with your build version:
+You can then run this image by executing the following, replacing `1.24` with your build version:
 
-`docker run -d -p 9998:9998 apache/tika-server:1.17`
+`docker run -d -p 9998:9998 apache/tika-server:1.24`
 
 This will load Apache Tika Server and expose its interface on:
 
 `http://localhost:9998`
 
+You may also be interested in the https://github.com/apache/tika-docker project
+which provides prebuilt Docker images.
+
 Installing as a Service on Linux
 -----------------------
 To run as a service on Linux you need to run the `install_tika_service.sh` script.
 
-Assuming you have the binary distribution like `tika-server-2.0.0-SNAPSHOT-bin.tgz`,
+Assuming you have the binary distribution like `tika-server-1.24-bin.tgz`,
 then you can extract the install script via:
 
-`tar xzf tika-server-2.0.0-SNAPSHOT-bin.tgz tika-server-2.0.0-SNAPSHOT-bin/bin/install_tika_service.sh --strip-components=2`
+`tar xzf tika-server-1.24-bin.tgz tika-server-1.24-bin/bin/install_tika_service.sh --strip-components=2`
 
 and then run the installation process via:
 
-`./install_tika_service.sh  ./tika-server-2.0.0-SNAPSHOT-bin.tgz`
+`./install_tika_service.sh  ./tika-server-1.24-bin.tgz`
 
 
 Usage


### PR DESCRIPTION
introduce the Docker image, bump some versions, link to the right place on the wiki.

I changed the versions to all be 1.24, but maybe everything needs to be 2.0-SNAPSHOT??