### PR TITLE
Fix key typo in BatchProcessBuilder

### DIFF
--- a/tika-batch/src/main/java/org/apache/tika/batch/builders/BatchProcessBuilder.java
+++ b/tika-batch/src/main/java/org/apache/tika/batch/builders/BatchProcessBuilder.java
@@ -131,7 +131,7 @@ public class BatchProcessBuilder {
         //build crawler
         crawler = buildCrawler(queue, keyNodes.get("crawler"), runtimeAttributes);
 
-        if (keyNodes.containsKey(reporter)) {
+        if (keyNodes.containsKey("reporter")) {
             reporter = buildReporter(crawler, consumersManager, keyNodes.get("reporter"), runtimeAttributes);
         }
 


### PR DESCRIPTION
We want to know if string "reporter" it's keyNodes's key instead of if null it's keyNodes's key.
So I think this a typo and this PR is a fix for it.