### PR TITLE
Fix some test error when jvm's default language is not en

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -448,7 +448,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven.surefire.version}</version> <!-- versions greater than this don't like System.exit calls in tika-batch -->
         <configuration>
-          <argLine>-Xmx3072m -Duser.timezone=UTC -Djava.awt.headless=true</argLine>
+          <argLine>-Xmx3072m -Duser.timezone=UTC -Djava.awt.headless=true -Duser.language=en</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Some test's assert expect language is english(e.g. org.apache.tika.parser.sas.SAS7BDAParserTest), these test will fail when jvm's default language is not en.
This is a fix to set jvm's default language to en.