### PR TITLE
Extend range of matching tex keywords

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5068,12 +5068,13 @@
     <_comment>TeX Source</_comment>
     <alias type="text/x-tex"/>
     <magic priority="50">
+      <match value="\\documentclass" type="string" offset="0:8192"/>
+      <match value="\\usepackage" type="string" offset="0:8192"/>
+      <match value="\\documentstyle" type="string" offset="0:8192"/>
       <match value="\\input" type="string" offset="0"/>
       <match value="\\section" type="string" offset="0"/>
       <match value="\\setlength" type="string" offset="0"/>
-      <match value="\\documentstyle" type="string" offset="0"/>
       <match value="\\chapter" type="string" offset="0"/>
-      <match value="\\documentclass" type="string" offset="0"/>
       <match value="\\relax" type="string" offset="0"/>
       <match value="\\contentsline" type="string" offset="0"/>
     </magic>


### PR DESCRIPTION
It's not uncommon for tex files to start with % comments, which then allows matlab to claim a match. By extending the range to match \documentclass, \documentstyle and adding \usepackage this works for my files.

On matlab, the match for comments has already caused a mis-match with pdf files TIKA-3328 , and as far as I can see it is the only one with a matcher for comments which I think is just ridiculous and should be removed altogether.