### PR TITLE
Add back dependency jaxb-runtime for tika-parser-pdf-module

### DIFF
--- a/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/pom.xml
+++ b/tika-parsers/tika-parsers-classic/tika-parsers-classic-modules/tika-parser-pdf-module/pom.xml
@@ -84,6 +84,16 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
+        <!-- for java 10
+           See TIKA-2778 for why we need to do this now.
+            May the gods of API design fix this in the future.
+            only required for jackcess-encrypt
+           -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>


### PR DESCRIPTION
I found there is a test error in `tika-parser-pdf-module` with JDK11.
See this log:
```
[ERROR] org.apache.tika.parser.pdf.PDFPreflightParserTest.testBasic  Time elapsed: 0.019 s  <<< ERROR!
java.lang.NoClassDefFoundError: javax/activation/DataSource
	at org.apache.tika.parser.pdf.PDFPreflightParserTest.testBasic(PDFPreflightParserTest.java:48)
Caused by: java.lang.ClassNotFoundException: javax.activation.DataSource
	at org.apache.tika.parser.pdf.PDFPreflightParserTest.testBasic(PDFPreflightParserTest.java:48)
```

I think we should add back dependency `jaxb-runtime` for tika-parser-pdf-module.