### PR TITLE
Remove dependency tika-parsers test-jar in tika-server and tika-examples

### DIFF
--- a/tika-example/pom.xml
+++ b/tika-example/pom.xml
@@ -81,13 +81,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
       <version>${javax.jcr.version}</version>

--- a/tika-server/pom.xml
+++ b/tika-server/pom.xml
@@ -150,13 +150,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>tika-parsers</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The `tika-parsers` is not generating `test-jar` with the recent commit `a504d7e`, but `tika-server` and `tika-examples` are still using it as dependency. This would lead to the building failure, and this PR is a fix for it.

Such kind of problems could not be easily found with local builds and jenkins builds - both of them have maven cache in `~/.m2/`. To find these problems needs cleaning all cache before maven building, and for most of time this is pretty time consuming.

I'm thinking about if we should add `Github Actions` building for Tika(see also PR [#333](https://github.com/apache/tika/pull/333)). It seems that actions could build without any cache, and it's downloading dependency pretty fast.

Ideas?