### PR TITLE
TIKA-4384 : Add ZipX in DefaultMimeTypes

### DIFF
--- a/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
+++ b/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml
@@ -5731,6 +5731,7 @@
       <match value="PK\x07\x08" type="string" offset="0"/>
     </magic>
     <glob pattern="*.zip"/>
+    <glob pattern="*.zipx"/>
   </mime-type>
 
   <mime-type type="application/zlib">

--- a/tika-core/src/test/java/org/apache/tika/mime/MimeTypesReaderTest.java
+++ b/tika-core/src/test/java/org/apache/tika/mime/MimeTypesReaderTest.java
@@ -295,6 +295,15 @@ public class MimeTypesReaderTest {
         assertEquals("application/x-msaccess", result.toString());
     }  
     
+    
+    @Test
+    public void testZipXFiles() {
+        MimeTypes mimeTypes = MimeTypes.getDefaultMimeTypes();
+        MediaType result = mimeTypes.getMimeType("testfile1.zipx").getType();
+        assertEquals("application/zip", result.toString());
+    }
+    
+    
     @Test
     public void testGetAliasForJavaScript() throws Exception {
         MimeType mt = this.mimeTypes.forName("text/javascript");


### PR DESCRIPTION
ZipX is a new Zip extension, the magic works, but name based detection returns application/octet-stream because it is not known to tika-mimetypes.xml