### PR TITLE
TIKA-4290 Change the way to output Arrays.

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/detect/MagicDetector.java
+++ b/tika-core/src/main/java/org/apache/tika/detect/MagicDetector.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -432,6 +433,6 @@ public class MagicDetector implements Detector {
     public String toString() {
         // Needs to be unique, as these get compared.
         return "Magic Detection for " + type + " looking for " + pattern.length + " bytes = " +
-                this.pattern + " mask = " + this.mask;
+                Arrays.toString(this.pattern) + " mask = " + Arrays.toString(this.mask);
     }
 }

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItsfHeader.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItsfHeader.java
@@ -19,6 +19,7 @@ package org.apache.tika.parser.microsoft.chm;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 
 import org.apache.tika.exception.TikaException;
 
@@ -72,8 +73,8 @@ public class ChmItsfHeader implements ChmAccessor<ChmItsfHeader> {
         sb.append(getUnknown_000c()).append(" ");
         sb.append(getLastModified()).append(" ");
         sb.append(getLangId()).append(" ");
-        sb.append(getDir_uuid()).append(" ");
-        sb.append(getStream_uuid()).append(" ");
+        sb.append(Arrays.toString(getDir_uuid())).append(" ");
+        sb.append(Arrays.toString(getStream_uuid())).append(" ");
         sb.append(getUnknownOffset()).append(" ");
         sb.append(getUnknownLen()).append(" ");
         sb.append(getDirOffset()).append(" ");

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItspHeader.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItspHeader.java
@@ -20,6 +20,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.tika.exception.TikaException;
 
+import java.util.Arrays;
+
 /**
  * Directory header The directory starts with a header; its format is as
  * follows: 0000: char[4] 'ITSP' 0004: DWORD Version number 1 0008: DWORD Length
@@ -118,10 +120,10 @@ public class ChmItspHeader implements ChmAccessor<ChmItspHeader> {
                 .append(ChmCommons.getLanguage(getLang_id()))
                 .append(System.getProperty("line.separator"));
         sb.append("system_uuid:=")
-                .append(getSystem_uuid())
+                .append(Arrays.toString(getSystem_uuid()))
                 .append(System.getProperty("line.separator"));
         sb.append("unknown_0044:=")
-                .append(getUnknown_0044())
+                .append(Arrays.toString(getUnknown_0044()))
                 .append(" ]");
         return sb.toString();
     }

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItspHeader.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItspHeader.java
@@ -18,9 +18,9 @@ package org.apache.tika.parser.microsoft.chm;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.apache.tika.exception.TikaException;
-
 import java.util.Arrays;
+
+import org.apache.tika.exception.TikaException;
 
 /**
  * Directory header The directory starts with a header; its format is as

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/onenote/GUID.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/onenote/GUID.java
@@ -133,7 +133,7 @@ public class GUID implements Comparable<GUID> {
     }
 
     public String getGuidString() {
-        return guid.toString();
+        return Arrays.toString(guid);
     }
 
     public List<Byte> toByteArray() {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/main/java/org/apache/tika/parser/dbf/DBFColumnHeader.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/main/java/org/apache/tika/parser/dbf/DBFColumnHeader.java
@@ -22,6 +22,7 @@ import static org.apache.tika.parser.dbf.DBFColumnHeader.ColType.PLUS;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -69,7 +70,7 @@ class DBFColumnHeader {
 
     @Override
     public String toString() {
-        return "DBFColumnHeader{" + "name='" + name + '\'' + ", colType=" + colType +
+        return "DBFColumnHeader{" + "name='" + Arrays.toString(name) + '\'' + ", colType=" + colType +
                 ", fieldLength=" + fieldLength + ", decimalCount=" + decimalCount + '}';
     }
 


### PR DESCRIPTION
TIKA-4290 Change the way to output Arrays. Previously they were output as hex addresses in memory
