### PR TITLE
[TIKA-4312] Make audio/mp4 a subclass of video/mp4

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5642,7 +5642,7 @@
     <glob pattern="*.mp4a"/>
     <glob pattern="*.m4a"/>
     <glob pattern="*.m4b"/>
-    <sub-class-of type="application/quicktime" />
+    <sub-class-of type="video/mp4" />
   </mime-type>
   <mime-type type="audio/mp4a-latm"/>
   <mime-type type="audio/mpa"/>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TIKA-4312

tika-mimetypes.xml currently defines these two <sub-class-of> ancestor chains:

- audio/mp4 → application/quicktime.
 - video/mp4 → video/quicktime → application/quicktime.

Based on [RFC 4337, section 2](https://datatracker.ietf.org/doc/html/rfc4337#section-2), it is my understanding that audio/mp4 is a special case of video/mp4. I thus suggest changing the ancestor chain of audio/mp4 to 

- audio/mp4 → video/mp4 → video/quicktime → application/quicktime