### PR TITLE
Simplify some test code by using method TikaTest#getResourceAsUrl and TikaTest#getResourceAsUri

### DIFF
--- a/tika-batch/src/test/java/org/apache/tika/batch/fs/BatchProcessTest.java
+++ b/tika-batch/src/test/java/org/apache/tika/batch/fs/BatchProcessTest.java
@@ -277,8 +277,7 @@ public class BatchProcessTest extends FSBatchTestBase {
 
         Map<String, String> args = getDefaultArgs("hierarchical", outputDir);
         args.put("numConsumers", "1");
-        args.put("fileList",
-                Paths.get(this.getClass().getResource("/testFileList.txt").toURI()).toString());
+        args.put("fileList", Paths.get(getResourceAsUri("/testFileList.txt")).toString());
         args.put("recursiveParserWrapper", "true");
         args.put("basicHandlerType", "text");
         BatchProcessTestExecutor ex = new BatchProcessTestExecutor(args, "/tika-batch-config-MockConsumersBuilder.xml");

--- a/tika-batch/src/test/java/org/apache/tika/batch/fs/FSBatchTestBase.java
+++ b/tika-batch/src/test/java/org/apache/tika/batch/fs/FSBatchTestBase.java
@@ -143,7 +143,7 @@ public abstract class FSBatchTestBase extends TikaTest {
 
     public Path getInputRoot(String subdir) throws Exception {
         String path = (subdir == null || subdir.length() == 0) ? "/test-input" : "/test-input/"+subdir;
-        return Paths.get(this.getClass().getResource(path).toURI());
+        return Paths.get(getResourceAsUri(path));
     }
 
     BatchProcess getNewBatchRunner(String testConfig,
@@ -173,8 +173,7 @@ public abstract class FSBatchTestBase extends TikaTest {
         List<String> commandLine = new ArrayList<>();
         commandLine.add("java");
         commandLine.add("-Djava.awt.headless=true");
-        commandLine.add("-Dlog4j.configuration=file:"+
-            this.getClass().getResource(loggerProps).getFile());
+        commandLine.add("-Dlog4j.configuration=file:" + getResourceAsUrl(loggerProps).getFile());
         commandLine.add("-Xmx128m");
         commandLine.add("-cp");
         String cp = System.getProperty("java.class.path");
@@ -185,7 +184,7 @@ public abstract class FSBatchTestBase extends TikaTest {
 
         String configFile = null;
         try {
-            configFile = Paths.get(this.getClass().getResource(testConfig).toURI()).toAbsolutePath().toString();
+            configFile = Paths.get(getResourceAsUri(testConfig)).toAbsolutePath().toString();
         } catch (URISyntaxException e) {
             e.printStackTrace();
         }
@@ -212,8 +211,7 @@ public abstract class FSBatchTestBase extends TikaTest {
         commandLine.add(cp);
         commandLine.add("org.apache.tika.batch.fs.FSBatchProcessCLI");
 
-        String configFile = Paths.get(
-                this.getClass().getResource(testConfig).toURI()).toAbsolutePath().toString();
+        String configFile = Paths.get(getResourceAsUri(testConfig)).toAbsolutePath().toString();
         commandLine.add("-bc");
 
         commandLine.add(configFile);

--- a/tika-core/src/test/java/org/apache/tika/TikaTest.java
+++ b/tika-core/src/test/java/org/apache/tika/TikaTest.java
@@ -62,6 +62,15 @@ public abstract class TikaTest {
 
     protected static Parser AUTO_DETECT_PARSER = new AutoDetectParser();
 
+    /**
+     * Finds a resource with a given name.
+     * @param name name of the desired resource
+     * @return A {@link java.net.URL} object or null
+     */
+    public URL getResourceAsUrl(String name) {
+        return this.getClass().getResource(name);
+    }
+
    /**
     * This method will give you back the filename incl. the absolute path name
     * to the resource. If the resource does not exist it will give you back the

--- a/tika-core/src/test/java/org/apache/tika/TikaTest.java
+++ b/tika-core/src/test/java/org/apache/tika/TikaTest.java
@@ -98,14 +98,14 @@ public abstract class TikaTest {
     *         the the class you've called it from.
     */
    public File getResourceAsFile(String name) throws URISyntaxException {
-       URL url = this.getClass().getResource(name);
-       if (url != null) {
-           return new File(url.toURI());
+       URI uri = getResourceAsUri(name);
+       if (uri != null) {
+           return new File(uri);
        } else {
            // We have a file which does not exists
            // We got the path
-           url = this.getClass().getResource(".");
-           File file = new File(new File(url.toURI()), name);
+           uri = getResourceAsUri(".");
+           File file = new File(new File(uri), name);
            if (file == null) {
               fail("Unable to find requested file " + name);
            }
@@ -526,8 +526,7 @@ public abstract class TikaTest {
         //for now, just get main files
         //TODO: fix this to be recursive
         try {
-            File[] pathArray = Paths.get(this.getClass().getResource("/test-documents")
-                    .toURI()).toFile().listFiles();
+            File[] pathArray = Paths.get(getResourceAsUri("/test-documents")).toFile().listFiles();
             List<Path> paths = new ArrayList<>();
             for (File f : pathArray) {
                 paths.add(f.toPath());

--- a/tika-core/src/test/java/org/apache/tika/TikaTest.java
+++ b/tika-core/src/test/java/org/apache/tika/TikaTest.java
@@ -26,6 +26,7 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -69,6 +70,21 @@ public abstract class TikaTest {
      */
     public URL getResourceAsUrl(String name) {
         return this.getClass().getResource(name);
+    }
+
+    /**
+     * Finds a resource with a given name.
+     * @param name name of the desired resource
+     * @return A {@link java.net.URI} object or null
+     * @throws URISyntaxException if this URL is not formatted strictly according to
+     *                            RFC2396 and cannot be converted to a URI.
+     */
+    public URI getResourceAsUri(String name) throws URISyntaxException {
+        URL url = getResourceAsUrl(name);
+        if (url == null) {
+            return null;
+        }
+        return url.toURI();
     }
 
    /**

--- a/tika-core/src/test/java/org/apache/tika/config/TikaConfigTest.java
+++ b/tika-core/src/test/java/org/apache/tika/config/TikaConfigTest.java
@@ -246,7 +246,7 @@ public class TikaConfigTest extends AbstractTikaConfigTest {
     
     @Test
     public void testDynamicServiceLoaderFromConfig() throws Exception {
-        URL url = TikaConfigTest.class.getResource("TIKA-1700-dynamic.xml");
+        URL url = getResourceAsUrl("TIKA-1700-dynamic.xml");
         TikaConfig config = new TikaConfig(url);
         
         DummyParser parser = (DummyParser)config.getParser();
@@ -259,7 +259,7 @@ public class TikaConfigTest extends AbstractTikaConfigTest {
     
     @Test
     public void testTikaExecutorServiceFromConfig() throws Exception {
-        URL url = TikaConfigTest.class.getResource("TIKA-1762-executors.xml");
+        URL url = getResourceAsUrl("TIKA-1762-executors.xml");
         
         TikaConfig config = new TikaConfig(url);
         

--- a/tika-parser-modules/tika-parser-font-module/src/test/java/org/apache/tika/parser/font/FontParsersTest.java
+++ b/tika-parser-modules/tika-parser-font-module/src/test/java/org/apache/tika/parser/font/FontParsersTest.java
@@ -39,8 +39,7 @@ public class FontParsersTest extends TikaTest {
         Metadata metadata = new Metadata();
         ParseContext context = new ParseContext();
 
-        try (TikaInputStream stream = TikaInputStream.get(
-                FontParsersTest.class.getResource("/test-documents/testAFM.afm"))) {
+        try (TikaInputStream stream = TikaInputStream.get(getResourceAsUrl("/test-documents/testAFM.afm"))) {
             AUTO_DETECT_PARSER.parse(stream, handler, metadata, context);
         }
 
@@ -72,8 +71,7 @@ public class FontParsersTest extends TikaTest {
         //http://www.google.com/fonts/specimen/Open+Sans
         //...despite the copyright in the file's metadata.
 
-        try (TikaInputStream stream = TikaInputStream.get(
-                FontParsersTest.class.getResource("/test-documents/testTrueType3.ttf"))) {
+        try (TikaInputStream stream = TikaInputStream.get(getResourceAsUrl("/test-documents/testTrueType3.ttf"))) {
             AUTO_DETECT_PARSER.parse(stream, handler, metadata, context);
         }
 

--- a/tika-parser-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
+++ b/tika-parser-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
@@ -1322,7 +1322,7 @@ public class HtmlParserTest extends TikaTest {
     }
 
     private void testDetector(EncodingDetector detector) throws Exception {
-        Path testDocs = Paths.get(this.getClass().getResource("/test-documents").toURI());
+        Path testDocs = Paths.get(getResourceAsUri("/test-documents"));
         List<Path> tmp = new ArrayList<>();
         Map<Path, String> encodings = new ConcurrentHashMap<>();
         File[] testDocArray = testDocs.toFile().listFiles();

--- a/tika-parser-modules/tika-parser-integration-tests/src/test/java/org/apache/tika/detect/TestContainerAwareDetector.java
+++ b/tika-parser-modules/tika-parser-integration-tests/src/test/java/org/apache/tika/detect/TestContainerAwareDetector.java
@@ -77,8 +77,7 @@ public class TestContainerAwareDetector extends MultiThreadedTikaTest {
         assertTypeByNameAndData(dataFile, name, type, null);
     }
     private void assertTypeByNameAndData(String dataFile, String name, String typeFromDetector, String typeFromMagic) throws Exception {
-        try (TikaInputStream stream = TikaInputStream.get(
-                TestContainerAwareDetector.class.getResource("/test-documents/" + dataFile))) {
+        try (TikaInputStream stream = TikaInputStream.get(getResourceAsUrl("/test-documents/" + dataFile))) {
             Metadata m = new Metadata();
             if (name != null)
                 m.add(TikaCoreProperties.RESOURCE_NAME_KEY, name);
@@ -227,8 +226,7 @@ public class TestContainerAwareDetector extends MultiThreadedTikaTest {
 
     @Test
     public void testOpenContainer() throws Exception {
-        try (TikaInputStream stream = TikaInputStream.get(
-                TestContainerAwareDetector.class.getResource("/test-documents/testPPT.ppt"))) {
+        try (TikaInputStream stream = TikaInputStream.get(getResourceAsUrl("/test-documents/testPPT.ppt"))) {
             assertNull(stream.getOpenContainer());
             assertEquals(
                     MediaType.parse("application/vnd.ms-powerpoint"),
@@ -367,8 +365,7 @@ public class TestContainerAwareDetector extends MultiThreadedTikaTest {
     private void assertRemovalTempfiles(String fileName) throws Exception {
         int numberOfTempFiles = countTemporaryFiles();
 
-        try (TikaInputStream stream = TikaInputStream.get(
-                TestContainerAwareDetector.class.getResource("/test-documents/" + fileName))) {
+        try (TikaInputStream stream = TikaInputStream.get(getResourceAsUrl("/test-documents/" + fileName))) {
             detector.detect(stream, new Metadata());
         }
 

--- a/tika-parser-modules/tika-parser-integration-tests/src/test/java/org/apache/tika/parser/RecursiveParserWrapperTest.java
+++ b/tika-parser-modules/tika-parser-integration-tests/src/test/java/org/apache/tika/parser/RecursiveParserWrapperTest.java
@@ -422,7 +422,7 @@ public class RecursiveParserWrapperTest extends TikaTest {
         InputStream stream = null;
         RecursiveParserWrapperHandler handler = new RecursiveParserWrapperHandler(contentHandlerFactory);
         try {
-            stream = TikaInputStream.get(RecursiveParserWrapperTest.class.getResource(path).toURI());
+            stream = TikaInputStream.get(getResourceAsUri(path));
             wrapper.parse(stream, handler, metadata, context);
         } finally {
             IOUtils.closeQuietly(stream);

--- a/tika-parser-modules/tika-parser-integration-tests/src/test/java/org/apache/tika/parser/pkg/CompositeZipContainerDetectorTest.java
+++ b/tika-parser-modules/tika-parser-integration-tests/src/test/java/org/apache/tika/parser/pkg/CompositeZipContainerDetectorTest.java
@@ -195,8 +195,7 @@ public class CompositeZipContainerDetectorTest extends TikaTest {
 
     private List<File> getTestZipBasedFiles(Detector detector, MediaTypeRegistry registry) throws Exception {
         List<File> zips = new ArrayList<>();
-        for (File f : Paths.get(
-                this.getClass().getResource("/test-documents").toURI()).toFile().listFiles()) {
+        for (File f : Paths.get(getResourceAsUri("/test-documents")).toFile().listFiles()) {
             try (InputStream is = TikaInputStream.get(f)) {
                 MediaType mt = detector.detect(is, new Metadata());
                 if (registry.isSpecializationOf(mt, MediaType.APPLICATION_ZIP)) {

--- a/tika-parser-modules/tika-parser-microsoft-module/src/test/java/org/apache/tika/parser/microsoft/chm/TestChmExtraction.java
+++ b/tika-parser-modules/tika-parser-microsoft-module/src/test/java/org/apache/tika/parser/microsoft/chm/TestChmExtraction.java
@@ -197,7 +197,7 @@ public class TestChmExtraction extends MultiThreadedTikaTest {
     
     @Test
     public void test_TIKA_1446() throws Exception {
-        URL chmDir = TestChmExtraction.class.getResource("/test-documents/chm/");
+        URL chmDir = getResourceAsUrl("/test-documents/chm/");
         File chmFolder = new File(chmDir.toURI());
         for (String fileName : chmFolder.list()) {
             File file = new File(chmFolder, fileName);

--- a/tika-parser-modules/tika-parser-microsoft-module/src/test/java/org/apache/tika/parser/microsoft/ooxml/TruncatedOOXMLTest.java
+++ b/tika-parser-modules/tika-parser-microsoft-module/src/test/java/org/apache/tika/parser/microsoft/ooxml/TruncatedOOXMLTest.java
@@ -84,7 +84,7 @@ public class TruncatedOOXMLTest extends TikaTest {
     @Test
     @Ignore("for dev/debugging only")
     public void listStreams() throws Exception {
-        File tstDir = new File(TruncatedOOXMLTest.class.getResource("/test-documents").toURI());
+        File tstDir = new File(getResourceAsUri("/test-documents"));
         for (File f : tstDir.listFiles()) {
             if (f.isDirectory()) {
                 continue;

--- a/tika-parser-modules/tika-parser-miscoffice-module/src/test/java/org/apache/tika/parser/odf/ODFParserTest.java
+++ b/tika-parser-modules/tika-parser-miscoffice-module/src/test/java/org/apache/tika/parser/odf/ODFParserTest.java
@@ -272,8 +272,7 @@ public class ODFParserTest extends TikaTest {
     
     @Test
     public void testFromFile() throws Exception {
-        try (TikaInputStream tis = TikaInputStream.get(this.getClass().getResource(
-                "/test-documents/testODFwithOOo3.odt"))) {
+        try (TikaInputStream tis = TikaInputStream.get(getResourceAsUrl("/test-documents/testODFwithOOo3.odt"))) {
             assertEquals(true, tis.hasFile());
             OpenDocumentParser parser = new OpenDocumentParser();
             Metadata metadata = new Metadata();
@@ -292,8 +291,7 @@ public class ODFParserTest extends TikaTest {
     @Test
     public void testNPEFromFile() throws Exception {
         OpenDocumentParser parser = new OpenDocumentParser();
-        try (TikaInputStream tis = TikaInputStream.get(this.getClass().getResource(
-                "/test-documents/testNPEOpenDocument.odt"))) {
+        try (TikaInputStream tis = TikaInputStream.get(getResourceAsUrl("/test-documents/testNPEOpenDocument.odt"))) {
             Metadata metadata = new Metadata();
             ContentHandler handler = new BodyContentHandler();
             parser.parse(tis, handler, metadata, new ParseContext());
@@ -377,8 +375,7 @@ public class ODFParserTest extends TikaTest {
 
     @Test(expected = IOException.class)
     public void testInvalidFromStream() throws Exception {
-        try (InputStream is = this.getClass().getResource(
-                "/test-documents/testODTnotaZipFile.odt").openStream()) {
+        try (InputStream is = getResourceAsUrl("/test-documents/testODTnotaZipFile.odt").openStream()) {
             OpenDocumentParser parser = new OpenDocumentParser();
             Metadata metadata = new Metadata();
             ContentHandler handler = new BodyContentHandler();
@@ -388,8 +385,7 @@ public class ODFParserTest extends TikaTest {
 
     @Test(expected = IOException.class)
     public void testInvalidFromFile() throws Exception {
-        try (TikaInputStream tis = TikaInputStream.get(this.getClass().getResource(
-                "/test-documents/testODTnotaZipFile.odt"))) {
+        try (TikaInputStream tis = TikaInputStream.get(getResourceAsUrl("/test-documents/testODTnotaZipFile.odt"))) {
             OpenDocumentParser parser = new OpenDocumentParser();
             Metadata metadata = new Metadata();
             ContentHandler handler = new BodyContentHandler();

--- a/tika-parsers-extended/tika-parser-scientific-module/src/test/java/org/apache/tika/parser/gdal/TestGDALParser.java
+++ b/tika-parsers-extended/tika-parser-scientific-module/src/test/java/org/apache/tika/parser/gdal/TestGDALParser.java
@@ -145,7 +145,7 @@ public class TestGDALParser extends TikaTest {
 
         assumeTrue(canRun());
         // If the exit code is 1 (meaning FITS isn't supported by the installed version of gdalinfo, don't run this test.
-        String[] fitsCommand = {"gdalinfo", TestGDALParser.class.getResource(fitsFilename).getPath()};
+        String[] fitsCommand = {"gdalinfo", getResourceAsUrl(fitsFilename).getPath()};
         assumeTrue(ExternalParser.check(fitsCommand, 1));
 
         String expectedAllgMin = "-7.319537E1";


### PR DESCRIPTION
1. Add method `getResourceAsUrl` to `TikaTest`
2. Add method `getResourceAsUri` to `TikaTest`
3. Simplify some test code by using method `TikaTest#getResourceAsUrl` and `TikaTest#getResourceAsUri`