### PR TITLE
[TIKA-4303] Handle OneNotePropertyEnum.CachedTitleString as RichEditTextUnicode

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/onenote/OneNoteTreeWalker.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/onenote/OneNoteTreeWalker.java
@@ -393,7 +393,8 @@ class OneNoteTreeWalker {
     private boolean propertyIsBinary(OneNotePropertyEnum property) {
         return property == OneNotePropertyEnum.RgOutlineIndentDistance ||
                 property == OneNotePropertyEnum.NotebookManagementEntityGuid ||
-                property == OneNotePropertyEnum.RichEditTextUnicode;
+                property == OneNotePropertyEnum.RichEditTextUnicode ||
+                property == OneNotePropertyEnum.CachedTitleString;
     }
 
     /**
@@ -508,7 +509,9 @@ class OneNoteTreeWalker {
                                     dif.size());
                 }
                 if (propertyValue.propertyId.propertyEnum ==
-                        OneNotePropertyEnum.RichEditTextUnicode) {
+                        OneNotePropertyEnum.RichEditTextUnicode
+                        || propertyValue.propertyId.propertyEnum ==
+                        OneNotePropertyEnum.CachedTitleString) {
                     if (!options.isOnlyLatestRevision()
                             || (parentPropertyId != null &&
                             parentPropertyId.propertyEnum != OneNotePropertyEnum.ElementChildNodesOfVersionHistory)) {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/onenote/OneNoteTreeWalkerOptions.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/onenote/OneNoteTreeWalkerOptions.java
@@ -29,8 +29,7 @@ public class OneNoteTreeWalkerOptions implements Serializable {
     private boolean crawlAllFileNodesFromRoot = true;
     private boolean onlyLatestRevision = true;
     private Set<OneNotePropertyEnum> utf16PropertiesToPrint = new HashSet<>(
-            Arrays.asList(OneNotePropertyEnum.ImageFilename, OneNotePropertyEnum.Author,
-                    OneNotePropertyEnum.CachedTitleString));
+            Arrays.asList(OneNotePropertyEnum.ImageFilename, OneNotePropertyEnum.Author));
 
     /**
      * Do this to ignore revisions and just parse all file nodes from the root recursively.


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/TIKA-4303

The issue of garbled text is caused by `OneNotePropertyEnum.CachedTitleString` not being correctly parsed. It should be parsed using `handleRichEditTextUnicode`.

As for why versions `2.7.0` and earlier did not encounter garbled text, I believe it was due to a previously erroneous line of code:
```java
if (options.getUtf16PropertiesToPrint().contains(propertyValue.propertyId))
```

This line caused the parsing of OneNote files to never append the parsed content of `OneNotePropertyEnum.ImageFilename, OneNotePropertyEnum.Author, and OneNotePropertyEnum.CachedTitleString` to the xhtml.

However, when parsing `OneNotePropertyEnum.RichEditTextUnicode`, the logic for only parsing the latest version’s content was not added. As a result, the files appeared to be successfully parsed and without garbled text, but in reality, CachedTitleString was never parsed.

I only fixed the bug in the issue where the title in the uploaded file was not parsed. During the testing process, I also discovered the following issues:
- Non-rich text content is not checked for the latest version, so when the content is TextExtendedAscii, it is still parsed repeatedly.
- Dates are not parsed.
- Chinese (or other non-Ascii characters? i'm not sure) characters in the content are not parsed.

I am not sure whether to create a new issue before proceeding with these fixes, so these issues have not been addressed in this PR.