### PR TITLE
TIKA-4382 : feat : support new MS Access format detection

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -4643,6 +4643,7 @@
     <glob pattern="*.xbap"/>
   </mime-type>
   <mime-type type="application/x-msaccess">
+    <glob pattern="*.accdb"/>
     <glob pattern="*.mdb"/>
     <magic priority="60">
       <match value="0x000100005374616e" type="string" offset="0"/>

--- a/tika-core/src/test/java/org/apache/tika/mime/MimeTypesReaderTest.java
+++ b/tika-core/src/test/java/org/apache/tika/mime/MimeTypesReaderTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
@@ -287,6 +288,14 @@ public class MimeTypesReaderTest {
         assertEquals(List.of(".js", ".mjs"), mt.getExtensions());
     }
 
+    
+    @Test
+    public void testMSAccessByName() {
+    	MimeTypes mimeTypes = MimeTypes.getDefaultMimeTypes();
+		MediaType result = mimeTypes.getMimeType("testfile1.accdb").getType();
+		assertEquals("application/x-msaccess", result.toString());
+    }  
+    
     @Test
     public void testGetAliasForJavaScript() throws Exception {
         MimeType mt = this.mimeTypes.forName("text/javascript");


### PR DESCRIPTION
.accdb is new MS Access DB Extension, while tika has support for .mdb (Access 2003 format), .accdb is needed for name based detection for newer file format.