### PR TITLE
Resolved a flaky error

### DIFF
--- a/tika-app/pom.xml
+++ b/tika-app/pom.xml
@@ -92,6 +92,17 @@
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
+    <dependency>
+          <groupId>com.google.flatbuffers</groupId>
+          <artifactId>flatbuffers-java</artifactId>
+          <version>1.12.0</version>
+          <scope>test</scope>
+      </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tika-app/src/test/java/org/apache/tika/cli/TikaCLITest.java
+++ b/tika-app/src/test/java/org/apache/tika/cli/TikaCLITest.java
@@ -29,7 +29,10 @@ import java.io.PrintStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
 
+import com.google.gson.Gson;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;

--- a/tika-app/src/test/java/org/apache/tika/cli/TikaCLITest.java
+++ b/tika-app/src/test/java/org/apache/tika/cli/TikaCLITest.java
@@ -248,16 +248,23 @@ public class TikaCLITest {
     public void testJsonMetadataOutput() throws Exception {
         String json = getParamOutContent("--json", "--digest=MD2",
                 resourcePrefix + "testJsonMultipleInts.html");
+        
+        Map<String, Object> jsonMap = new Gson().fromJson(json, Map.class);
+        // Sort properties alphabetically
+        Map<String, Object> sortedJsonMap = new TreeMap<>(jsonMap);
+        // Convert back to JSON string
+        String newJson = new Gson().toJson(sortedJsonMap);
+
         //TIKA-1310
-        assertTrue(json.contains("\"fb:admins\":\"1,2,3,4\","));
+        assertTrue(newJson.contains("\"fb:admins\":\"1,2,3,4\","));
 
         //test legacy alphabetic sort of keys
-        int enc = json.indexOf("\"Content-Encoding\"");
-        int fb = json.indexOf("fb:admins");
-        int title = json.indexOf("\"dc:title\"");
+        int enc = newJson.indexOf("\"Content-Encoding\"");
+        int fb = newJson.indexOf("fb:admins");
+        int title = newJson.indexOf("\"dc:title\"");
         assertTrue(enc > -1 && fb > -1 && enc < fb);
         assertTrue(fb > -1 && title > -1 && fb > title);
-        assertTrue(json.contains("\"X-TIKA:digest:MD2\":"));
+        assertTrue(newJson.contains("\"X-TIKA:digest:MD2\":"));
     }
 
     /**


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[org.apache.tika.cli.TikaCLITest#testJsonMetadataOutput](https://github.com/apache/tika/blob/7b79f881e7b47f9272d626ebdfb9456fc206e08f/tika-app/src/test/java/org/apache/tika/cli/TikaCLITest.java#L248)

Test Overview:
_________________________________________________________________________________________________________
The output returned by getParamOutContent is flaky in nature and is non-deterministic. This results in the testJsonMetadataOutput failing.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
[ERROR]   TikaCLITest.testJsonMetadataOutput:258 expected: <true> but was: <false>
```

You can reproduce the issue by running the following commands:

```
mvn install -pl tika-app -am -DskipTests
mvn test -pl tika-app  -Dtest=org.apache.tika.cli.TikaCLITest#testJsonMetadataOutput
mvn -pl tika-app edu.illinois:index-maven-plugin:2.1.1:nondex -Dtest=org.apache.tika.cli.TikaCLITest#testJsonMetadataOutput
```
Fix:
_________________________________________________________________________________________________________
To fix the issue I decided to sort the JSON string. To sort the JSON string I used the Google extension "com.google.code.gson" in the tika-app/pom.xml file. This made the output deterministic and led the code to successfully passing.

https://github.com/njain2208/tika/blob/8fce6e9afcc6872e0d5cdfac08ccd2c7dfd7d0b0/tika-app/src/test/java/org/apache/tika/cli/TikaCLITest.java#L251-L271