### PR TITLE
fix for TIKA-1570 contributed by michaelwda

### DIFF
--- a/tika-server/src/main/java/org/apache/tika/server/TikaServerWatchDog.java
+++ b/tika-server/src/main/java/org/apache/tika/server/TikaServerWatchDog.java
@@ -99,6 +99,16 @@ public class TikaServerWatchDog {
         }
     }
 
+    public void close()
+    {
+        setChildStatus(CHILD_STATUS.SHUTTING_DOWN);
+        LOG.debug("about to shutdown");
+        if (childProcess != null) {
+            LOG.info("about to shutdown process");
+            childProcess.close();
+        }
+    }
+
     private void startPingTimer(ServerTimeouts serverTimeouts) {
         //if the child thread is in stop-the-world mode, and isn't
         //reading the ping, this thread checks to make sure

--- a/tika-server/src/test/java/org/apache/tika/server/TikaServerIntegrationTest.java
+++ b/tika-server/src/test/java/org/apache/tika/server/TikaServerIntegrationTest.java
@@ -234,6 +234,8 @@ public class TikaServerIntegrationTest extends TikaTest {
                         });
             }
             //Add custom implementation of the destroy method
+            //This method was never implemented in the super class, and gives us an easy way to invoke our stop command.
+            //We pass in the prevent system exit, so stop the call to System.Exit, which terminates the JVM and causes a test failure.
             @Override            
             public void destroy()  {
                 TikaServerCli.stop(new String []{"-preventSystemExit"});    

--- a/tika-server/src/test/java/org/apache/tika/server/TikaServerIntegrationTest.java
+++ b/tika-server/src/test/java/org/apache/tika/server/TikaServerIntegrationTest.java
@@ -220,6 +220,40 @@ public class TikaServerIntegrationTest extends TikaTest {
     }
 
     @Test
+    public void testSystemExitViaStopMethod() throws Exception {
+ 
+        Thread serverThread = new Thread() {
+            @Override
+            public void run() {
+                TikaServerCli.main(
+                        new String[]{
+                                "-spawnChild",
+                                "-p", INTEGRATION_TEST_PORT,
+                                "-tmpFilePrefix", "tika-server-systemexitstopmethod"
+
+                        });
+            }
+            //Add custom implementation of the destroy method
+            @Override            
+            public void destroy()  {
+                TikaServerCli.stop(new String []{"-preventSystemExit"});    
+            }
+        };
+        serverThread.start();
+        awaitServerStartup();
+        serverThread.destroy();
+
+        //give some time for the server to crash/kill itself
+        Thread.sleep(2000);
+
+        try {
+            testBaseline();
+        } finally {
+            serverThread.interrupt();
+        }
+    }
+
+    @Test
     public void testTimeoutOk() throws Exception {
         //test that there's enough time for this file.
         Thread serverThread = new Thread() {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/TIKA-1570

Add a stop method that will shutdown the watchdog process and terminate the JVM. This is useful for Apache Commons Daemon, allowing a user to define the StopClass and StopMethod. Under windows, this will allow a user to run tika-server as a windows service with correct start/stop behavior.