### PR TITLE
Fix file exist judgement in method TikaTest#getResourceAsFile

### DIFF
--- a/tika-core/src/test/java/org/apache/tika/TikaTest.java
+++ b/tika-core/src/test/java/org/apache/tika/TikaTest.java
@@ -106,7 +106,7 @@ public abstract class TikaTest {
            // We got the path
            uri = getResourceAsUri(".");
            File file = new File(new File(uri), name);
-           if (file == null) {
+           if (!file.exists()) {
               fail("Unable to find requested file " + name);
            }
            return file;

--- a/tika-eval/src/test/java/org/apache/tika/eval/SimpleComparerTest.java
+++ b/tika-eval/src/test/java/org/apache/tika/eval/SimpleComparerTest.java
@@ -155,7 +155,7 @@ public class SimpleComparerTest extends TikaTest {
         );
         EvalFilePaths fpsB = new EvalFilePaths(
                 Paths.get("non-existent.json"),
-                getResourceAsFile("/test-dirs/extractsB/non-existent.json").toPath());
+                Paths.get("/test-dirs/extractsB/non-existent.json"));
 
         comparer.compareFiles(fpsA, fpsB);
 
@@ -338,8 +338,8 @@ public class SimpleComparerTest extends TikaTest {
                 getResourceAsFile("/test-dirs/extractsA/file17_tagsOutOfOrder.json").toPath()
         );
         EvalFilePaths fpsB = new EvalFilePaths(
-                Paths.get("file16_badtags.html"),
-                getResourceAsFile("/test-dirs/extractsB/file16_badtags.html").toPath());
+                Paths.get("file16_badTags.html"),
+                getResourceAsFile("/test-dirs/extractsB/file16_badTags.html").toPath());
         comparer.compareFiles(fpsA, fpsB);
         List<Map<Cols, String>> tableInfosA = WRITER.getTable(ExtractComparer.TAGS_TABLE_A);
         assertEquals(1, tableInfosA.size());


### PR DESCRIPTION
1. Fix file exist judgement in method TikaTest#getResourceAsFile

In method [TikaTest#getResourceAsFile](https://github.com/apache/tika/blob/4696bd6cbc021c96bc64f63e8cea2ab8f3092ba3/tika-core/src/test/java/org/apache/tika/TikaTest.java#L109), there is a file exist judgement:
```
File file = new File(new File(uri), name);
if (file == null) {
    fail("Unable to find requested file " + name);
}
```
The result of `file==null` is always true.  Should be replaced with `!file.exists()`.

2.  Fix test error in test case SimpleComparerTest

Fix file can't find in method `testChinese`. 
Test file don't exist. Use method `Paths.get`.

Fix file name typo in method `testTagsOutOfOrder`.
Change file name typo from "file16_badtags.html" to "file16_badTags.html".
This typo won't affect `windows` because file name on `windows` can ignore case.