### PR TITLE
Fix Jenkins build error on JDK11 and JDK14

### DIFF
--- a/tika-translate/pom.xml
+++ b/tika-translate/pom.xml
@@ -128,6 +128,10 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Jenkins's job `tika-main-jdk11` and `tika-main-jdk14` build fail caused by depenency conflict in component `tika-translate`.

Here is the full log: 
[tika-main-jdk11 build 22](https://ci-builds.apache.org/job/Tika/job/tika-main-jdk11/22/console), 
[tika-main-jdk14 build 6](https://ci-builds.apache.org/job/Tika/job/tika-main-jdk14/6/console)

Here is the failed part of the log:
```
Dependency convergence error for jakarta.activation:jakarta.activation-api:1.2.2 paths to dependency are:
+-org.apache.tika:tika-translate:2.0.0-SNAPSHOT
  +-org.apache.cxf:cxf-rt-rs-client:3.4.0
    +-jakarta.xml.soap:jakarta.xml.soap-api:1.4.2
      +-jakarta.activation:jakarta.activation-api:1.2.2
and
+-org.apache.tika:tika-translate:2.0.0-SNAPSHOT
  +-com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.11.2
    +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.2
      +-jakarta.activation:jakarta.activation-api:1.2.1
```

This PR is a fix for this