### PR TITLE
[TIKA-4290] Refactor parseToString method to use try-with-resources

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/Tika.java
+++ b/tika-core/src/main/java/org/apache/tika/Tika.java
@@ -519,17 +519,15 @@ public class Tika {
     public String parseToString(InputStream stream, Metadata metadata, int maxLength)
             throws IOException, TikaException {
         WriteOutContentHandler handler = new WriteOutContentHandler(maxLength);
-        try {
-            ParseContext context = new ParseContext();
-            context.set(Parser.class, parser);
-            parser.parse(stream, new BodyContentHandler(handler), metadata, context);
+        ParseContext context = new ParseContext();
+        context.set(Parser.class, parser);
+        try (InputStream autoCloseStream = stream) {
+            parser.parse(autoCloseStream, new BodyContentHandler(handler), metadata, context);
         } catch (SAXException e) {
             if (!WriteLimitReachedException.isWriteLimitReached(e)) {
                 // This should never happen with BodyContentHandler...
                 throw new TikaException("Unexpected SAX processing failure", e);
             }
-        } finally {
-            stream.close();
         }
         return handler.toString();
     }


### PR DESCRIPTION
Changes made:
try-with-resources is used to automatically handle closing the InputStream, ensuring that it is always closed properly without the need for a finally block.