### PR TITLE
TIKA-4606: Upgrade Apache Ignite from 2.x to 3.x

### DIFF
--- a/tika-grpc/dev-tika-config.json
+++ b/tika-grpc/dev-tika-config.json
@@ -16,7 +16,7 @@
   ],
   "pipes": {
     "configStoreType": "ignite",
-    "configStoreParams": "{\"cacheName\":\"tika-config-cache\",\"cacheMode\":\"REPLICATED\",\"igniteInstanceName\":\"TikaGrpcIgnite\",\"autoClose\":true}"
+    "configStoreParams": "{\"tableName\":\"tika-config-cache\",\"igniteInstanceName\":\"TikaGrpcIgnite\",\"replicas\":2,\"partitions\":10,\"autoClose\":true}"
   },
   "fetchers": [
     {

--- a/tika-grpc/pom.xml
+++ b/tika-grpc/pom.xml
@@ -34,7 +34,6 @@
   </parent>
 
   <properties>
-    <grpc.version>1.78.0</grpc.version>
     <asarkar-grpc-test.version>2.0.0</asarkar-grpc-test.version>
     <awaitility.version>4.3.0</awaitility.version>
     <j2objc-annotations.version>3.1</j2objc-annotations.version>
@@ -50,6 +49,56 @@
         <version>${grpc.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-runtime</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-inject</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-server</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-websocket</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-netty</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-validation</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-client-core</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>2.2.38</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>2.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -423,10 +472,10 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/test/resources/certs/**</exclude>
-            <exclude>README.md</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>src/test/resources/certs/**</inputExclude>
+            <inputExclude>README.md</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
       <plugin>

--- a/tika-grpc/src/main/proto/tika.proto
+++ b/tika-grpc/src/main/proto/tika.proto
@@ -98,6 +98,8 @@ message FetchAndParseRequest {
   // You can supply additional fetch configuration using this. Follows same fetch configuration json schema
   // as the fetcher configuration.
   string additional_fetch_config_json = 3;
+  // The ID of the emitter to use (optional). If not provided, no emitter will be used.
+  string emitter_id = 4;
 }
 
 message FetchAndParseReply {

--- a/tika-grpc/src/test/resources/tika-config-ignite.json
+++ b/tika-grpc/src/test/resources/tika-config-ignite.json
@@ -1,7 +1,7 @@
 {
   "pipes": {
     "configStoreType": "ignite",
-    "configStoreParams": "{\"cacheName\":\"my-tika-cache\",\"cacheMode\":\"REPLICATED\",\"igniteInstanceName\":\"MyTikaCluster\",\"autoClose\":true}"
+    "configStoreParams": "{\"tableName\":\"my-tika-cache\",\"igniteInstanceName\":\"MyTikaCluster\",\"replicas\":2,\"partitions\":10,\"autoClose\":true}"
   },
   "fetchers": [
     {

--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>35</version>
+    <version>37</version>
     <relativePath/>
   </parent>
 
@@ -287,7 +287,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
-    <project.build.outputTimestamp>1729074250</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-02-01T00:00:00Z</project.build.outputTimestamp>
     <!-- plugin versions -->
     <!-- updates may not be detected by the maven versions plugin:
          https://github.com/mojohaus/versions/issues/1070 -->
@@ -297,7 +297,7 @@
     <maven.antrun.version>3.2.0</maven.antrun.version>
     <maven.assembly.version>3.8.0</maven.assembly.version>
     <maven.bundle.version>6.0.0</maven.bundle.version>
-    <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
+    <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
     <maven.failsafe.version>3.5.4</maven.failsafe.version>
     <maven.surefire.version>3.5.4</maven.surefire.version>
     <maven.javadoc.version>3.12.0</maven.javadoc.version>
@@ -305,7 +305,7 @@
     <maven.scr.version>1.26.4</maven.scr.version>
     <maven.shade.version>3.6.1</maven.shade.version>
     <maven.project.info.reports.version>3.9.0</maven.project.info.reports.version>
-    <puppycrawl.version>12.3.0</puppycrawl.version>
+    <puppycrawl.version>12.3.1</puppycrawl.version>
     <rat.version>0.17</rat.version>
     <scm.version>2.2.1</scm.version>
     <checkstyle.configLocation>${maven.multiModuleProjectDirectory}/tika-parent/checkstyle.xml</checkstyle.configLocation>
@@ -313,14 +313,14 @@
     <spotless.header.file>${maven.multiModuleProjectDirectory}/tika-parent/license-header.txt</spotless.header.file>
     <!-- dependency versions -->
     <!-- change threetenbp exclusion version -->
-    <google.cloud.version>2.61.0</google.cloud.version>
-    <aws2.version>2.40.16</aws2.version>
+    <google.cloud.version>2.62.1</google.cloud.version>
+    <aws2.version>2.41.24</aws2.version>
     <!-- WARNING: when you upgrade asm make sure that you update the
         OpCode in the initializer in org.apache.tika.parser.asm.XHTMLClassVisitor
         See TIKA-2992.
     -->
     <asm.version>9.9.1</asm.version>
-    <azure.version>1.3.3</azure.version>
+    <azure.version>1.3.4</azure.version>
     <biz.aqute.version>7.1.0</biz.aqute.version>
     <boilerpipe.version>1.1.0</boilerpipe.version>
     <!--  used by POI, PDFBox and Jackcess encrypt ...try to sync -->
@@ -329,7 +329,7 @@
     <brotli.version>0.1.2</brotli.version>
     <c3p0.version>0.11.2</c3p0.version>
     <commons.cli.version>1.11.0</commons.cli.version>
-    <commons.codec.version>1.20.0</commons.codec.version>
+    <commons.codec.version>1.21.0</commons.codec.version>
     <commons.collections4.version>4.5.0</commons.collections4.version>
     <commons.compress.version>1.28.0</commons.compress.version>
     <commons.csv.version>1.14.1</commons.csv.version>
@@ -352,6 +352,7 @@
     <freemarker.version>2.3.34</freemarker.version>
     <geoapi.version>3.0.2</geoapi.version>
     <gson.version>2.13.2</gson.version>
+    <grpc.version>1.79.0</grpc.version>
     <guava.version>33.5.0-jre</guava.version>
     <h2.version>2.4.240</h2.version>
     <hdf5.version>1.14.3-1.5.10</hdf5.version>
@@ -364,14 +365,14 @@
     <icu4j.version>75.1</icu4j.version>
     <imageio.version>1.4.0</imageio.version>
     <jackrabbit.version>2.23.3-beta</jackrabbit.version>
-    <jackson.version>2.20.1</jackson.version>
+    <jackson.version>2.21.0</jackson.version>
     <jackcess.version>4.0.10</jackcess.version>
     <jackcess.encrypt.version>4.0.3</jackcess.encrypt.version>
     <jai.imageio.core.version>1.4.0</jai.imageio.core.version>
     <jakarta.activation.version>2.2.0-M1</jakarta.activation.version>
     <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
     <jakarta.ws.rs.version>4.0.0</jakarta.ws.rs.version>
-    <jakarta.xml.bind.version>4.0.4</jakarta.xml.bind.version>
+    <jakarta.xml.bind.version>4.0.5</jakarta.xml.bind.version>
     <jakarta.xml.soap.version>3.0.2</jakarta.xml.soap.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <javax.jcr.version>2.0</javax.jcr.version>
@@ -395,13 +396,12 @@
     <jhighlight.version>1.1.1</jhighlight.version>
     <jna.version>5.18.1</jna.version>
     <json.simple.version>1.1.1</json.simple.version>
-    <jsoup.version>1.21.2</jsoup.version>
+    <jsoup.version>1.22.1</jsoup.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <junit4.version>4.13.2</junit4.version>
-    <junit5.version>6.1.0-M1</junit5.version>
+    <junit6.version>6.1.0-M1</junit6.version>
     <juniversalchardet.version>2.5.0</juniversalchardet.version>
     <junrar.version>7.5.7</junrar.version>
-    <jwarc.version>0.33.0</jwarc.version>
+    <jwarc.version>0.34.0</jwarc.version>
     <kafka.version>4.1.1</kafka.version>
     <libpst.version>0.9.3</libpst.version>
     <log4j2.version>2.25.3</log4j2.version>
@@ -415,8 +415,8 @@
     <mockito.version>5.21.0</mockito.version>
     <mockito-junit-jupiter.version>5.21.0</mockito-junit-jupiter.version>
     <netcdf-java.version>4.5.5</netcdf-java.version>
-    <netty.version>4.2.9.Final</netty.version>
-    <oak.jackrabbit.version>1.88.0</oak.jackrabbit.version>
+    <netty.version>4.2.10.Final</netty.version>
+    <oak.jackrabbit.version>1.90.0</oak.jackrabbit.version>
     <openjson.version>1.0.13</openjson.version>
     <opennlp.version>2.5.7</opennlp.version>
     <ops4j.version>1.5.1</ops4j.version>
@@ -430,18 +430,17 @@
     <poi.version>5.5.1</poi.version>
     <protobuf.version>3.25.8</protobuf.version>
     <quartz.version>2.5.2</quartz.version>
-    <reactor.core.version>3.8.1</reactor.core.version>
-    <reactor.netty.version>1.3.1</reactor.netty.version>
+    <reactor.core.version>3.8.2</reactor.core.version>
+    <reactor.netty.version>1.3.2</reactor.netty.version>
     <rome.version>2.1.0</rome.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <sis.version>1.5</sis.version>
+    <sis.version>1.6</sis.version>
     <snappy.version>1.1.10.8</snappy.version>
     <solrj.version>9.10.0</solrj.version>
-    <spring.version>7.0.2</spring.version>
+    <spring.version>7.0.3</spring.version>
     <sqlite.version>3.51.1.0</sqlite.version>
     <stax.ex.version>2.1.0</stax.ex.version>
     <testcontainers.version>2.0.3</testcontainers.version>
-    <testcontainersv1.version>1.21.4</testcontainersv1.version>
     <!-- NOTE: sync tukaani version with commons-compress in tika-parent -->
     <tukaani.version>1.11</tukaani.version>
     <twelvemonkeys.version>3.13.0</twelvemonkeys.version>
@@ -453,8 +452,8 @@
     <woodstox.core.version>7.1.1</woodstox.core.version>
     <xmpcore.version>6.1.11</xmpcore.version>
     <zookeeper.version>3.9.4</zookeeper.version>
-    <zstd.version>1.5.7-6</zstd.version>
-    <nimbus-jose-jwt.version>10.6</nimbus-jose-jwt.version>
+    <zstd.version>1.5.7-7</zstd.version>
+    <nimbus-jose-jwt.version>10.7</nimbus-jose-jwt.version>
     <javacpp.version>1.5.12</javacpp.version>
     <maven.exec.version>3.6.3</maven.exec.version>
 
@@ -515,6 +514,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- because cxf 4.0.9 uses 2.0.2 and jaxb 4.0.6 uses 2.0.3 -->
       <dependency>
         <groupId>org.eclipse.angus</groupId>
@@ -539,7 +545,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>${junit5.version}</version>
+        <version>${junit6.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -583,16 +589,37 @@
         <artifactId>jsoup</artifactId>
         <version>${jsoup.version}</version>
       </dependency>
-      <!-- missing in testcontainers-bom 2.* -->
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${testcontainersv1.version}</version>
+        <artifactId>testcontainers-junit-jupiter</artifactId>
+        <version>${testcontainers.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>kafka</artifactId>
-        <version>${testcontainersv1.version}</version>
+        <artifactId>testcontainers-kafka</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+
+      <!-- Ignite 3.x convergence fixes -->
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>info.picocli</groupId>
+        <artifactId>picocli</artifactId>
+        <version>4.7.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>2.4</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>2.0.1.Final</version>
       </dependency>
 
       <dependency>
@@ -675,7 +702,14 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.45.0</version>
+        <version>2.47.0</version>
+      </dependency>
+      <!-- avoid dependency convergence error in Google Cloud Storage fetcher
+           starting with grpc 1.79.0 with google cloud 2.62.1 -->
+      <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-annotations</artifactId>
+        <version>1.27</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.json-simple</groupId>
@@ -821,19 +855,14 @@
         <version>2.14.0</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit4.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit5.version}</version>
+        <version>${junit6.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit5.version}</version>
+        <version>${junit6.version}</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
@@ -1129,7 +1158,7 @@
       <dependency>
         <groupId>org.pf4j</groupId>
         <artifactId>pf4j</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
       </dependency>
       <dependency>
         <groupId>com.nimbusds</groupId>
@@ -1158,7 +1187,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.9.0</version>
+          <version>3.10.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1223,7 +1252,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.21.0</version>
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
         </configuration>
@@ -1439,7 +1468,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.1</version>
         <configuration>
           <java>
             <includes>
@@ -1523,12 +1552,12 @@
             <groupId>org.apache.rat</groupId>
             <artifactId>apache-rat-plugin</artifactId>
             <configuration>
-              <excludes>
-                <exclude>nb-configuration.xml</exclude> <!-- local netbeans -->
-                <exclude>nbactions.xml</exclude> <!-- local netbeans -->
-                <exclude>**/test-documents/**</exclude>
-                <exclude>**/target/**</exclude> <!-- generated files -->
-              </excludes>
+              <inputExcludes>
+                <inputExclude>nb-configuration.xml</inputExclude> <!-- local netbeans -->
+                <inputExclude>nbactions.xml</inputExclude> <!-- local netbeans -->
+                <inputExclude>**/test-documents/**</inputExclude>
+                <inputExclude>**/target/**</inputExclude> <!-- generated files -->
+              </inputExcludes>
             </configuration>
             <executions>
               <execution>
@@ -1615,6 +1644,7 @@
         <checkstyle.configLocation>${session.executionRootDirectory}/tika-parent/checkstyle.xml</checkstyle.configLocation>
       </properties>
     </profile>
+    <!-- Fast profile: ./mvnw install -Pfast -T1C -->
     <profile>
       <id>fast</id>
       <properties>

--- a/tika-pipes/tika-pipes-config-store-ignite/pom.xml
+++ b/tika-pipes/tika-pipes-config-store-ignite/pom.xml
@@ -30,10 +30,78 @@
   <packaging>jar</packaging>
 
   <properties>
-    <ignite.version>2.17.0</ignite.version>
-    <!-- Ignite 2.16.0 requires H2 1.4.x - not compatible with 2.x -->
-    <h2.version>1.4.197</h2.version>
+    <ignite.version>3.1.0</ignite.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>2.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>info.picocli</groupId>
+        <artifactId>picocli</artifactId>
+        <version>4.7.5</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-inject</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-runtime</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-server</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-websocket</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-netty</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-validation</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micronaut</groupId>
+        <artifactId>micronaut-http-client-core</artifactId>
+        <version>3.10.4</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>2.2.38</version>
+      </dependency>
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>2.4</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -57,37 +125,38 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ignite</groupId>
-      <artifactId>ignite-core</artifactId>
+      <artifactId>ignite-api</artifactId>
       <version>${ignite.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ignite</groupId>
-      <artifactId>ignite-indexing</artifactId>
+      <artifactId>ignite-client</artifactId>
       <version>${ignite.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ignite</groupId>
-      <artifactId>ignite-spring</artifactId>
+      <artifactId>ignite-runner</artifactId>
       <version>${ignite.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-core</artifactId>
+          <groupId>org.apache.ignite</groupId>
+          <artifactId>ignite-metrics-exporter-otlp</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
+          <groupId>io.micronaut.picocli</groupId>
+          <artifactId>micronaut-picocli</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>${h2.version}</version>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-sql-engine</artifactId>
+      <version>${ignite.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-table</artifactId>
+      <version>${ignite.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -100,6 +169,15 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <inputExcludes>
+            <inputExclude>README.md</inputExclude>
+          </inputExcludes>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -117,13 +195,23 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            --add-opens java.base/java.nio=ALL-UNNAMED
-            --add-opens java.base/java.util=ALL-UNNAMED
             --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
             --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.nio=ALL-UNNAMED
+            --add-opens java.base/java.math=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
+            --add-opens java.base/java.time=ALL-UNNAMED
+            --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+            --add-opens java.base/jdk.internal.access=ALL-UNNAMED
             --add-opens java.base/sun.nio.ch=ALL-UNNAMED
             --add-opens java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
             --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true
           </argLine>
         </configuration>
       </plugin>

--- a/tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/ExtensionConfigDTO.java
+++ b/tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/ExtensionConfigDTO.java
@@ -18,45 +18,23 @@ package org.apache.tika.pipes.ignite;
 
 import java.io.Serializable;
 
-import org.apache.tika.plugins.ExtensionConfig;
-
 /**
- * Serializable wrapper for ExtensionConfig to work with Ignite's binary serialization.
- * Since ExtensionConfig is a Java record with final fields, it cannot be directly
- * serialized by Ignite. This DTO provides mutable fields that Ignite can work with.
+ * Serializable wrapper for ExtensionConfig value fields for Ignite 3.x KeyValueView.
+ * The 'id' is the KEY in the KeyValueView and is NOT included in this DTO.
+ * Only the VALUE fields (name, json) are included here.
  */
 public class ExtensionConfigDTO implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String id;
     private String name;
     private String json;
 
     public ExtensionConfigDTO() {
     }
 
-    public ExtensionConfigDTO(String id, String name, String json) {
-        this.id = id;
+    public ExtensionConfigDTO(String name, String json) {
         this.name = name;
         this.json = json;
-    }
-
-    public ExtensionConfigDTO(ExtensionConfig config) {
-        this.id = config.id();
-        this.name = config.name();
-        this.json = config.json();
-    }
-
-    public ExtensionConfig toExtensionConfig() {
-        return new ExtensionConfig(id, name, json);
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
     }
 
     public String getName() {

--- a/tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/IgniteConfigStore.java
+++ b/tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/IgniteConfigStore.java
@@ -16,14 +16,14 @@
  */
 package org.apache.tika.pipes.ignite;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.ignite.Ignite;
-import org.apache.ignite.IgniteCache;
-import org.apache.ignite.Ignition;
-import org.apache.ignite.cache.CacheMode;
-import org.apache.ignite.configuration.CacheConfiguration;
-import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.table.KeyValueView;
+import org.apache.ignite.table.Table;
+import org.apache.ignite.table.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,34 +33,37 @@ import org.apache.tika.pipes.ignite.config.IgniteConfigStoreConfig;
 import org.apache.tika.plugins.ExtensionConfig;
 
 /**
- * Apache Ignite-based implementation of {@link ConfigStore}.
- * Provides distributed configuration storage for Tika Pipes clustering.
+ * Apache Ignite 3.x-based implementation of {@link ConfigStore}.
+ * Provides distributed configuration storage for Tika Pipes clustering using Calcite SQL engine.
  * <p>
  * This implementation is thread-safe and suitable for multi-instance deployments
  * where configurations need to be shared across multiple servers.
  * <p>
  * Configuration options:
  * <ul>
- *   <li>cacheName - Name of the Ignite cache (default: "tika-config-store")</li>
- *   <li>cacheMode - Cache replication mode: PARTITIONED or REPLICATED (default: REPLICATED)</li>
+ *   <li>tableName - Name of the Ignite table (default: "tika_config_store")</li>
+ *   <li>replicas - Replication factor (default: 2)</li>
+ *   <li>partitions - Number of partitions (default: 10)</li>
  *   <li>igniteInstanceName - Name of the Ignite instance (default: "TikaIgniteConfigStore")</li>
  * </ul>
+ * 
+ * Note: This uses Ignite 3.x with built-in Apache Calcite SQL engine (no H2 dependency).
  */
 public class IgniteConfigStore implements ConfigStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(IgniteConfigStore.class);
-    private static final String DEFAULT_CACHE_NAME = "tika-config-store";
+    private static final String DEFAULT_TABLE_NAME = "tika_config_store";
     private static final String DEFAULT_INSTANCE_NAME = "TikaIgniteConfigStore";
 
     private Ignite ignite;
-    private IgniteCache<String, ExtensionConfigDTO> cache;
-    private String cacheName = DEFAULT_CACHE_NAME;
-    private CacheMode cacheMode = CacheMode.REPLICATED;
+    private KeyValueView<String, ExtensionConfigDTO> kvView;
+    private String tableName = DEFAULT_TABLE_NAME;
+    private int replicas = 2;
+    private int partitions = 10;
     private String igniteInstanceName = DEFAULT_INSTANCE_NAME;
     private boolean autoClose = true;
     private ExtensionConfig extensionConfig;
     private boolean closed = false;
-    private boolean clientMode = true;  // Default to client mode
 
     public IgniteConfigStore() {
     }
@@ -69,14 +72,15 @@ public class IgniteConfigStore implements ConfigStore {
         this.extensionConfig = extensionConfig;
         
         IgniteConfigStoreConfig config = IgniteConfigStoreConfig.load(extensionConfig.json());
-        this.cacheName = config.getCacheName();
-        this.cacheMode = config.getCacheModeEnum();
+        this.tableName = config.getTableName();
+        this.replicas = config.getReplicas();
+        this.partitions = config.getPartitions();
         this.igniteInstanceName = config.getIgniteInstanceName();
         this.autoClose = config.isAutoClose();
     }
 
-    public IgniteConfigStore(String cacheName) {
-        this.cacheName = cacheName;
+    public IgniteConfigStore(String tableName) {
+        this.tableName = tableName;
     }
 
     @Override
@@ -94,105 +98,162 @@ public class IgniteConfigStore implements ConfigStore {
             return;
         }
 
-        LOG.info("Initializing IgniteConfigStore with cache: {}, mode: {}, instance: {}",
-                cacheName, cacheMode, igniteInstanceName);
+        LOG.info("Initializing IgniteConfigStore with table: {}, replicas: {}, partitions: {}, instance: {}",
+                tableName, replicas, partitions, igniteInstanceName);
 
-        // Disable Ignite's Object Input Filter autoconfiguration to avoid conflicts
-        System.setProperty("IGNITE_ENABLE_OBJECT_INPUT_FILTER_AUTOCONFIGURATION", "false");
+        // In Ignite 3.x, we connect as a client to an existing cluster
+        // The server must be started separately via IgniteStoreServer
+        try {
+            // Connect to Ignite cluster as client
+            ignite = IgniteClient.builder()
+                    .addresses("127.0.0.1:10800")  // Default client port
+                    .build();
 
-        IgniteConfiguration cfg = new IgniteConfiguration();
-        cfg.setIgniteInstanceName(igniteInstanceName + (clientMode ? "-Client" : ""));
-        cfg.setClientMode(clientMode);
-        cfg.setPeerClassLoadingEnabled(false);  // Disable to avoid classloader conflicts
-        
-        // Set work directory to /var/cache/tika to match Tika's cache location
-        cfg.setWorkDirectory(System.getProperty("ignite.work.dir", "/var/cache/tika/ignite-work"));
+            LOG.info("Connected to Ignite cluster as client");
 
-        ignite = Ignition.start(cfg);
+            // Get or create table
+            Table table = ignite.tables().table(tableName);
+            if (table == null) {
+                LOG.warn("Table {} not found on server. It should be created by IgniteStoreServer.", tableName);
+                throw new IllegalStateException("Table " + tableName + " not found. Ensure IgniteStoreServer is running.");
+            }
 
-        // Get cache (it should already exist on the server)
-        cache = ignite.cache(cacheName);
-        if (cache == null) {
-            // If not found, create it (shouldn't happen if server started first)
-            LOG.warn("Cache {} not found on server, creating it", cacheName);
-            CacheConfiguration<String, ExtensionConfigDTO> cacheCfg = new CacheConfiguration<>(cacheName);
-            cacheCfg.setCacheMode(cacheMode);
-            cacheCfg.setBackups(cacheMode == CacheMode.PARTITIONED ? 1 : 0);
-            cache = ignite.getOrCreateCache(cacheCfg);
+            // Get key-value view for simple get/put operations
+            kvView = table.keyValueView(String.class, ExtensionConfigDTO.class);
+            
+            LOG.info("IgniteConfigStore initialized successfully as client");
+        } catch (Exception e) {
+            LOG.error("Failed to initialize IgniteConfigStore", e);
+            throw new TikaConfigException("Failed to connect to Ignite cluster. Ensure IgniteStoreServer is running.", e);
         }
-        LOG.info("IgniteConfigStore initialized successfully as client");
     }
 
     @Override
     public void put(String id, ExtensionConfig config) {
-        if (cache == null) {
+        if (kvView == null) {
             throw new IllegalStateException("IgniteConfigStore not initialized. Call init() first.");
         }
-        cache.put(id, new ExtensionConfigDTO(config));
+        try {
+            // Create DTO with only value fields (name, json) - id is the key
+            ExtensionConfigDTO dto = new ExtensionConfigDTO(config.name(), config.json());
+            kvView.put(null, id, dto);
+        } catch (Exception e) {
+            LOG.error("Failed to put config with id: {}", id, e);
+            throw new RuntimeException("Failed to put config", e);
+        }
     }
 
     @Override
     public ExtensionConfig get(String id) {
-        if (cache == null) {
+        if (kvView == null) {
             throw new IllegalStateException("IgniteConfigStore not initialized. Call init() first.");
         }
-        ExtensionConfigDTO dto = cache.get(id);
-        return dto != null ? dto.toExtensionConfig() : null;
+        try {
+            ExtensionConfigDTO dto = kvView.get(null, id);
+            // Reconstruct ExtensionConfig with the id (key) and DTO fields (value)
+            return dto != null ? new ExtensionConfig(id, dto.getName(), dto.getJson()) : null;
+        } catch (Exception e) {
+            LOG.error("Failed to get config with id: {}", id, e);
+            throw new RuntimeException("Failed to get config", e);
+        }
     }
 
     @Override
     public boolean containsKey(String id) {
-        if (cache == null) {
+        if (kvView == null) {
             throw new IllegalStateException("IgniteConfigStore not initialized. Call init() first.");
         }
-        return cache.containsKey(id);
+        try {
+            return kvView.get(null, id) != null;
+        } catch (Exception e) {
+            LOG.error("Failed to check if key exists: {}", id, e);
+            throw new RuntimeException("Failed to check key", e);
+        }
     }
 
     @Override
     public Set<String> keySet() {
-        if (cache == null) {
+        if (kvView == null) {
             throw new IllegalStateException("IgniteConfigStore not initialized. Call init() first.");
         }
-        return Set.copyOf(cache.query(new org.apache.ignite.cache.query.ScanQuery<String, ExtensionConfigDTO>())
-                .getAll()
-                .stream()
-                .map(javax.cache.Cache.Entry::getKey)
-                .toList());
+        try {
+            // Use SQL query to get all keys
+            var sql = ignite.sql();
+            var resultSet = sql.execute(null, "SELECT id FROM " + tableName);
+            
+            Set<String> keys = new HashSet<>();
+            while (resultSet.hasNext()) {
+                Tuple tuple = resultSet.next();
+                keys.add(tuple.stringValue("id"));
+            }
+            return keys;
+        } catch (Exception e) {
+            LOG.error("Failed to get keySet", e);
+            throw new RuntimeException("Failed to get keySet", e);
+        }
     }
 
     @Override
     public int size() {
-        if (cache == null) {
+        if (kvView == null) {
             throw new IllegalStateException("IgniteConfigStore not initialized. Call init() first.");
         }
-        return cache.size();
+        try {
+            // Use SQL query to count rows
+            var sql = ignite.sql();
+            var resultSet = sql.execute(null, "SELECT COUNT(*) as cnt FROM " + tableName);
+            
+            if (resultSet.hasNext()) {
+                Tuple tuple = resultSet.next();
+                // COUNT(*) returns LONG (INT64), not INT32
+                return (int) tuple.longValue("cnt");
+            }
+            return 0;
+        } catch (Exception e) {
+            LOG.error("Failed to get size", e);
+            throw new RuntimeException("Failed to get size", e);
+        }
     }
 
     @Override
     public ExtensionConfig remove(String id) {
-        if (cache == null) {
+        if (kvView == null) {
             throw new IllegalStateException("IgniteConfigStore not initialized. Call init() first.");
         }
-        ExtensionConfigDTO removed = cache.getAndRemove(id);
-        return removed != null ? removed.toExtensionConfig() : null;
+        try {
+            ExtensionConfigDTO removed = kvView.getAndRemove(null, id);
+            // Reconstruct ExtensionConfig with the id and DTO fields
+            return removed != null ? new ExtensionConfig(id, removed.getName(), removed.getJson()) : null;
+        } catch (Exception e) {
+            LOG.error("Failed to remove config with id: {}", id, e);
+            throw new RuntimeException("Failed to remove config", e);
+        }
     }
 
     public void close() {
         if (ignite != null && autoClose) {
             LOG.info("Closing IgniteConfigStore");
-            ignite.close();
+            try {
+                ((AutoCloseable) ignite).close();
+            } catch (Exception e) {
+                LOG.error("Error closing Ignite", e);
+            }
             ignite = null;
-            cache = null;
+            kvView = null;
             closed = true;
         }
     }
 
-    public void setCacheName(String cacheName) {
-        this.cacheName = cacheName;
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
     }
 
-    public void setCacheMode(CacheMode cacheMode) {
-        this.cacheMode = cacheMode;
+    public void setReplicas(int replicas) {
+        this.replicas = replicas;
+    }
+
+    public void setPartitions(int partitions) {
+        this.partitions = partitions;
     }
 
     public void setIgniteInstanceName(String igniteInstanceName) {
@@ -201,9 +262,5 @@ public class IgniteConfigStore implements ConfigStore {
 
     public void setAutoClose(boolean autoClose) {
         this.autoClose = autoClose;
-    }
-
-    public void setClientMode(boolean clientMode) {
-        this.clientMode = clientMode;
     }
 }

--- a/tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/config/IgniteConfigStoreConfig.java
+++ b/tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/config/IgniteConfigStoreConfig.java
@@ -18,7 +18,6 @@ package org.apache.tika.pipes.ignite.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.ignite.cache.CacheMode;
 
 import org.apache.tika.exception.TikaConfigException;
 
@@ -28,12 +27,16 @@ import org.apache.tika.exception.TikaConfigException;
  * Example JSON configuration:
  * <pre>
  * {
- *   "cacheName": "my-tika-cache",
- *   "cacheMode": "REPLICATED",
+ *   "tableName": "my-tika-table",
+ *   "replicas": 2,
  *   "igniteInstanceName": "MyTikaCluster",
  *   "autoClose": true
  * }
  * </pre>
+ * 
+ * Note: In Ignite 3.x, "cacheMode" is replaced by "replicas" (replication factor).
+ * - replicas=1 is similar to PARTITIONED (each partition on one node)
+ * - replicas=N where N>=cluster size is similar to REPLICATED
  */
 public class IgniteConfigStoreConfig {
 
@@ -50,45 +53,28 @@ public class IgniteConfigStoreConfig {
         }
     }
 
-    private String cacheName = "tika-config-store";
-    private String cacheMode = "REPLICATED";
+    private String tableName = "tika_config_store";
+    private int replicas = 2;  // Replication factor
     private String igniteInstanceName = "TikaIgniteConfigStore";
     private boolean autoClose = true;
+    private int partitions = 10;  // Number of partitions
 
-    public String getCacheName() {
-        return cacheName;
+    public String getTableName() {
+        return tableName;
     }
 
-    public IgniteConfigStoreConfig setCacheName(String cacheName) {
-        this.cacheName = cacheName;
+    public IgniteConfigStoreConfig setTableName(String tableName) {
+        this.tableName = tableName;
         return this;
     }
 
-    public String getCacheMode() {
-        return cacheMode;
+    public int getReplicas() {
+        return replicas;
     }
 
-    public IgniteConfigStoreConfig setCacheMode(String cacheMode) {
-        this.cacheMode = cacheMode;
+    public IgniteConfigStoreConfig setReplicas(int replicas) {
+        this.replicas = replicas;
         return this;
-    }
-
-    public CacheMode getCacheModeEnum() {
-        if (cacheMode == null || cacheMode.trim().isEmpty()) {
-            return CacheMode.REPLICATED;
-        }
-        
-        if ("PARTITIONED".equalsIgnoreCase(cacheMode)) {
-            return CacheMode.PARTITIONED;
-        }
-        
-        if ("REPLICATED".equalsIgnoreCase(cacheMode)) {
-            return CacheMode.REPLICATED;
-        }
-        
-        throw new IllegalArgumentException(
-                "Unsupported cacheMode: '" + cacheMode
-                        + "'. Supported values are PARTITIONED and REPLICATED.");
     }
 
     public String getIgniteInstanceName() {
@@ -106,6 +92,15 @@ public class IgniteConfigStoreConfig {
 
     public IgniteConfigStoreConfig setAutoClose(boolean autoClose) {
         this.autoClose = autoClose;
+        return this;
+    }
+
+    public int getPartitions() {
+        return partitions;
+    }
+
+    public IgniteConfigStoreConfig setPartitions(int partitions) {
+        this.partitions = partitions;
         return this;
     }
 }


### PR DESCRIPTION
## Summary
Upgrades Apache Ignite from 2.16.0 to 3.1.0 in the `tika-pipes-config-store-ignite` module and updates dependent gRPC server code.

## Changes
- **`tika-pipes-config-store-ignite`**: Upgraded `ignite-core` → `ignite-runner 3.1.0`; migrated from `IgniteConfiguration` API to HOCON-based config; replaced `IgniteCache` with `KeyValueView` API; updated `ExtensionConfigDTO` with Ignite 3.x `@Column`/`@Id` annotations; rewrote `IgniteStoreServer` to use synchronous embedded `Ignite.start()` node API
- **`tika-grpc`**: Added `emitter_id` field to `FetchAndParseRequest` proto; updated `TikaGrpcServerImpl` with proper `IgniteStoreServer` lifecycle; added required `--add-opens` JVM flags for Java 17+
- **`tika-pipes-core/EmitHandler`**: Fixed NPE — added null check for `NO_EMIT` scenario before attempting emission
- **`tika-parent/pom.xml`**: Added Ignite 3.x convergence entries for `asm`, `picocli`, `snakeyaml`, `javax.validation`
- **Unit tests**: Updated `IgniteConfigStoreTest` to use shared `IgniteStoreServer` via `@BeforeAll`/`@AfterAll` (Ignite 3.x embedded server pattern)

## Review Focus Areas
- [ ] **API migration**: `IgniteConfigStore` — `IgniteCache` replaced by `KeyValueView`; verify CRUD semantics are preserved
- [ ] **IgniteStoreServer lifecycle**: embedded node start/stop in `TikaGrpcServerImpl`
- [ ] **EmitHandler null check**: correct guard condition for `NO_EMIT` / null emitter ID
- [ ] **Dependency convergence**: new entries in `tika-parent` for Ignite 3.x transitive conflicts

## Critical Files
- `tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/IgniteConfigStore.java`
- `tika-pipes/tika-pipes-config-store-ignite/src/main/java/org/apache/tika/pipes/ignite/server/IgniteStoreServer.java`
- `tika-grpc/src/main/java/org/apache/tika/pipes/grpc/TikaGrpcServerImpl.java`
- `tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/EmitHandler.java`

## Testing Instructions
```bash
# Build and run unit tests for the ignite module
mvn clean install -pl tika-pipes/tika-pipes-config-store-ignite

# Run specific test class
mvn test -pl tika-pipes/tika-pipes-config-store-ignite -Dtest=IgniteConfigStoreTest
```

## Related
- E2E tests are in a separate PR: TIKA-4606-e2e-tests
- Closes TIKA-4606