### PR TITLE
 [TIKA-4304] Add audio/flac as an alias to the audio/x-flac MIME type

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5957,6 +5957,7 @@
   </mime-type>
 
   <mime-type type="audio/x-flac">
+    <alias type="audio/flac" />
     <acronym>FLAC</acronym>
     <_comment>Free Lossless Audio Codec</_comment>
     <magic priority="50">


### PR DESCRIPTION
This makes it possible to recognize the standard audio/flac MIME type