### PR TITLE
Remove deprecated method call in PackageParser

### DIFF
--- a/tika-parser-modules/tika-parser-pkg-module/src/main/java/org/apache/tika/parser/pkg/PackageParser.java
+++ b/tika-parser-modules/tika-parser-pkg-module/src/main/java/org/apache/tika/parser/pkg/PackageParser.java
@@ -246,7 +246,7 @@ public class PackageParser extends AbstractParser {
                     if (password == null) {
                         sevenz = new SevenZFile(tstream.getFile());
                     } else {
-                        sevenz = new SevenZFile(tstream.getFile(), password.getBytes("UnicodeLittleUnmarked"));
+                        sevenz = new SevenZFile(tstream.getFile(), password.toCharArray());
                     }
                 }catch(PasswordRequiredException e){
                     throw new EncryptedDocumentException(e);


### PR DESCRIPTION
Method `SevenZFile` use byte[]-arg version for the password is deprecated.
Use the char[]-arg version for the password instead.