### PR TITLE
Fix unecessary close

### DIFF
--- a/tika-core/src/test/java/org/apache/tika/config/ParamTest.java
+++ b/tika-core/src/test/java/org/apache/tika/config/ParamTest.java
@@ -61,8 +61,6 @@ public class ParamTest {
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
             param.save(stream);
             ByteArrayInputStream inStream = new ByteArrayInputStream(stream.toByteArray());
-            stream.close();
-            inStream.close();
             Param<?> loaded = Param.load(inStream);
             assertEquals(param.getName(), loaded.getName());
             assertEquals(param.getTypeString(), loaded.getTypeString());


### PR DESCRIPTION
Meaningless Close: In several classes, close(), specified in Closeable interface, has no effect and other methods in those classes can be called after close() without IOException.