### PR TITLE
fix for TIKA-3089 contributed by pvanderweerd

### DIFF
--- a/tika-parsers/src/main/java/org/apache/tika/parser/csv/TextAndCSVParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/csv/TextAndCSVParser.java
@@ -231,14 +231,14 @@ public class TextAndCSVParser extends AbstractEncodingDetectorParser {
 
     private static void handleText(Reader reader, XHTMLContentHandler xhtml)
             throws SAXException, IOException {
-        xhtml.startElement("p");
+        xhtml.startElement("pre");
         char[] buffer = new char[4096];
         int n = reader.read(buffer);
         while (n != -1) {
             xhtml.characters(buffer, 0, n);
             n = reader.read(buffer);
         }
-        xhtml.endElement("p");
+        xhtml.endElement("pre");
 
     }
 
@@ -306,7 +306,6 @@ public class TextAndCSVParser extends AbstractEncodingDetectorParser {
 
         String delimiterString = mediaType.getParameters().get(DELIMITER);
         if (delimiterString == null) {
-            return new CSVParams(mediaType, charset);
         }
         if (STRING_TO_CHAR_DELIMITER_MAP.containsKey(delimiterString)) {
             return new CSVParams(mediaType, charset, (char) STRING_TO_CHAR_DELIMITER_MAP.get(delimiterString));

--- a/tika-parsers/src/main/java/org/apache/tika/parser/txt/TXTParser.java
+++ b/tika-parsers/src/main/java/org/apache/tika/parser/txt/TXTParser.java
@@ -97,14 +97,14 @@ public class TXTParser extends AbstractEncodingDetectorParser {
                     new XHTMLContentHandler(handler, metadata);
             xhtml.startDocument();
 
-            xhtml.startElement("p");
+            xhtml.startElement("pre");
             char[] buffer = new char[4096];
             int n = reader.read(buffer);
             while (n != -1) {
                 xhtml.characters(buffer, 0, n);
                 n = reader.read(buffer);
             }
-            xhtml.endElement("p");
+            xhtml.endElement("pre");
 
             xhtml.endDocument();
         }


### PR DESCRIPTION
Wrapping text in pre-tags instead of p-tags will preserving formatting much better