### PR TITLE
Update Grobid parsers

### DIFF
--- a/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/java/org/apache/tika/parser/journal/GrobidRESTParser.java
+++ b/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/java/org/apache/tika/parser/journal/GrobidRESTParser.java
@@ -96,8 +96,9 @@ public class GrobidRESTParser {
         try {
             checkMode();
             Response response = WebClient.create(restHostUrlStr +
-                    (legacyMode ? GROBID_LEGACY_PROCESSHEADER_PATH : GROBID_PROCESSHEADER_PATH))
-                    .accept(MediaType.APPLICATION_XML).type(MediaType.MULTIPART_FORM_DATA)
+                            (legacyMode ? GROBID_LEGACY_PROCESSHEADER_PATH : GROBID_PROCESSHEADER_PATH))
+                    .accept(MediaType.APPLICATION_XML)
+                    .type(MediaType.MULTIPART_FORM_DATA)
                     .post(body);
 
 

--- a/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/java/org/apache/tika/parser/journal/GrobidRESTParser.java
+++ b/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/java/org/apache/tika/parser/journal/GrobidRESTParser.java
@@ -41,7 +41,7 @@ public class GrobidRESTParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrobidRESTParser.class);
 
-    private static final String GROBID_REST_HOST = "http://localhost:8080";
+    private static final String GROBID_REST_HOST = "http://localhost:8070";
     private static final String GROBID_ISALIVE_PATH = "/api/isalive";
     private static final String GROBID_PROCESSHEADER_PATH = "/api/processHeaderDocument";
     private static final String GROBID_LEGACY_ISALIVE_PATH = "/grobid";

--- a/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/java/org/apache/tika/parser/ner/grobid/GrobidNERecogniser.java
+++ b/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/java/org/apache/tika/parser/ner/grobid/GrobidNERecogniser.java
@@ -49,7 +49,7 @@ public class GrobidNERecogniser implements NERecogniser {
         }
         };
     private static final Logger LOG = LoggerFactory.getLogger(GrobidNERecogniser.class);
-    private static final String GROBID_REST_HOST = "http://localhost:8080";
+    private static final String GROBID_REST_HOST = "http://localhost:8060";
     private static boolean available = false;
     private String restHostUrlStr;
 

--- a/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/resources/org/apache/tika/parser/journal/GrobidExtractor.properties
+++ b/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/resources/org/apache/tika/parser/journal/GrobidExtractor.properties
@@ -13,4 +13,4 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-grobid.server.url=http://localhost:8080
+grobid.server.url=http://localhost:8070

--- a/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/resources/org/apache/tika/parser/ner/grobid/GrobidServer.properties
+++ b/tika-parsers/tika-parsers-ml/tika-parser-nlp-module/src/main/resources/org/apache/tika/parser/ner/grobid/GrobidServer.properties
@@ -13,5 +13,5 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-grobid.server.url=http://localhost:8080
-grobid.endpoint.text=/processQuantityText
+grobid.server.url=http://localhost:8060
+grobid.endpoint.text=/service/processQuantityText


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

TIKA JIRA issue: https://issues.apache.org/jira/browse/TIKA-4112


This PR updates the grobid (github.com/kermitt2/grobid) and grobid-quantities (github.com/kermitt2/grobid-quantities) parsers

- default URLS for both parsed 
- added try-catch when checking whether the service is alive


