### PR TITLE
Add support for forbiddenapis 3.0

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -322,7 +322,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
     <!-- plugin versions -->
-    <forbiddenapis.version>2.7</forbiddenapis.version>
+    <forbiddenapis.version>3.0</forbiddenapis.version>
     <groovy.maven.version>2.1</groovy.maven.version>
     <maven.antrun.version>1.8</maven.antrun.version>
     <maven.assembly.version>3.1.0</maven.assembly.version>
@@ -408,11 +408,10 @@
       <plugin>
         <groupId>de.thetaphi</groupId>
         <artifactId>forbiddenapis</artifactId>
-        <!-- if this version contains commons-io 2.6, remove hard-coded commons-io version below -->
         <version>${forbiddenapis.version}</version>
         <configuration>
           <targetVersion>${maven.compiler.target}</targetVersion>
-          <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
+          <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
           <failOnUnsupportedJava>false</failOnUnsupportedJava>
           <excludes>test-documents/*.class</excludes>
           <bundledSignatures>


### PR DESCRIPTION
This hides all warnings caused by commons-io not used in all modules (cf. new mojo parameter).

See https://github.com/policeman-tools/forbidden-apis/wiki/Changes#version-30-released-2020-04-27