### PR TITLE
[TIKA-4457] Updating Automatic-Module tag for cad module.

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/pom.xml
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/pom.xml
@@ -53,7 +53,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>org.apache.tika.parser.code</Automatic-Module-Name>
+              <Automatic-Module-Name>org.apache.tika.parser.cad</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
The original value appears to have been copied from the "code" module. Compiling an upstream project complains of a conflict with the code module.
