### PR TITLE
Return correct result code from start script

### DIFF
--- a/tika-server/tika-server-standard/bin/tika
+++ b/tika-server/tika-server-standard/bin/tika
@@ -563,5 +563,5 @@ function start_tika() {
 
 if [[ "$SCRIPT_CMD" == "start" ]]; then
   start_tika "$FG" "$ADDITIONAL_CMD_OPTS"
-  exit 1
+  exit $?
 fi


### PR DESCRIPTION
Returning "1" after calling the start method seems wrong. The solr start script, which seems to be the origin of the tika one, has since fixed this by using $? instead.