### PR TITLE
Circumvention for MNG-8180 Maven bug

### DIFF
--- a/tika-grpc/pom.xml
+++ b/tika-grpc/pom.xml
@@ -376,6 +376,7 @@
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>module-info.class</exclude>
+                    <exclude>META-INF/maven/plugin.xml</exclude>
                     <exclude>META-INF/versions/9/module-info.class</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>


### PR DESCRIPTION
Exclude plugin metadata from shaded JAR.
