### PR TITLE
Fix Jenkins build error on JDK11 build 7

### DIFF
--- a/tika-bundle/pom.xml
+++ b/tika-bundle/pom.xml
@@ -148,14 +148,6 @@
 	    <version>1.2.16</version>
 	    <scope>test</scope>
 	</dependency>
-	<dependency>
-    <groupId>jakarta.activation</groupId>
-	  <artifactId>jakarta.activation-api</artifactId>
-	  <version>1.2.1</version>
-	  <scope>test</scope>
-	</dependency>
-
-    
   </dependencies>
 
   <build>


### PR DESCRIPTION
Jenkins's job `tika-branch1x-jdk11` build fail caused by depenency conflict in `tika-bundle`.

Here is the full log: [tika-branch1x-jdk11 build 7](https://ci-builds.apache.org/job/Tika/job/tika-branch1x-jdk11/7/console)

Here is the failed part of the log:
```
Dependency convergence error for jakarta.activation:jakarta.activation-api:1.2.2 paths to dependency are:
+-org.apache.tika:tika-bundle:1.25-SNAPSHOT
  +-org.apache.tika:tika-parsers:1.25-SNAPSHOT
    +-org.apache.cxf:cxf-rt-rs-client:3.4.0
      +-jakarta.xml.soap:jakarta.xml.soap-api:1.4.2
        +-jakarta.activation:jakarta.activation-api:1.2.2
and
+-org.apache.tika:tika-bundle:1.25-SNAPSHOT
  +-jakarta.activation:jakarta.activation-api:1.2.1
```

This PR is a fix for this