### PR TITLE
TIKA-2001: Add TextAndAttributeContentHandler and TextAndAttributeXMLParser

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/sax/TextAndAttributeContentHandler.java
+++ b/tika-core/src/main/java/org/apache/tika/sax/TextAndAttributeContentHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.sax;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+/*
+* extends TextContentHandler, will also handle element attributes
+*/
+public class TextAndAttributeContentHandler extends TextContentHandler {
+
+    public TextAndAttributeContentHandler(ContentHandler delegate) {
+        this(delegate, false);
+    }
+
+    public TextAndAttributeContentHandler(ContentHandler delegate, boolean addSpaceBetweenElements) {
+        super(delegate, addSpaceBetweenElements);
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        super.startElement(uri, localName, qName, attributes);
+
+        // output element name and attributes if attributes length larger than 0.
+        int attributeLength = attributes.getLength();
+        if (attributeLength > 0) {
+            // output element name
+            char[] elementName = (localName.trim() + " ").toCharArray();
+            characters(elementName, 0, elementName.length);
+
+            // output attributes
+            for (int i=0; i<attributeLength; i++) {
+                char[] attributeName = (attributes.getLocalName(i).trim() + " ").toCharArray();
+                char[] attributeValue = (attributes.getValue(i).trim() + " ").toCharArray();
+                characters(attributeName, 0, attributeName.length);
+                characters(attributeValue, 0, attributeValue.length);
+            }
+        }
+    }
+}

--- a/tika-parser-modules/tika-parser-xml-module/src/main/java/org/apache/tika/parser/xml/TextAndAttributeXMLParser.java
+++ b/tika-parser-modules/tika-parser-xml-module/src/main/java/org/apache/tika/parser/xml/TextAndAttributeXMLParser.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.parser.xml;
+
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.TextAndAttributeContentHandler;
+import org.xml.sax.ContentHandler;
+
+public class TextAndAttributeXMLParser extends XMLParser {
+
+    private static final long serialVersionUID = 7796914007312429473L;
+
+    @Override
+    protected ContentHandler getContentHandler(ContentHandler handler, Metadata metadata, ParseContext context) {
+        return new TextAndAttributeContentHandler(handler, true);
+    }
+}

--- a/tika-parser-modules/tika-parser-xml-module/src/test/java/org/apache/tika/parser/xml/TextAndAttributeXMLParserTest.java
+++ b/tika-parser-modules/tika-parser-xml-module/src/test/java/org/apache/tika/parser/xml/TextAndAttributeXMLParserTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.parser.xml;
+
+import org.apache.tika.TikaTest;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.BodyContentHandler;
+import org.junit.Test;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class TextAndAttributeXMLParserTest extends TikaTest {
+
+    @Test
+    public void testParseTextAndAttributes() throws IOException, TikaException, SAXException {
+        try (InputStream input = getResourceAsStream("/test-documents/testXML2.xml")) {
+            Metadata metadata = new Metadata();
+            ParseContext context = new ParseContext();
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            ContentHandler handler = new BodyContentHandler(buffer);
+            new TextAndAttributeXMLParser().parse(input, handler, metadata, context);
+            String output = buffer.toString("UTF-8");
+
+            assertEquals("application/xml", metadata.get(Metadata.CONTENT_TYPE));
+            assertTrue(output.contains("document type Microsoft Word 2003/2004"));
+            assertTrue(output.contains("doc_property type title Title test"));
+            assertTrue(output.contains("doc_property type subject Subject test"));
+        }
+    }
+}


### PR DESCRIPTION
[TIKA-2001](https://issues.apache.org/jira/browse/TIKA-2001) requires a XML parser which can output text and attributes.
This PR would like to provide it.
User can config `TextAndAttributeXMLParser` as parser of `application/xml`.