### PR TITLE
Use IOException instead of IOExceptionWithCause

### DIFF
--- a/tika-batch/src/main/java/org/apache/tika/batch/builders/BatchProcessBuilder.java
+++ b/tika-batch/src/main/java/org/apache/tika/batch/builders/BatchProcessBuilder.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.batch.BatchProcess;
 import org.apache.tika.batch.ConsumersManager;
 import org.apache.tika.batch.FileResource;
@@ -71,7 +70,7 @@ public class BatchProcessBuilder {
             DocumentBuilder docBuilder = XMLReaderUtils.getDocumentBuilder();
             doc = docBuilder.parse(is);
         } catch (TikaException|SAXException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         Node docElement = doc.getDocumentElement();
         return build(docElement, runtimeAttributes);

--- a/tika-batch/src/main/java/org/apache/tika/batch/builders/CommandLineParserBuilder.java
+++ b/tika-batch/src/main/java/org/apache/tika/batch/builders/CommandLineParserBuilder.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.utils.XMLReaderUtils;
@@ -47,7 +46,7 @@ public class CommandLineParserBuilder {
             DocumentBuilder docBuilder = XMLReaderUtils.getDocumentBuilder();
             doc = docBuilder.parse(is);
         } catch (TikaException|SAXException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
 
         Node docElement = doc.getDocumentElement();

--- a/tika-core/src/main/java/org/apache/tika/detect/FileCommandDetector.java
+++ b/tika-core/src/main/java/org/apache/tika/detect/FileCommandDetector.java
@@ -16,7 +16,6 @@
  */
 package org.apache.tika.detect;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.IOUtils;
 import org.apache.tika.config.Field;
 import org.apache.tika.io.BoundedInputStream;
@@ -140,11 +139,11 @@ public class FileCommandDetector implements Detector {
             finished = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS);
             if (!finished) {
                 process.destroyForcibly();
-                throw new IOExceptionWithCause(new TimeoutException("timed out"));
+                throw new IOException(new TimeoutException("timed out"));
             }
             int exitValue = process.exitValue();
             if (exitValue != 0) {
-                throw new IOExceptionWithCause(new RuntimeException("bad exit value"));
+                throw new IOException(new RuntimeException("bad exit value"));
             }
             errorThread.join();
             outThread.join();

--- a/tika-core/src/main/java/org/apache/tika/extractor/ParsingEmbeddedDocumentExtractor.java
+++ b/tika-core/src/main/java/org/apache/tika/extractor/ParsingEmbeddedDocumentExtractor.java
@@ -21,7 +21,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.tika.exception.EncryptedDocumentException;
 import org.apache.tika.exception.CorruptedFileException;
@@ -110,7 +109,7 @@ public class ParsingEmbeddedDocumentExtractor implements EmbeddedDocumentExtract
             // TODO: can we log a warning that we lack the password?
             // For now, just skip the content
         } catch (CorruptedFileException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         } catch (TikaException e) {
             // TODO: can we log a warning somehow?
             // Could not parse the entry, just skip the content

--- a/tika-core/src/main/java/org/apache/tika/parser/digest/CompositeDigester.java
+++ b/tika-core/src/main/java/org/apache/tika/parser/digest/CompositeDigester.java
@@ -20,7 +20,6 @@ package org.apache.tika.parser.digest;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
@@ -49,7 +48,7 @@ public class CompositeDigester implements DigestingParser.Digester {
             try {
                 tmp.dispose();
             } catch (TikaException e) {
-                throw new IOExceptionWithCause(e);
+                throw new IOException(e);
             }
         }
     }

--- a/tika-core/src/main/java/org/apache/tika/parser/digest/InputStreamDigester.java
+++ b/tika-core/src/main/java/org/apache/tika/parser/digest/InputStreamDigester.java
@@ -25,7 +25,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.io.BoundedInputStream;
 import org.apache.tika.io.TemporaryResources;
@@ -148,7 +147,7 @@ public class InputStreamDigester implements DigestingParser.Digester {
                 try {
                     tmp.dispose();
                 } catch (TikaException e) {
-                    throw new IOExceptionWithCause(e);
+                    throw new IOException(e);
                 }
             }
         }

--- a/tika-core/src/test/java/org/apache/tika/parser/mock/MockParser.java
+++ b/tika-core/src/test/java/org/apache/tika/parser/mock/MockParser.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
@@ -97,7 +96,7 @@ public class MockParser extends AbstractParser {
             doc = docBuilder.parse(stream);
         } catch (SAXException e) {
             //to distinguish between SAX on read vs SAX while writing
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         Node root = doc.getDocumentElement();
         NodeList actions = root.getChildNodes();

--- a/tika-eval/tika-eval-app/src/main/java/org/apache/tika/eval/app/XMLErrorLogUpdater.java
+++ b/tika-eval/tika-eval-app/src/main/java/org/apache/tika/eval/app/XMLErrorLogUpdater.java
@@ -32,7 +32,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.log4j.Level;
 import org.apache.tika.eval.app.db.Cols;
 import org.apache.tika.eval.app.db.H2Util;
@@ -98,7 +97,7 @@ public class XMLErrorLogUpdater {
             try {
                 reader = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(xml));
             } catch (XMLStreamException e) {
-                throw new IOExceptionWithCause(e);
+                throw new IOException(e);
             }
             String type = null;
             String resourceId = null;
@@ -121,7 +120,7 @@ public class XMLErrorLogUpdater {
                 }
                 reader.close();
             } catch (XMLStreamException e) {
-                throw new IOExceptionWithCause(e);
+                throw new IOException(e);
             }
         }
 

--- a/tika-eval/tika-eval-app/src/main/java/org/apache/tika/eval/app/io/DBWriter.java
+++ b/tika-eval/tika-eval-app/src/main/java/org/apache/tika/eval/app/io/DBWriter.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.eval.app.db.ColInfo;
 import org.apache.tika.eval.app.db.Cols;
 import org.apache.tika.eval.app.db.JDBCUtil;
@@ -145,13 +144,13 @@ public class DBWriter implements IDBWriter {
             try {
                 p.executeBatch();
             } catch (SQLException e) {
-                throw new IOExceptionWithCause(e);
+                throw new IOException(e);
             }
         }
         try {
             conn.commit();
         } catch (SQLException e){
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
     }
 

--- a/tika-fuzzing/src/main/java/org/apache/tika/fuzzing/pdf/EvilCOSWriter.java
+++ b/tika-fuzzing/src/main/java/org/apache/tika/fuzzing/pdf/EvilCOSWriter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.tika.fuzzing.pdf;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSBoolean;
@@ -515,7 +514,7 @@ public class EvilCOSWriter implements ICOSVisitor, Closeable {
             try {
                 unfilteredStreamTransformer.transform(new ByteArrayInputStream(bos.toByteArray()), transformed);
             } catch (TikaException e) {
-                throw new IOExceptionWithCause(e);
+                throw new IOException(e);
             }
             try (OutputStream os = cosStream.createRawOutputStream()) {
                 IOUtils.copy(new ByteArrayInputStream(transformed.toByteArray()), os);
@@ -540,7 +539,7 @@ public class EvilCOSWriter implements ICOSVisitor, Closeable {
                 try {
                     config.getStreamTransformer().transform(new ByteArrayInputStream(bytes), bos);
                 } catch (TikaException e) {
-                    throw new IOExceptionWithCause(e);
+                    throw new IOException(e);
                 }
                 bytes = bos.toByteArray();
             }
@@ -615,7 +614,7 @@ public class EvilCOSWriter implements ICOSVisitor, Closeable {
                     bos.close();
                     return TikaInputStream.get(bos.toByteArray());
                 } catch (TikaException e) {
-                    throw new IOExceptionWithCause(e);
+                    throw new IOException(e);
                 }
             } else {
                 TemporaryResources tmp = new TemporaryResources();
@@ -624,7 +623,7 @@ public class EvilCOSWriter implements ICOSVisitor, Closeable {
                     config.getUnfilteredStreamTransformer().transform(is, os);
                     os.flush();
                 } catch (TikaException e) {
-                    throw new IOExceptionWithCause(e);
+                    throw new IOException(e);
                 }
                 return TikaInputStream.get(p, new Metadata(), tmp);
             }

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-apple-module/src/main/java/org/apache/tika/detect/apple/BPListDetector.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-apple-module/src/main/java/org/apache/tika/detect/apple/BPListDetector.java
@@ -20,7 +20,6 @@ import com.dd.plist.NSDictionary;
 import com.dd.plist.NSObject;
 import com.dd.plist.PropertyListFormatException;
 import com.dd.plist.PropertyListParser;
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.IOUtils;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.io.TikaInputStream;
@@ -111,7 +110,7 @@ public class BPListDetector implements Detector {
                 ((TikaInputStream) input).setOpenContainer(rootObj);
             }
         } catch (PropertyListFormatException | ParseException | ParserConfigurationException | SAXException e) {
-            throw new IOExceptionWithCause("problem parsing root", e);
+            throw new IOException("problem parsing root", e);
         }
         if (rootObj instanceof NSDictionary) {
             return detectOnKeys(((NSDictionary) rootObj).getHashMap().keySet());

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-jdbc-commons/src/main/java/org/apache/tika/parser/jdbc/AbstractDBParser.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-jdbc-commons/src/main/java/org/apache/tika/parser/jdbc/AbstractDBParser.java
@@ -24,7 +24,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.exception.CorruptedFileException;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentUtil;
@@ -70,7 +69,7 @@ public abstract class AbstractDBParser extends AbstractParser {
                 throw new CorruptedFileException("Corrupt SQLITE", e);
             }
 
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         for (String tableName : tableNames) {
             //add table names to parent metadata
@@ -144,7 +143,7 @@ public abstract class AbstractDBParser extends AbstractParser {
         try {
             connection = DriverManager.getConnection(connectionString);
         } catch (SQLException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         return connection;
     }

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-jdbc-commons/src/main/java/org/apache/tika/parser/jdbc/JDBCTableReader.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-jdbc-commons/src/main/java/org/apache/tika/parser/jdbc/JDBCTableReader.java
@@ -33,7 +33,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.IOUtils;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.detect.Detector;
@@ -78,7 +77,7 @@ public class JDBCTableReader {
                 return false;
             }
         } catch (SQLException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         try {
             ResultSetMetaData meta = results.getMetaData();
@@ -90,7 +89,7 @@ public class JDBCTableReader {
             }
             handler.endElement(XHTMLContentHandler.XHTML, "tr", "tr");
         } catch (SQLException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         rows++;
         return true;
@@ -151,7 +150,7 @@ public class JDBCTableReader {
                 headers.add(meta.getColumnName(i));
             }
         } catch (SQLException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         return headers;
     }
@@ -291,7 +290,7 @@ public class JDBCTableReader {
             Statement st = connection.createStatement();
             results = st.executeQuery(sql);
         } catch (SQLException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         rows = 0;
     }

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/HSLFExtractor.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/HSLFExtractor.java
@@ -16,7 +16,6 @@
  */
 package org.apache.tika.parser.microsoft;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.poi.common.usermodel.Hyperlink;
 import org.apache.poi.hslf.exceptions.EncryptedPowerPointFileException;
@@ -521,7 +520,7 @@ public class HSLFExtractor extends AbstractPOIFSExtractor {
                             try {
                                 poifs = new POIFSFileSystem(new CloseShieldInputStream(stream));
                             } catch (RuntimeException e) {
-                                throw new IOExceptionWithCause(e);
+                                throw new IOException(e);
                             }
                             try {
                                 handleEmbeddedOfficeDoc(poifs.getRoot(), objID, xhtml);

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.IOUtils;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -193,7 +192,7 @@ class AbstractPDF2XHTML extends PDFTextStripper {
         try {
             xhtml.startElement("div", "class", "page");
         } catch (SAXException e) {
-            throw new IOExceptionWithCause("Unable to start a page", e);
+            throw new IOException("Unable to start a page", e);
         }
         writeParagraphStart();
     }
@@ -470,7 +469,7 @@ class AbstractPDF2XHTML extends PDFTextStripper {
         } catch (IOException e) {
             handleCatchableIOE(e);
         } catch (SAXException e) {
-            throw new IOExceptionWithCause("error writing OCR content from PDF", e);
+            throw new IOException("error writing OCR content from PDF", e);
         } finally {
             tmp.dispose();
         }
@@ -495,9 +494,9 @@ class AbstractPDF2XHTML extends PDFTextStripper {
                             attributes.addAttribute("", "source", "source", "CDATA", "annotation");
                             extractMultiOSPDEmbeddedFiles(fann.getAttachmentName(), fileSpec, attributes);
                         } catch (SAXException e) {
-                            throw new IOExceptionWithCause("file embedded in annotation sax exception", e);
+                            throw new IOException("file embedded in annotation sax exception", e);
                         } catch (TikaException e) {
-                            throw new IOExceptionWithCause("file embedded in annotation tika exception", e);
+                            throw new IOException("file embedded in annotation tika exception", e);
                         } catch (IOException e) {
                             handleCatchableIOE(e);
                         }
@@ -567,7 +566,7 @@ class AbstractPDF2XHTML extends PDFTextStripper {
             }
             xhtml.endElement("div");
         } catch (SAXException|TikaException e) {
-            throw new IOExceptionWithCause("Unable to end a page", e);
+            throw new IOException("Unable to end a page", e);
         } catch (IOException e) {
             handleCatchableIOE(e);
         } finally {
@@ -621,7 +620,7 @@ class AbstractPDF2XHTML extends PDFTextStripper {
                 //swallow -- no need to report this
             }
         } catch (TikaException|SAXException e) {
-            throw new IOExceptionWithCause("Unable to start a document", e);
+            throw new IOException("Unable to start a document", e);
         }
     }
 
@@ -713,9 +712,9 @@ class AbstractPDF2XHTML extends PDFTextStripper {
             handleDestinationOrAction(additionalActions.getWS(), ActionTrigger.BEFORE_DOCUMENT_SAVE);
             xhtml.endDocument();
         } catch (TikaException e) {
-            throw new IOExceptionWithCause("Unable to end a document", e);
+            throw new IOException("Unable to end a document", e);
         } catch (SAXException e) {
-            throw new IOExceptionWithCause("Unable to end a document", e);
+            throw new IOException("Unable to end a document", e);
         }
         if (fontNames.size() > 0) {
             for (String fontName : fontNames) {

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/ImageGraphicsEngine.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/ImageGraphicsEngine.java
@@ -16,7 +16,6 @@
  */
 package org.apache.tika.parser.pdf;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.pdfbox.contentstream.PDFGraphicsStreamEngine;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
@@ -177,7 +176,7 @@ class ImageGraphicsEngine extends PDFGraphicsStreamEngine {
         try {
             processImage(pdImage, imageNumber);
         } catch (TikaException|SAXException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         } catch (IOException e) {
             handleCatchableIOE(e);
         }

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/OCR2XHTML.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/OCR2XHTML.java
@@ -19,7 +19,6 @@ package org.apache.tika.parser.pdf;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.text.PDFTextStripper;
@@ -97,7 +96,7 @@ class OCR2XHTML extends AbstractPDF2XHTML {
             doOCROnCurrentPage(PDFParserConfig.OCR_STRATEGY.OCR_ONLY);
             endPage(pdPage);
         } catch (TikaException|SAXException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         } catch (IOException e) {
             handleCatchableIOE(e);
         }

--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/PDFMarkedContent2XHTML.java
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/PDFMarkedContent2XHTML.java
@@ -16,7 +16,6 @@
  */
 package org.apache.tika.parser.pdf;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
@@ -154,7 +153,7 @@ public class PDFMarkedContent2XHTML extends PDF2XHTML {
         findPages(pdDocument.getPages().getCOSObject().getItem(COSName.KIDS), pageRefs);
         //confirm the right number of pages was found
         if (pageRefs.size() != pdDocument.getNumberOfPages()) {
-            throw new IOExceptionWithCause(
+            throw new IOException(
                     new TikaException("Couldn't find the right number of page refs ("
                             + pageRefs.size() + ") for pages (" +
                             pdDocument.getNumberOfPages() + ")"));
@@ -174,7 +173,7 @@ public class PDFMarkedContent2XHTML extends PDF2XHTML {
         try {
             recurse(structureTreeRoot.getK(), null, 0, paragraphs, roleMap);
         } catch (SAXException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
 
         //STEP 5: handle all the potentially unprocessed bits
@@ -198,7 +197,7 @@ public class PDFMarkedContent2XHTML extends PDF2XHTML {
                 }
             }
         } catch (SAXException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         //Step 6: for now, iterate through the pages again and do all the other handling
         //TODO: figure out when we're crossing page boundaries during the recursion
@@ -215,7 +214,7 @@ public class PDFMarkedContent2XHTML extends PDF2XHTML {
                          Map<MCID, String> paragraphs, Map<String, HtmlTag> roleMap) throws IOException, SAXException {
 
         if (depth > MAX_RECURSION_DEPTH) {
-            throw new IOExceptionWithCause(
+            throw new IOException(
                     new TikaException("Exceeded max recursion depth "+MAX_RECURSION_DEPTH));
         }
 

--- a/tika-parsers/tika-parsers-extended/tika-parser-sqlite3-module/src/main/java/org/apache/tika/parser/sqlite3/SQLite3DBParser.java
+++ b/tika-parsers/tika-parsers-extended/tika-parser-sqlite3-module/src/main/java/org/apache/tika/parser/sqlite3/SQLite3DBParser.java
@@ -29,7 +29,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.tika.extractor.EmbeddedDocumentUtil;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -68,7 +67,7 @@ class SQLite3DBParser extends AbstractDBParser {
         try {
             Class.forName(getJDBCClassName());
         } catch (ClassNotFoundException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         try {
             SQLiteConfig config = new SQLiteConfig();

--- a/tika-server/tika-server-core/src/main/java/org/apache/tika/server/core/resource/UnpackerResource.java
+++ b/tika-server/tika-server-core/src/main/java/org/apache/tika/server/core/resource/UnpackerResource.java
@@ -43,7 +43,6 @@ import java.util.UUID;
 
 import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.tika.exception.TikaMemoryLimitException;
@@ -182,8 +181,7 @@ public class UnpackerResource {
             BoundedInputStream bis = new BoundedInputStream(MAX_ATTACHMENT_BYTES, inputStream);
             IOUtils.copy(bis, bos);
             if (bis.hasHitBound()) {
-                throw new IOExceptionWithCause(
-                        new TikaMemoryLimitException(MAX_ATTACHMENT_BYTES+1, MAX_ATTACHMENT_BYTES));
+                throw new IOException(new TikaMemoryLimitException(MAX_ATTACHMENT_BYTES+1, MAX_ATTACHMENT_BYTES));
             }
             byte[] data = bos.toByteArray();
 


### PR DESCRIPTION
We used to use` IOExceptionWithCause` because `IOException` with the `Throwable` constructors is missing before `JDK 6`.
I think we should use `IOException` after `JDK 6`.