### PR TITLE
TIKA-4365 : feat : Support Detection for AAB Bundle file

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-zip-commons/src/main/java/org/apache/tika/detect/zip/JarDetector.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-zip-commons/src/main/java/org/apache/tika/detect/zip/JarDetector.java
@@ -46,6 +46,10 @@ public class JarDetector implements ZipContainerDetector {
             if (zip.getEntry("META-INF/application.xml") != null) {
                 return MediaType.application("x-tika-java-enterprise-archive");
             }
+            // AAB archive
+             if (zip.getEntry("base/manifest/AndroidManifest.xml") != null) {
+                return MediaType.application("x-authorware-bin");
+            }
 
             // Looks like a regular Jar Archive
             return MediaType.application("java-archive");
@@ -69,7 +73,10 @@ public class JarDetector implements ZipContainerDetector {
         } else if (name.equals("META-INF/MANIFEST.MF")) {
             // It's a Jar file, or something based on Jar
             detectContext.set(SeenManifest.class, SEEN_MANIFEST);
-        }
+        } else if (name.equals("base/manifest/AndroidManifest.xml") != null) {
+                return MediaType.application("x-authorware-bin");
+            }
+        
         SeenManifest seenManifest = detectContext.get(SeenManifest.class);
 
         if (seenManifest != null) {
@@ -79,7 +86,11 @@ public class JarDetector implements ZipContainerDetector {
             } else if (name.equals("WEB-INF/")) {
                 // Check for WAR and EAR
                 return MediaType.application("x-tika-java-web-archive");
+            } else if (name.equals("base/manifest/AndroidManifest.xml") != null) {
+                // Check for AAB bundle
+                return MediaType.application("x-authorware-bin");
             }
+        
             if (name.equals("META-INF/application.xml")) {
                 return MediaType.application("x-tika-java-enterprise-archive");
             }

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-zip-commons/src/main/java/org/apache/tika/detect/zip/JarDetector.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-zip-commons/src/main/java/org/apache/tika/detect/zip/JarDetector.java
@@ -25,6 +25,10 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.mime.MediaType;
 
+/**
+ * This detector detects JAR files and file type variants of zip subtypes
+ * that may contain a MANIFEST.MF
+ */
 public class JarDetector implements ZipContainerDetector {
 
     private static SeenManifest SEEN_MANIFEST = new SeenManifest();


### PR DESCRIPTION
TIKA-4365 : Support added for Android AAB bundle file. 

Detection is through AndroidManifest.xml similar to APK files in JarDetector. As per Android Developer Documentation this file is seen in manifest directory. 


https://developer.android.com/guide/app-bundle/app-bundle-format