### PR TITLE
Fix test fail in SAS7BDATParserTest caused by default language is not english

### DIFF
--- a/tika-parser-modules/tika-parser-code-module/src/test/java/org/apache/tika/parser/sas/SAS7BDATParserTest.java
+++ b/tika-parser-modules/tika-parser-code-module/src/test/java/org/apache/tika/parser/sas/SAS7BDATParserTest.java
@@ -19,7 +19,9 @@ package org.apache.tika.parser.sas;
 import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
+import java.text.DateFormatSymbols;
 import java.util.Arrays;
+import java.util.Locale;
 
 import org.apache.tika.TikaTest;
 import org.apache.tika.metadata.Database;
@@ -36,6 +38,7 @@ import org.junit.Test;
 import org.xml.sax.ContentHandler;
 
 public class SAS7BDATParserTest extends TikaTest {
+    private static final String[] SHORT_MONTHS = new DateFormatSymbols(Locale.getDefault()).getShortMonths();
     private Parser parser = new SAS7BDATParser();
     
     @Test
@@ -109,7 +112,7 @@ public class SAS7BDATParserTest extends TikaTest {
         assertContains("2\t4\tThis", content);
         assertContains("4\t16\tThis", content);
         assertContains("\t01-01-1960\t", content);
-        assertContains("\t01Jan1960:00:00", content);
+        assertContains("\t01"+SHORT_MONTHS[0]+"1960:00:00", content);
     }
 
     @Test
@@ -141,6 +144,6 @@ public class SAS7BDATParserTest extends TikaTest {
         assertContains("<th title=\"date\">date</th>", xml);
         // Check formatting of dates
         assertContains("<td>01-01-1960</td>", xml);
-        assertContains("<td>01Jan1960:00:00:10.00</td>", xml);
+        assertContains("<td>01"+SHORT_MONTHS[0]+"1960:00:00:10.00</td>", xml);
     }
 }


### PR DESCRIPTION
Use short months in default language to test.