### PR TITLE
[TIKA-4300] Add audio/aac as an alias for the audio/x-aac MIME type

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5880,6 +5880,7 @@
   <mime-type type="audio/vnd.vmx.cvsd"/>
   <mime-type type="audio/vorbis-config"/>
   <mime-type type="audio/x-aac">
+    <alias type="audio/aac"/>
     <glob pattern="*.aac"/>
     <magic priority="30">
       <!-- Without ID3 tags -->


### PR DESCRIPTION
The audio/x-aac is deprecated, and replaced by audio/aac. Having audio/aac as an alias for the deprecated type makes it possible to recognize the audio/aac MIME type.
