### PR TITLE
Modify TikaInputStream

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/io/TikaInputStream.java
+++ b/tika-core/src/main/java/org/apache/tika/io/TikaInputStream.java
@@ -676,7 +676,7 @@ public class TikaInputStream extends TaggedInputStream {
             } else {
                 Path tmpFile = tmp.createTempFile();
                 if (maxBytes > -1) {
-                    try (InputStream lookAhead = new LookaheadInputStream(in, maxBytes)) {
+                    try (InputStream lookAhead = new LookaheadInputStream(this, maxBytes)) {
                         Files.copy(lookAhead, tmpFile, REPLACE_EXISTING);
                         if (Files.size(tmpFile) >= maxBytes) {
                             //tmpFile will be cleaned up when this TikaInputStream is closed
@@ -685,7 +685,7 @@ public class TikaInputStream extends TaggedInputStream {
                     }
                 } else {
                     // Spool the entire stream into a temporary file
-                    Files.copy(in, tmpFile, REPLACE_EXISTING);
+                    Files.copy(this, tmpFile, REPLACE_EXISTING);
                 }
                 //successful so far, set tis' path to tmpFile
                 path = tmpFile;


### PR DESCRIPTION
In method `getPath`, copy data from InputStream to a temporary file should use current TikaInputStream.
Otherwise the variable of TikaInputStream `position` will not update.
There is not meaning if `position` is not real position.