### PR TITLE
Tika-3141 : add empty environment variable handle

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/config/TikaConfig.java
+++ b/tika-core/src/main/java/org/apache/tika/config/TikaConfig.java
@@ -249,11 +249,11 @@ public class TikaConfig {
     public TikaConfig() throws TikaException, IOException {
 
         String config = System.getProperty("tika.config");
-        if (config == null) {
+        if (config == null || config.trim().equals("")) {
             config = System.getenv("TIKA_CONFIG");
         }
 
-        if (config == null) {
+        if (config == null || config.trim().equals("")) {
             this.serviceLoader = new ServiceLoader();
             this.mimeTypes = getDefaultMimeTypes(getContextClassLoader());
             this.encodingDetector = getDefaultEncodingDetector(serviceLoader);


### PR DESCRIPTION
Trying to fix Tika-3141 with a empty string check in `TikaConfig`