### PR TITLE
[TIKA-860] Allow for AutoDetectParser to specify SecureContentHandler parameters.

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/parser/AutoDetectParser.java
+++ b/tika-core/src/main/java/org/apache/tika/parser/AutoDetectParser.java
@@ -18,6 +18,7 @@ package org.apache.tika.parser;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -40,6 +41,52 @@ import org.apache.tika.sax.SecureContentHandler;
 public class AutoDetectParser extends CompositeParser {
 
     /**
+     * This config object can be used to tune how conservative we want to be
+     * when parsing data that is extremely compressible and resembles a ZIP
+     * bomb. Null values will be ignored and will not effect the default values
+     * in SecureContentHandler.
+     */
+    public static class SecureContentHandlerConfig implements Serializable {
+        /**
+         * Creates a SecureContentHandlerConfig using the passed in parameters.
+         * @param maxOutputThreshold character output threshold.
+         * @param maxCompressionRatio max compression ratio allowed.
+         * @param maxDepth maximum XML element nesting level.
+         * @param maxPackageEntryDepth maximum package entry nesting level.
+         */
+        public SecureContentHandlerConfig(
+            Long maxOutputThreshold,
+            Long maxCompressionRatio,
+            Integer maxDepth,
+            Integer maxPackageEntryDepth) {
+            this.maxOutputThreshold = maxOutputThreshold;
+            this.maxCompressionRatio = maxCompressionRatio;
+            this.maxDepth = maxDepth;
+            this.maxPackageEntryDepth = maxPackageEntryDepth;
+        }
+
+        /**
+         * Desired output threshold in characters.
+         */
+        public final Long maxOutputThreshold;
+
+        /**
+         * Desired maximum compression ratio.
+         */
+        public final Long maxCompressionRatio;
+
+        /**
+         * Desired maximum XML nesting level.
+         */
+        public final Integer maxDepth;
+
+        /**
+         * Desired maximum package entry nesting level.
+         */
+        public final Integer maxPackageEntryDepth;
+    }
+
+    /**
      * Serial version UID
      */
     private static final long serialVersionUID = 6110455808615143122L;
@@ -50,6 +97,11 @@ public class AutoDetectParser extends CompositeParser {
      * of a document.
      */
     private Detector detector; // always set in the constructor
+
+    /**
+     * Configuration used when initializing a SecureContentHandler.
+     */
+    private SecureContentHandlerConfig secureContentHandlerConfig;
 
     /**
      * Creates an auto-detecting parser instance using the default Tika
@@ -108,6 +160,18 @@ public class AutoDetectParser extends CompositeParser {
         this.detector = detector;
     }
 
+    /**
+     * Sets the configuration that will be used to create SecureContentHandlers
+     * that will be used for parsing.
+     *
+     * @param secureContentHandlerConfig type SecureContentHandlerConfig
+     * @since Apache Tika 2.1.1
+     */
+    public void setSecureContentHandlerConfig(
+        SecureContentHandlerConfig secureContentHandlerConfig) {
+        this.secureContentHandlerConfig = secureContentHandlerConfig;
+    }
+
     public void parse(InputStream stream, ContentHandler handler, Metadata metadata,
                       ParseContext context) throws IOException, SAXException, TikaException {
         TemporaryResources tmp = new TemporaryResources();
@@ -132,7 +196,8 @@ public class AutoDetectParser extends CompositeParser {
             }
             // TIKA-216: Zip bomb prevention
             SecureContentHandler sch =
-                    handler != null ? new SecureContentHandler(handler, tis) : null;
+                    handler != null ?
+                        createSecureContentHandler(handler, tis, secureContentHandlerConfig) : null;
 
             //pass self to handle embedded documents if
             //the caller hasn't specified one.
@@ -163,6 +228,33 @@ public class AutoDetectParser extends CompositeParser {
         ParseContext context = new ParseContext();
         context.set(Parser.class, this);
         parse(stream, handler, metadata, context);
+    }
+
+    private SecureContentHandler createSecureContentHandler(
+        ContentHandler handler,
+        TikaInputStream tis,
+        SecureContentHandlerConfig config) {
+        SecureContentHandler sch = new SecureContentHandler(handler, tis);
+        if (config == null) {
+            return sch;
+        }
+
+        if (config.maxOutputThreshold != null) {
+            sch.setMaximumCompressionRatio(config.maxOutputThreshold);
+        }
+
+        if (config.maxCompressionRatio != null) {
+            sch.setMaximumCompressionRatio(config.maxCompressionRatio);
+        }
+
+        if (config.maxDepth != null) {
+            sch.setMaximumCompressionRatio(config.maxDepth);
+        }
+
+        if (config.maxPackageEntryDepth != null) {
+            sch.setMaximumCompressionRatio(config.maxPackageEntryDepth);
+        }
+        return sch;
     }
 
 }


### PR DESCRIPTION
Previously TIKA-860 added getter and setters to make Zip bomb prevention
configurable but because SecureContentHandler is create inline in
AutoDetectParser we have no access to these parameters.

This change adds a configuration object that can be set and used when
constructing the SecureContentHandler inline.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Tika](https://tika.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Tika issue tracker](https://issues.apache.org/jira/projects/TIKA) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`TIKA-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[TIKA-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Tika is successfully built and unit tests pass by running `mvn clean test`
* there should be no conflicts when merging the pull request branch into the *recent* `main` branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled `main` branch.

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Tika in general, please sign up for the [Tika mailing list](http://tika.apache.org/mail-lists.html). Thanks!
