### PR TITLE
TIKA-3825 fork parser interrupt 1x

### DIFF
--- a/tika-core/src/test/java/org/apache/tika/fork/ForkParserTest.java
+++ b/tika-core/src/test/java/org/apache/tika/fork/ForkParserTest.java
@@ -495,7 +495,7 @@ public class ForkParserTest extends TikaTest {
         service.shutdownNow();
         service.awaitTermination(15, TimeUnit.SECONDS);
         long secondsSinceShutdown = ChronoUnit.SECONDS.between(requestShutdown, Instant.now());
-        assertTrue(secondsSinceShutdown < 5, "Should have shutdown the service in less than 5 seconds");
+        assertTrue("Should have shutdown the service in less than 5 seconds", secondsSinceShutdown < 5);
     }
 
 


### PR DESCRIPTION
Additional pull following on from https://github.com/apache/tika/pull/633 with additional commit 
https://github.com/apache/tika/pull/634/commits/6b0ae6c032ec6024d8b2a4fa23c20b9d12f0edfc
Fixing complilation error in `ForkParserTest`
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->
