### PR TITLE
Fix infinite loop in tika-parser-nlp-module

### DIFF
--- a/tika-advanced-parser-modules/tika-parser-nlp-module/src/main/resources/META-INF/services/org.apache.tika.parser.Parser
+++ b/tika-advanced-parser-modules/tika-parser-nlp-module/src/main/resources/META-INF/services/org.apache.tika.parser.Parser
@@ -13,7 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-org.apache.tika.parser.ctakes.CTAKESParser
 org.apache.tika.parser.geo.GeoParser
 org.apache.tika.parser.journal.JournalParser
 org.apache.tika.parser.sentiment.SentimentAnalysisParser


### PR DESCRIPTION
CTAKESParser should not load via the parser service loader because it will cause an infinite loop.

If `org.apache.tika.parser.ctakes.CTAKESParser` in file `org.apache.tika.parser.Parser`:

1. `org.apache.tika.config.ServiceLoader#loadStaticServiceProviders(Class<T>)` will create a new instance for `org.apache.tika.parser.ctakes.CTAKESParser`

2. `org.apache.tika.parser.ctakes.CTAKESParser#CTAKESParser()` will create a new instance for `org.apache.tika.config.TikaConfig` and then will call `org.apache.tika.config.ServiceLoader#loadStaticServiceProviders(Class<T> )` to load another `org.apache.tika.parser.ctakes.CTAKESParser`.

It's a infinite loop, Should remove CTAKESParser from file org.apache.tika.parser.Parser.