### PR TITLE
TIKA-4392: core osgi requirements now list xerces as optional

### DIFF
--- a/tika-core/pom.xml
+++ b/tika-core/pom.xml
@@ -142,7 +142,11 @@
               org.apache.tika.config.TikaActivator
             </Bundle-Activator>
             <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
-            <Import-Package>org.apache.commons.io.*;version="[2,3)",*</Import-Package>
+            <Import-Package>
+              org.apache.xerces.util;resolution:=optional,
+              org.apache.commons.io.*;version="[2,3)",
+              *
+            </Import-Package>
             <Export-Package>
               org.apache.tika.*
             </Export-Package>


### PR DESCRIPTION
Fixes TIKA-4392. Makes xerces optional in OSGI imports. Tested in my OSGI environment (equinox).

I have decided to use "TIKA-*:" format for git messages - other commits use it instead of "bracket rule".

Based on current main. Rebasing to branch_3_2x is trivial.