### PR TITLE
Fix test error of tika-bundle-classic module

### DIFF
--- a/tika-bundles/tika-bundle-classic/pom.xml
+++ b/tika-bundles/tika-bundle-classic/pom.xml
@@ -143,6 +143,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.sun.istack</groupId>
       <artifactId>istack-commons-runtime</artifactId>
       <version>3.0.11</version>
@@ -180,6 +186,7 @@
               org.apache.tika.parser.internal.Activator
             </Bundle-Activator>
             <Embed-Dependency>*;scope=compile;artifactId=tika-parsers-classic-package|
+              javax.activation|
               xerces|
               commons-compress|
               xz|


### PR DESCRIPTION
I notice there is a test error in tika-bundle-classic if JDK's version bigger than 8.
See is this [Jenkins log](https://ci-builds.apache.org/job/Tika/job/tika-main-jdk11/lastBuild/org.apache.tika$tika-bundle-classic/console)

This PR is a fix for it. 
I have tested on windows with JDK8 and ubuntu with JDK11, and it work.  WDYT :)