### PR TITLE
[TIKA-4194] Fix for unrecognized pkcs12 keystores

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5253,6 +5253,8 @@
     <!-- Always seem to have a version integer as their first entry, -->
     <!--  normally 00, 01 or 02, check for that -->
     <magic priority="40">
+      <match value="0x3080020100" type="string"
+              mask="0xFFFFFFFFFC" offset="0"/>
       <match value="0x3081FF020100" type="string"
               mask="0xFFFF00FFFFFC" offset="0"/>
       <match value="0x3082FFFF020100" type="string"


### PR DESCRIPTION
Fixes the issue that some pkcs12 keystores are not correctly detected. Tested with 157x p12 keystores (kindly provided by [redhat](https://github.com/redhat-qe-security/keyfile-corpus/tree/master).)