### PR TITLE
Add more judge between Charset Windows-1252 and ISO-8859-1(5)

### DIFF
--- a/tika-parser-modules/tika-parser-text-module/src/main/java/org/apache/tika/parser/txt/UniversalEncodingListener.java
+++ b/tika-parser-modules/tika-parser-text-module/src/main/java/org/apache/tika/parser/txt/UniversalEncodingListener.java
@@ -59,7 +59,8 @@ class UniversalEncodingListener implements CharsetListener {
             if (hint != null) {
                 // Use the encoding hint when available
                 name = hint;
-            } else if (statistics.count('\r') == 0) {
+            } else if (hasNonexistentHexInCharsetWindows1252() || statistics.count('\r') == 0) {
+                // If it has nonexistent hex value in charset windows-1252 or
                 // If there are no CR(LF)s, then the encoding is more
                 // likely to be ISO-8859-1(5) than windows-1252
                 if (statistics.count(0xa4) > 0) { // currency/euro sign
@@ -95,6 +96,18 @@ class UniversalEncodingListener implements CharsetListener {
             report(Constants.CHARSET_WINDOWS_1252);
         }
         return charset;
+    }
+
+    /*
+    * hex value 0x81, 0x8d, 0x8f, 0x90, 0x9d don't exist in charset windows-1252.
+    * If these value's count > 0, return true
+    * */
+    private Boolean hasNonexistentHexInCharsetWindows1252() {
+        return (statistics.count(0x81) > 0 ||
+                statistics.count(0x8d) > 0 ||
+                statistics.count(0x8f) > 0 ||
+                statistics.count(0x90) > 0 ||
+                statistics.count(0x9d) > 0);
     }
 
 }


### PR DESCRIPTION
According to these web pages: [Windows-1252 Chraracter list](https://www.fileformat.info/info/charset/windows-1252/list.htm) , [ISO-8859-1 Chraracter list](http://www.fileformat.info/info/charset/ISO-8859-1/list.htm), [ISO-8859-15 Chraracter list](https://www.fileformat.info/info/charset/ISO-8859-15/list.htm)

There are 5 byte values ( 0x81, 0x8d, 0x8f, 0x90, 0x9d ) that charset Windows-1252 don't has but charset ISO-8859-1 and  charset ISO-8859-15 have.

I think we can add one more judgment condition:  if content has these byte values , means charset isn't Windows-1252