### PR TITLE
[TIKA-2328] Improved error handling for HtmlParser errors with unbalanced quotes

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/main/java/org/apache/tika/parser/html/HtmlParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/main/java/org/apache/tika/parser/html/HtmlParser.java
@@ -146,7 +146,11 @@ public class HtmlParser extends AbstractEncodingDetectorParser {
             parser.setContentHandler(new XHTMLDowngradeHandler(
                     new HtmlHandler(mapper, handler, metadata, context, extractScripts)));
 
-            parser.parse(reader.asInputSource());
+            try {
+                parser.parse(reader.asInputSource());
+            } catch (StringIndexOutOfBoundsException e) {
+                throw new TikaException(e.getMessage(), e);
+            }
         }
     }
 

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -1267,6 +1268,19 @@ public class HtmlParserTest extends TikaTest {
 
         assertEquals("ActualTitle", m.get(TikaCoreProperties.TITLE));
         assertEquals("OldMetaTitle", m.get("title"));
+    }
+
+    @Test
+    public void testUnbalancedQuotes() throws Exception {
+        //this tests handling of unbalanced quotes (see TIKA-2328)
+        String testData = "<!DOCTYPE HTML PUBLIC \">";
+        assertThrows(TikaException.class, () -> {
+            new HtmlParser().parse(new ByteArrayInputStream(testData.getBytes()),
+                    new BodyContentHandler(),
+                    new Metadata(),
+                    new ParseContext());
+
+        });
     }
 
     private class EncodingDetectorRunner implements Callable<String> {


### PR DESCRIPTION
This PR improves error handling by re-throwing the error as a TikaException instead of the unexpected StringsOutOfBoundsException.

Tests for "tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module" run without issues.

I have a signed ICLA with Apache.