### PR TITLE
TIKA-4417: fix dependency convergence error with jackcess-encrypt

### DIFF
--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -710,8 +710,12 @@
           <!-- to avoid maven-enforcer convergence error,
             let's make this explicit -->
           <exclusion>
+            <groupId>com.healthmarketscience.jackcess</groupId>
+            <artifactId>jackcess</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
- jackcess-encrypt depends on an older version of  jackcess
- jackcess-encrypt now uses org.bouncycastle:bcprov-jdk18on rather than org.bouncycastle:bcprov-jdk15on

By updating the exclusions we avoid dependency convergence errors in projects using Tika.