### PR TITLE
Fix html parsing logic when body contains script tag

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/main/java/org/apache/tika/parser/html/JSoupParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/main/java/org/apache/tika/parser/html/JSoupParser.java
@@ -199,7 +199,7 @@ public class JSoupParser extends AbstractEncodingDetectorParser {
 
         @Override
         public NodeFilter.FilterResult tail(Node node, int i) {
-            if (node instanceof TextNode) {
+            if (node instanceof TextNode || node instanceof DataNode) {
                 return FilterResult.CONTINUE;
             }
             try {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
@@ -1092,6 +1092,12 @@ public class HtmlParserTest extends TikaTest {
     }
 
     @Test
+    public void testScriptInBody() throws Exception {
+        String xml = getXML("testHTML_script_in_body.html").xml;
+        assertContains("This is a test", xml);
+        assertNotContained("cool", xml);
+    }
+    @Test
     public void testExtractScript() throws Exception {
         JSoupParser p = new JSoupParser();
         p.setExtractScripts(true);

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/java/org/apache/tika/parser/html/HtmlParserTest.java
@@ -1097,6 +1097,7 @@ public class HtmlParserTest extends TikaTest {
         assertContains("This is a test", xml);
         assertNotContained("cool", xml);
     }
+
     @Test
     public void testExtractScript() throws Exception {
         JSoupParser p = new JSoupParser();

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/resources/test-documents/testHTML_script_in_body.html
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-html-module/src/test/resources/test-documents/testHTML_script_in_body.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<body>
+<script lang="javascript">cool script</script>
+<p>This is a test.</p>
+</body>
+</html>


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Hey there. I spotted that public signup to Tika Jira is disabled, so I'm not sure what is the correct flow for issues without a ticket, putting all related info here...

### Issue description
`org.apache.tika.parser.html.JSoupParser` parser ignores `body` content after the `script` tag. Check `org.apache.tika.parser.html.HtmlParserTest#testScriptInBody` test for details.

### Fix description
The main reason of such behaviour is that `#data` tag tail decrements `org.apache.tika.parser.html.HtmlHandler.bodyLevel`, when `#data` tag head is considered a content node and doesn't invoke `startElement` logic at all. As a fix I mirrored head logic for the data node to the tail and returned `FilterResult.CONTINUE` early.
