### PR TITLE
TIKA-4350 HTML snippet containing <iframe> as root element erroneously recognized as application/xml

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -7680,6 +7680,8 @@
     <root-XML localName="SCRIPT"/>
     <root-XML localName="frameset"/>
     <root-XML localName="FRAMESET"/>
+    <root-XML localName="iframe"/>
+    <root-XML localName="IFRAME"/>
     <magic priority="60">
       <match value="(?i)&lt;(html|head|body|title|div)[ >]" type="regex" offset="0"/>
       <match value="(?i)&lt;h[123][ >]" type="regex" offset="0"/>

--- a/tika-core/src/test/java/org/apache/tika/mime/MimeDetectionTest.java
+++ b/tika-core/src/test/java/org/apache/tika/mime/MimeDetectionTest.java
@@ -74,6 +74,8 @@ public class MimeDetectionTest {
         testFile("text/html", "testlargerbuffer.html");
         // test fragment of HTML with <div> (TIKA-1102)
         testFile("text/html", "htmlfragment");
+        // test fragment of HTML with <iframe> and potentially misleading file suffix
+        testFile("text/html", "test-html-snippet-iframe.jsp");
         // test binary CGM detection (TIKA-1170)
         testFile("image/cgm", "plotutils-bin-cgm-v3.cgm");
         // test HTML detection of malformed file, previously identified as image/cgm (TIKA-1170)

--- a/tika-core/src/test/resources/org/apache/tika/mime/test-html-snippet-iframe.jsp
+++ b/tika-core/src/test/resources/org/apache/tika/mime/test-html-snippet-iframe.jsp
@@ -1,0 +1,2 @@
+<!-- this is a comment: https://www.example.org/path/file.pdf --> 
+          <iframe src='/path/file.pdf' width='100%' height='100%' target='_blank'>


### PR DESCRIPTION
Trivial solution adding `<iframe>` as a `root-XML` hint, analogous to `<frameset>`. 
