### PR TITLE
Tika 2368 renable cve checks

### DIFF
--- a/tika-nlp/pom.xml
+++ b/tika-nlp/pom.xml
@@ -33,7 +33,7 @@
 
   <name>Apache Tika Natural Language Processing</name>
   <url>http://maven.apache.org</url>
-  
+
 
   <dependencies>
     <dependency>
@@ -43,11 +43,52 @@
       <scope>provided</scope>
     </dependency>
     <!-- AgePredictor client for Tika -->
-    <dependency>  
+    <dependency>
       <groupId>edu.usc.ir</groupId>
       <artifactId>age-predictor-api</artifactId>
       <version>1.0</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scalap</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.mesos</groupId>
+          <artifactId>mesos</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.spark-project.spark</groupId>
+          <artifactId>unused</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
@@ -160,12 +201,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.10.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-reflect</artifactId>
-      <version>2.10.6</version>
+      <version>2.10.7</version>
     </dependency>
     <dependency>
       <groupId>commons-net</groupId>
@@ -181,11 +217,6 @@
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <version>1.1.2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -248,17 +279,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- dependencies in this module need to be cleaned up.
-          Until TIKA-2368 is resolved, report but ignore
-          vulnerabilities.
-        -->
-      <plugin>
-        <groupId>org.sonatype.ossindex.maven</groupId>
-        <artifactId>ossindex-maven-plugin</artifactId>
-        <configuration>
-          <fail>false</fail>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
@@ -290,7 +310,7 @@
                     </configuration>
                 </execution>
             </executions>
-        </plugin>      
+        </plugin>
 
     </plugins>
   </build>

--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -342,7 +342,7 @@
     <guava.version>28.2-jre</guava.version>
     <osgi.core.version>6.0.0</osgi.core.version>
 
-    <cxf.version>3.3.5</cxf.version>
+    <cxf.version>3.3.6</cxf.version>
     <slf4j.version>1.7.28</slf4j.version>
     <jackson.version>2.10.3</jackson.version>
     <!-- when this is next upgraded, see if we can get rid of


### PR DESCRIPTION
From a discussion on the mailing list re: the `ossindex-maven-plugin` plugin, discovered the open ticket TIKA-2368 which is about a long list of dependencies.

As far as I can tell we don't use them, though the unit test completely mocking things up makes things hard to tell.  Here is a stab at exclusions that make `mvn test` happy, and the `ossindex-maven-plugin` happy as well..