### PR TITLE
Removed exclusion of tika-server-core from tika-server-classic

### DIFF
--- a/tika-server/tika-server-classic/pom.xml
+++ b/tika-server/tika-server-classic/pom.xml
@@ -100,7 +100,6 @@
                         <artifactSet>
                             <excludes>
                                 <exclude>org.apache.tika:tika-parsers-classic-package:jar:</exclude>
-                                <exclude>org.apache.tika:tika-server-core:jar:</exclude>
                             </excludes>
                         </artifactSet>
                         <filters>


### PR DESCRIPTION
Was looking to spin a tika-docker for the 2.0.0-ALPHA (yay!) and saw the tika-server-classic isn't loading.

Good news is following this change my test suites in a couple of applications I use Tika in have pass nicely.

Updated tika-docker is ready to go once tika-server-classic is updated and republished.
