### PR TITLE
TIKA-4255: text-parser uses Metadata.CONTENT_ENCODING

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-text-module/src/main/java/org/apache/tika/parser/csv/TextAndCSVParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-text-module/src/main/java/org/apache/tika/parser/csv/TextAndCSVParser.java
@@ -294,6 +294,13 @@ public class TextAndCSVParser extends AbstractEncodingDetectorParser {
                         getEncodingDetector(context));
             }
         }
+        String charsetString = metadata.get(Metadata.CONTENT_ENCODING);
+        if (charsetString != null && params.getCharset() == null) {
+            try {
+                params.setCharset(Charset.forName(charsetString));
+            } catch (Exception ignored) {
+            }
+        }
         Reader reader = null;
         if (params.getCharset() == null) {
             reader = new AutoDetectReader(CloseShieldInputStream.wrap(stream), metadata,


### PR DESCRIPTION
If CSVParams.getCharset() is null, the passed in encoding is used before trying to auto detect it.
