### PR TITLE
[TIKA-4432]-Issue with EMF Parser Merging Header, Page Number, and First Content Word During Extraction

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/EMFParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/EMFParser.java
@@ -124,6 +124,9 @@ public class EMFParser implements Parser {
                     }
                     String txt = extTextOutW.getText();
                     buffer.append(txt);
+                    if (!txt.endsWith(" ")) {
+                        buffer.append(" ");
+                    }
                     parseState.lastY = extTextOutW.getReference().getY();
                     parseState.lastX = extTextOutW.getReference().getX();
                 }


### PR DESCRIPTION
It appears that the EMF parser is incorrectly combining multiple elements during text extraction. Specifically, information from the document header, the page number, and the first word of the main content are being merged into a single word.

The issue stems from how text fragments (EmfExtTextOutW records) are appended to a buffer. In cases where the EMF text does not include a trailing space, the next fragment gets concatenated directly without separation. The logic in PR ensures that if a text fragment does not end with a space, an explicit space is added between it and the next fragment.