### PR TITLE
Address TIKA-3126 - add headers to control writeLimit and maxEmbeddedResources for recursive parsing 

### DIFF
--- a/tika-server/src/main/java/org/apache/tika/server/resource/RecursiveMetadataResource.java
+++ b/tika-server/src/main/java/org/apache/tika/server/resource/RecursiveMetadataResource.java
@@ -139,10 +139,20 @@ public class RecursiveMetadataResource {
 		TikaResource.fillParseContext(context, httpHeaders, null);
 		TikaResource.logRequest(LOG, info, metadata);
 
-        BasicContentHandlerFactory.HANDLER_TYPE type =
+    int writeLimit = -1;
+    if (httpHeaders.containsKey("writeLimit")) {
+      writeLimit = Integer.parseInt(httpHeaders.getFirst("writeLimit"));
+    }
+
+    int maxEmbeddedResources = -1;
+    if (httpHeaders.containsKey("maxEmbeddedResources")) {
+      writeLimit = Integer.parseInt(httpHeaders.getFirst("maxEmbeddedResources"));
+    }
+
+    BasicContentHandlerFactory.HANDLER_TYPE type =
                 BasicContentHandlerFactory.parseHandlerType(handlerTypeName, DEFAULT_HANDLER_TYPE);
 		RecursiveParserWrapperHandler handler = new RecursiveParserWrapperHandler(
-		        new BasicContentHandlerFactory(type, -1), -1);
+		        new BasicContentHandlerFactory(type, writeLimit), maxEmbeddedResources);
 		try {
             TikaResource.parse(wrapper, LOG, info.getPath(), is, handler, metadata, context);
         } catch (SecurityException e) {


### PR DESCRIPTION
add new parameters to `rmeta` rest endpoint

`writeLimit` - max number of characters to store; if < 0, the handler will store all characters
`maxEmbeddedResources` - number of embedded resources that will be parsed. if < 0, it will handle unlimited embedded resources.