### PR TITLE
TIKA-4606: Add e2e tests for Ignite 3.x upgrade

### DIFF
--- a/.github/workflows/main-jdk17-build.yml
+++ b/.github/workflows/main-jdk17-build.yml
@@ -44,4 +44,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean apache-rat:check test install javadoc:aggregate -Pci,e2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean apache-rat:check test install javadoc:aggregate -Pci -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-build.yml
+++ b/.github/workflows/main-jdk17-build.yml
@@ -63,4 +63,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Run E2E Tests
-        run: mvn clean install -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn -pl tika-e2e-tests -am clean verify -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-build.yml
+++ b/.github/workflows/main-jdk17-build.yml
@@ -50,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build
-    if: github.event_name == 'push'
     strategy:
       matrix:
         java: [ '17' ]
@@ -64,4 +63,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Run E2E Tests
-        run: mvn test -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean install -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-build.yml
+++ b/.github/workflows/main-jdk17-build.yml
@@ -44,4 +44,24 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean apache-rat:check test install javadoc:aggregate -Pci -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean apache-rat:check test install javadoc:aggregate -Pci -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    if: github.event_name == 'push'
+    strategy:
+      matrix:
+        java: [ '17' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: Run E2E Tests
+        run: mvn test -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-build.yml
+++ b/.github/workflows/main-jdk17-build.yml
@@ -44,4 +44,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean apache-rat:check test install javadoc:aggregate -Pci -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean apache-rat:check test install javadoc:aggregate -Pci,e2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-windows-build-multi-locale.yml
+++ b/.github/workflows/main-jdk17-windows-build-multi-locale.yml
@@ -48,4 +48,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean test install javadoc:aggregate -Pci -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean test install javadoc:aggregate -Pci,e2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-windows-build-multi-locale.yml
+++ b/.github/workflows/main-jdk17-windows-build-multi-locale.yml
@@ -48,4 +48,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean test install javadoc:aggregate -Pci,e2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean test install javadoc:aggregate -Pci -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-windows-build.yml
+++ b/.github/workflows/main-jdk17-windows-build.yml
@@ -47,4 +47,4 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         working-directory: 'tika build dir'
-        run: mvn clean test install javadoc:aggregate -Pci,e2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean test install javadoc:aggregate -Pci -Pe2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-windows-build.yml
+++ b/.github/workflows/main-jdk17-windows-build.yml
@@ -47,4 +47,4 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         working-directory: 'tika build dir'
-        run: mvn clean test install javadoc:aggregate -Pci -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean test install javadoc:aggregate -Pci,e2e -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <module>tika-example</module>
     <module>tika-java7</module>
     <module>tika-handlers</module>
+    <module>tika-e2e-tests</module>
   </modules>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,15 @@
     <module>tika-example</module>
     <module>tika-java7</module>
     <module>tika-handlers</module>
-    <module>tika-e2e-tests</module>
   </modules>
 
   <profiles>
+    <profile>
+      <id>e2e</id>
+      <modules>
+        <module>tika-e2e-tests</module>
+      </modules>
+    </profile>
     <profile>
       <id>apache-release</id>
       <modules>

--- a/tika-e2e-tests/README.md
+++ b/tika-e2e-tests/README.md
@@ -16,28 +16,28 @@ This module contains standalone end-to-end (E2E) tests for various Apache Tika d
 
 - Java 17 or later
 - Maven 3.6 or later
-- Docker and Docker Compose
 - Internet connection (for downloading test documents)
+- Docker and Docker Compose (only required for Docker Compose mode; not needed for the default local-server mode)
 
 ## Building All E2E Tests
 
 From this directory:
 
 ```bash
-./mvnw clean install
+../mvnw clean install
 ```
 
 ## Running All E2E Tests
 
 ```bash
-./mvnw test
+../mvnw test
 ```
 
 ## Running Specific Test Module
 
 ```bash
 cd tika-grpc
-./mvnw test
+../../mvnw test
 ```
 
 ## Why Standalone?

--- a/tika-e2e-tests/README.md
+++ b/tika-e2e-tests/README.md
@@ -6,7 +6,7 @@ End-to-end integration tests for Apache Tika components.
 
 This module contains standalone end-to-end (E2E) tests for various Apache Tika distribution formats and deployment modes. Unlike unit and integration tests in the main Tika build, these E2E tests validate complete deployment scenarios using Docker containers and real-world test data.
 
-**Note:** This module is intentionally **NOT** included in the main Tika parent POM. It is designed to be built and run independently to avoid slowing down the primary build process.
+**Note:** This module is included in the main Tika build under the `e2e` Maven profile (`-Pe2e`). Run `mvn test -Pe2e` from the repo root to execute these tests.
 
 ## Test Modules
 

--- a/tika-e2e-tests/README.md
+++ b/tika-e2e-tests/README.md
@@ -1,0 +1,59 @@
+# Apache Tika End-to-End Tests
+
+End-to-end integration tests for Apache Tika components.
+
+## Overview
+
+This module contains standalone end-to-end (E2E) tests for various Apache Tika distribution formats and deployment modes. Unlike unit and integration tests in the main Tika build, these E2E tests validate complete deployment scenarios using Docker containers and real-world test data.
+
+**Note:** This module is intentionally **NOT** included in the main Tika parent POM. It is designed to be built and run independently to avoid slowing down the primary build process.
+
+## Test Modules
+
+- **tika-grpc** - E2E tests for tika-grpc server
+
+## Prerequisites
+
+- Java 17 or later
+- Maven 3.6 or later
+- Docker and Docker Compose
+- Internet connection (for downloading test documents)
+
+## Building All E2E Tests
+
+From this directory:
+
+```bash
+./mvnw clean install
+```
+
+## Running All E2E Tests
+
+```bash
+./mvnw test
+```
+
+## Running Specific Test Module
+
+```bash
+cd tika-grpc
+./mvnw test
+```
+
+## Why Standalone?
+
+The E2E tests are kept separate from the main build because they:
+
+- Have different build requirements (Docker, Testcontainers)
+- Take significantly longer to run than unit tests
+- Require external resources (test corpora, Docker images)
+- Can be run independently in CI/CD pipelines
+- Allow developers to run them selectively
+
+## Integration with CI/CD
+
+These tests can be integrated into the release pipeline as a separate step.
+
+## License
+
+Licensed under the Apache License, Version 2.0. See the main Tika LICENSE.txt file for details.

--- a/tika-e2e-tests/README.md
+++ b/tika-e2e-tests/README.md
@@ -16,7 +16,7 @@ This module contains standalone end-to-end (E2E) tests for various Apache Tika d
 
 - Java 17 or later
 - Maven 3.6 or later
-- Internet connection (for downloading test documents)
+- Internet connection (only when running tests that download external corpora, e.g. with `-Dtika.e2e.useGovdocs=true`)
 - Docker and Docker Compose (only required for Docker Compose mode; not needed for the default local-server mode)
 
 ## Building All E2E Tests

--- a/tika-e2e-tests/pom.xml
+++ b/tika-e2e-tests/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../tika-parent/pom.xml</relativePath>
     </parent>
 

--- a/tika-e2e-tests/pom.xml
+++ b/tika-e2e-tests/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-parent</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../tika-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>tika-e2e-tests</artifactId>
+    <packaging>pom</packaging>
+    <name>Apache Tika End-to-End Tests</name>
+    <description>End-to-end integration tests for Apache Tika components</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Tika version -->
+        <tika.version>4.0.0-SNAPSHOT</tika.version>
+
+        <!-- Test dependencies -->
+        <junit.version>5.11.4</junit.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
+
+        <!-- Logging -->
+        <slf4j.version>2.0.16</slf4j.version>
+        <log4j.version>2.25.3</log4j.version>
+
+        <!-- Other -->
+        <lombok.version>1.18.32</lombok.version>
+        <jackson.version>2.18.2</jackson.version>
+    </properties>
+
+    <modules>
+        <module>tika-grpc</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- JUnit 5 -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Testcontainers -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-junit-jupiter</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Logging -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <!-- Jackson for JSON -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <!-- Micronaut version alignment for Ignite 3.x -->
+            <dependency>
+                <groupId>io.micronaut</groupId>
+                <artifactId>micronaut-validation</artifactId>
+                <version>3.10.4</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micronaut</groupId>
+                <artifactId>micronaut-http</artifactId>
+                <version>3.10.4</version>
+            </dependency>
+
+            <!-- Lombok -->
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <optional>true</optional>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                    <configuration>
+                        <release>17</release>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <inputExcludes>
+                        <inputExclude>README.md</inputExclude>
+                        <inputExclude>**/README.md</inputExclude>
+                        <inputExclude>**/target/**</inputExclude>
+                        <inputExclude>**/.idea/**</inputExclude>
+                    </inputExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tika-e2e-tests/pom.xml
+++ b/tika-e2e-tests/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Tika version -->
-        <tika.version>4.0.0-SNAPSHOT</tika.version>
+        <tika.version>${revision}</tika.version>
 
         <!-- Test dependencies -->
         <junit.version>5.11.4</junit.version>

--- a/tika-e2e-tests/pom.xml
+++ b/tika-e2e-tests/pom.xml
@@ -55,7 +55,6 @@
 
         <!-- Other -->
         <lombok.version>1.18.32</lombok.version>
-        <jackson.version>2.18.2</jackson.version>
     </properties>
 
     <modules>

--- a/tika-e2e-tests/tika-grpc/README.md
+++ b/tika-e2e-tests/tika-grpc/README.md
@@ -39,16 +39,16 @@ This test module validates the functionality of Apache Tika gRPC Server by:
 
 ### Test with the full GovDocs1 corpus (opt-in)
 
-By default tests use small committed fixture files. To run against the real GovDocs1 corpus, set `govdocs1.fromIndex` to trigger a download:
+By default tests use small committed fixture files. To run against the real GovDocs1 corpus, pass `-Dtika.e2e.useGovdocs=true` to trigger a download:
 
 ```bash
-../../mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=1
+../../mvnw test -Dtika.e2e.useGovdocs=true
 ```
 
-To test with more documents, increase the range or set `corpus.numDocs`:
+`govdocs1.fromIndex` and `govdocs1.toIndex` control which zip files are downloaded (default: zip 001 only). To fetch a wider range or cap the number of documents parsed:
 
 ```bash
-../../mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=5 -Dcorpus.numDocs=100
+../../mvnw test -Dtika.e2e.useGovdocs=true -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=5 -Dcorpus.numDocs=100
 ```
 
 ## Test Structure

--- a/tika-e2e-tests/tika-grpc/README.md
+++ b/tika-e2e-tests/tika-grpc/README.md
@@ -1,0 +1,144 @@
+# Tika gRPC End-to-End Tests
+
+End-to-end integration tests for Apache Tika gRPC Server using Testcontainers.
+
+## Overview
+
+This test module validates the functionality of Apache Tika gRPC Server by:
+- Starting a tika-grpc Docker container using Docker Compose
+- Loading test documents from the GovDocs1 corpus
+- Testing various fetchers (filesystem, Ignite config store, etc.)
+- Verifying parsing results and metadata extraction
+
+## Prerequisites
+
+- Java 17 or later
+- Maven 3.6 or later
+- Docker and Docker Compose
+- Internet connection (for downloading test documents)
+- Docker image `apache/tika-grpc:local` (see below)
+
+## Building
+
+```bash
+./mvnw clean install
+```
+
+## Running Tests
+
+### Run all tests
+
+```bash
+./mvnw test
+```
+
+### Run specific test
+
+```bash
+./mvnw test -Dtest=FileSystemFetcherTest
+./mvnw test -Dtest=IgniteConfigStoreTest
+```
+
+### Configure test document range
+
+By default, only the first batch of GovDocs1 documents (001.zip) is downloaded. To test with more documents:
+
+```bash
+./mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=5
+```
+
+This will download and test with batches 001.zip through 005.zip.
+
+### Limit number of documents to process
+
+To limit the test to only process a specific number of documents (useful for quick testing):
+
+```bash
+./mvnw test -Dcorpa.numdocs=10
+```
+
+This will process only the first 10 documents instead of all documents in the corpus. Omit this parameter or set to -1 to process all documents.
+
+**Examples:**
+
+```bash
+# Test with just 5 documents
+./mvnw test -Dcorpa.numdocs=5
+
+# Test with 100 documents from multiple batches
+./mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=2 -Dcorpa.numdocs=100
+
+# Test all documents (default behavior)
+./mvnw test
+```
+
+## Test Structure
+
+- `ExternalTestBase.java` - Base class for all tests
+  - Manages Docker Compose containers
+  - Downloads and extracts GovDocs1 test corpus
+  - Provides utility methods for gRPC communication
+
+- `filesystem/FileSystemFetcherTest.java` - Tests for filesystem fetcher
+  - Tests fetching and parsing files from local filesystem
+  - Verifies all documents are processed
+
+- `ignite/IgniteConfigStoreTest.java` - Tests for Ignite config store
+  - Tests configuration storage and retrieval via Ignite
+  - Validates config persistence
+
+## GovDocs1 Test Corpus
+
+The tests use the [GovDocs1](https://digitalcorpora.org/corpora/govdocs) corpus, a collection of real-world documents from US government websites. Documents are automatically downloaded and cached in `target/govdocs1/`.
+
+## Docker Image
+
+The tests expect a Docker image named `apache/tika-grpc:local`. Build one using:
+
+```bash
+cd /path/to/tika-docker/tika-grpc
+./build-from-branch.sh -l /path/to/tika -t local
+```
+
+Or build from the main Tika repository and tag it:
+
+```bash
+cd /path/to/tika
+./mvnw clean install -DskipTests
+cd tika-grpc
+# Follow tika-grpc Docker build instructions
+```
+
+## Sample Configurations
+
+The `sample-configs/` directory contains example Tika configuration files for various scenarios:
+- `customocr/` - Custom OCR configurations
+- `grobid/` - GROBID PDF parsing configuration
+- `ignite/` - Ignite config store examples
+- `ner/` - Named Entity Recognition configuration
+- `vision/` - Computer vision and image analysis configs
+
+## Logs
+
+Test logs are output to console. Docker container logs are also captured and displayed.
+
+## Troubleshooting
+
+**Container fails to start:**
+- Ensure Docker is running
+- Check that port 50052 is available
+- Verify the `apache/tika-grpc:local` image exists: `docker images | grep tika-grpc`
+
+**Tests timeout:**
+- Increase timeout in test class
+- Check Docker container logs for errors
+- Ensure sufficient memory is available to Docker
+
+**Download failures:**
+- Check internet connection
+- GovDocs1 files are downloaded from digitalcorpora.org
+- Downloaded files are cached in `target/govdocs1/`
+
+## License
+
+Licensed under the Apache License, Version 2.0. See the main Tika LICENSE.txt file for details.

--- a/tika-e2e-tests/tika-grpc/README.md
+++ b/tika-e2e-tests/tika-grpc/README.md
@@ -45,10 +45,10 @@ By default tests use small committed fixture files. To run against the real GovD
 ../../mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=1
 ```
 
-To test with more documents, increase the range or set `corpa.numdocs`:
+To test with more documents, increase the range or set `corpus.numDocs`:
 
 ```bash
-../../mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=5 -Dcorpa.numdocs=100
+../../mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=5 -Dcorpus.numDocs=100
 ```
 
 ## Test Structure

--- a/tika-e2e-tests/tika-grpc/README.md
+++ b/tika-e2e-tests/tika-grpc/README.md
@@ -1,12 +1,12 @@
 # Tika gRPC End-to-End Tests
 
-End-to-end integration tests for Apache Tika gRPC Server using Testcontainers.
+End-to-end integration tests for Apache Tika gRPC Server.
 
 ## Overview
 
 This test module validates the functionality of Apache Tika gRPC Server by:
-- Starting a tika-grpc Docker container using Docker Compose
-- Loading test documents from the GovDocs1 corpus
+- Starting a local tika-grpc server using the Maven exec plugin (default)
+- Parsing small committed test fixture documents
 - Testing various fetchers (filesystem, Ignite config store, etc.)
 - Verifying parsing results and metadata extraction
 
@@ -14,130 +14,70 @@ This test module validates the functionality of Apache Tika gRPC Server by:
 
 - Java 17 or later
 - Maven 3.6 or later
-- Docker and Docker Compose
-- Internet connection (for downloading test documents)
-- Docker image `apache/tika-grpc:local` (see below)
+- Docker and Docker Compose (only required when using `tika.e2e.useLocalServer=false`)
 
 ## Building
 
 ```bash
-./mvnw clean install
+../../mvnw clean install
 ```
 
 ## Running Tests
 
-### Run all tests
+### Run all tests (default: local server mode, committed fixtures)
 
 ```bash
-./mvnw test
+../../mvnw test
 ```
 
 ### Run specific test
 
 ```bash
-./mvnw test -Dtest=FileSystemFetcherTest
-./mvnw test -Dtest=IgniteConfigStoreTest
+../../mvnw test -Dtest=FileSystemFetcherTest
+../../mvnw test -Dtest=IgniteConfigStoreTest
 ```
 
-### Configure test document range
+### Test with the full GovDocs1 corpus (opt-in)
 
-By default, only the first batch of GovDocs1 documents (001.zip) is downloaded. To test with more documents:
+By default tests use small committed fixture files. To run against the real GovDocs1 corpus, set `govdocs1.fromIndex` to trigger a download:
 
 ```bash
-./mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=5
+../../mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=1
 ```
 
-This will download and test with batches 001.zip through 005.zip.
-
-### Limit number of documents to process
-
-To limit the test to only process a specific number of documents (useful for quick testing):
+To test with more documents, increase the range or set `corpa.numdocs`:
 
 ```bash
-./mvnw test -Dcorpa.numdocs=10
-```
-
-This will process only the first 10 documents instead of all documents in the corpus. Omit this parameter or set to -1 to process all documents.
-
-**Examples:**
-
-```bash
-# Test with just 5 documents
-./mvnw test -Dcorpa.numdocs=5
-
-# Test with 100 documents from multiple batches
-./mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=2 -Dcorpa.numdocs=100
-
-# Test all documents (default behavior)
-./mvnw test
+../../mvnw test -Dgovdocs1.fromIndex=1 -Dgovdocs1.toIndex=5 -Dcorpa.numdocs=100
 ```
 
 ## Test Structure
 
 - `ExternalTestBase.java` - Base class for all tests
-  - Manages Docker Compose containers
-  - Downloads and extracts GovDocs1 test corpus
+  - Manages local server or Docker Compose containers
   - Provides utility methods for gRPC communication
 
 - `filesystem/FileSystemFetcherTest.java` - Tests for filesystem fetcher
   - Tests fetching and parsing files from local filesystem
-  - Verifies all documents are processed
 
 - `ignite/IgniteConfigStoreTest.java` - Tests for Ignite config store
   - Tests configuration storage and retrieval via Ignite
-  - Validates config persistence
 
-## GovDocs1 Test Corpus
+## Docker Mode
 
-The tests use the [GovDocs1](https://digitalcorpora.org/corpora/govdocs) corpus, a collection of real-world documents from US government websites. Documents are automatically downloaded and cached in `target/govdocs1/`.
-
-## Docker Image
-
-The tests expect a Docker image named `apache/tika-grpc:local`. Build one using:
+To run against a Docker Compose deployment instead of a local server:
 
 ```bash
-cd /path/to/tika-docker/tika-grpc
-./build-from-branch.sh -l /path/to/tika -t local
+../../mvnw test -Dtika.e2e.useLocalServer=false -Dtika.docker.compose.file=/path/to/docker-compose.yml
 ```
 
-Or build from the main Tika repository and tag it:
+The Docker image `apache/tika-grpc:local` can be built from the Tika root:
 
 ```bash
 cd /path/to/tika
 ./mvnw clean install -DskipTests
-cd tika-grpc
-# Follow tika-grpc Docker build instructions
+# then follow tika-grpc Docker build instructions
 ```
-
-## Sample Configurations
-
-The `sample-configs/` directory contains example Tika configuration files for various scenarios:
-- `customocr/` - Custom OCR configurations
-- `grobid/` - GROBID PDF parsing configuration
-- `ignite/` - Ignite config store examples
-- `ner/` - Named Entity Recognition configuration
-- `vision/` - Computer vision and image analysis configs
-
-## Logs
-
-Test logs are output to console. Docker container logs are also captured and displayed.
-
-## Troubleshooting
-
-**Container fails to start:**
-- Ensure Docker is running
-- Check that port 50052 is available
-- Verify the `apache/tika-grpc:local` image exists: `docker images | grep tika-grpc`
-
-**Tests timeout:**
-- Increase timeout in test class
-- Check Docker container logs for errors
-- Ensure sufficient memory is available to Docker
-
-**Download failures:**
-- Check internet connection
-- GovDocs1 files are downloaded from digitalcorpora.org
-- Downloaded files are cached in `target/govdocs1/`
 
 ## License
 

--- a/tika-e2e-tests/tika-grpc/pom.xml
+++ b/tika-e2e-tests/tika-grpc/pom.xml
@@ -37,7 +37,8 @@
 
     <properties>
         <!-- Use local server mode by default in CI (faster, no Docker required) -->
-        <!-- Override with -Dtika.e2e.useLocalServer=false to use Docker -->
+        <govdocs1.fromIndex>1</govdocs1.fromIndex>
+        <govdocs1.toIndex>1</govdocs1.toIndex>
         <tika.e2e.useLocalServer>true</tika.e2e.useLocalServer>
         <corpa.numdocs>2</corpa.numdocs>
     </properties>
@@ -136,8 +137,8 @@
                         <include>**/*Test.java</include>
                     </includes>
                     <systemPropertyVariables>
-                        <govdocs1.fromIndex>1</govdocs1.fromIndex>
-                        <govdocs1.toIndex>1</govdocs1.toIndex>
+                        <govdocs1.fromIndex>${govdocs1.fromIndex}</govdocs1.fromIndex>
+                        <govdocs1.toIndex>${govdocs1.toIndex}</govdocs1.toIndex>
                         <tika.e2e.useLocalServer>${tika.e2e.useLocalServer}</tika.e2e.useLocalServer>
                         <corpa.numdocs>${corpa.numdocs}</corpa.numdocs>
                     </systemPropertyVariables>

--- a/tika-e2e-tests/tika-grpc/pom.xml
+++ b/tika-e2e-tests/tika-grpc/pom.xml
@@ -40,7 +40,8 @@
         <govdocs1.fromIndex>1</govdocs1.fromIndex>
         <govdocs1.toIndex>1</govdocs1.toIndex>
         <tika.e2e.useLocalServer>true</tika.e2e.useLocalServer>
-        <corpa.numdocs>2</corpa.numdocs>
+        <tika.e2e.useGovdocs>false</tika.e2e.useGovdocs>
+        <corpus.numDocs>2</corpus.numDocs>
     </properties>
 
     <dependencies>
@@ -140,7 +141,8 @@
                         <govdocs1.fromIndex>${govdocs1.fromIndex}</govdocs1.fromIndex>
                         <govdocs1.toIndex>${govdocs1.toIndex}</govdocs1.toIndex>
                         <tika.e2e.useLocalServer>${tika.e2e.useLocalServer}</tika.e2e.useLocalServer>
-                        <corpa.numdocs>${corpa.numdocs}</corpa.numdocs>
+                        <tika.e2e.useGovdocs>${tika.e2e.useGovdocs}</tika.e2e.useGovdocs>
+                        <corpus.numDocs>${corpus.numDocs}</corpus.numDocs>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -166,6 +168,8 @@
                         <inputExclude>**/README*.md</inputExclude>
                         <inputExclude>src/test/resources/docker-compose*.yml</inputExclude>
                         <inputExclude>src/test/resources/log4j2.xml</inputExclude>
+                        <inputExclude>src/test/resources/tika-config*.json</inputExclude>
+                        <inputExclude>src/test/resources/test-fixtures/**</inputExclude>
                     </inputExcludes>
                 </configuration>
             </plugin>

--- a/tika-e2e-tests/tika-grpc/pom.xml
+++ b/tika-e2e-tests/tika-grpc/pom.xml
@@ -27,7 +27,8 @@
     <parent>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-e2e-tests</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>tika-grpc-e2e-test</artifactId>

--- a/tika-e2e-tests/tika-grpc/pom.xml
+++ b/tika-e2e-tests/tika-grpc/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-e2e-tests</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tika-grpc-e2e-test</artifactId>
+    <name>Apache Tika gRPC End-to-End Tests</name>
+    <description>End-to-end tests for Apache Tika gRPC Server using test containers</description>
+
+    <properties>
+        <!-- Use local server mode by default in CI (faster, no Docker required) -->
+        <!-- Override with -Dtika.e2e.useLocalServer=false to use Docker -->
+        <tika.e2e.useLocalServer>true</tika.e2e.useLocalServer>
+        <corpa.numdocs>2</corpa.numdocs>
+    </properties>
+
+    <dependencies>
+        <!-- Tika gRPC -->
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-grpc</artifactId>
+            <version>${tika.version}</version>
+        </dependency>
+
+        <!-- Tika Fetchers -->
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-pipes-file-system</artifactId>
+            <version>${tika.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-pipes-core</artifactId>
+            <version>${tika.version}</version>
+        </dependency>
+
+        <!-- Jackson for JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        
+        <!-- Awaitility for robust waiting -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <systemPropertyVariables>
+                        <govdocs1.fromIndex>1</govdocs1.fromIndex>
+                        <govdocs1.toIndex>1</govdocs1.toIndex>
+                        <tika.e2e.useLocalServer>${tika.e2e.useLocalServer}</tika.e2e.useLocalServer>
+                        <corpa.numdocs>${corpa.numdocs}</corpa.numdocs>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <!-- Disable dependency convergence check for e2e tests -->
+            <!-- Ignite 3.x brings many transitive dependencies that conflict -->
+            <!-- but tests work fine in practice -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Configure RAT to exclude files that don't need license headers -->
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <inputExcludes>
+                        <inputExclude>**/README*.md</inputExclude>
+                        <inputExclude>src/test/resources/docker-compose*.yml</inputExclude>
+                        <inputExclude>src/test/resources/log4j2.xml</inputExclude>
+                    </inputExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tika-e2e-tests/tika-grpc/sample-configs/ignite/tika-config-ignite.json
+++ b/tika-e2e-tests/tika-grpc/sample-configs/ignite/tika-config-ignite.json
@@ -1,0 +1,24 @@
+{
+  "pipes": {
+    "configStoreType": "ignite",
+    "configStoreParams": "{\n      \"tableName\": \"tika-config-store\",\n      \"igniteInstanceName\": \"TikaIgniteCluster\",\n      \"replicas\": 2,\n      \"partitions\": 10,\n      \"autoClose\": true\n    }"
+  },
+  "fetchers": [
+    {
+      "id": "fs",
+      "name": "file-system",
+      "params": {
+        "basePath": "/data/input"
+      }
+    }
+  ],
+  "emitters": [
+    {
+      "id": "fs",
+      "name": "file-system",
+      "params": {
+        "basePath": "/data/output"
+      }
+    }
+  ]
+}

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -57,10 +57,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.apache.tika.FetchAndParseReply;
 
-/**
- * Base class for Tika gRPC end-to-end tests.
- * Can run with either local server (default in CI) or Docker Compose.
- */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Testcontainers
 @Slf4j
@@ -129,7 +125,6 @@ public abstract class ExternalTestBase {
         
         localGrpcProcess = pb.start();
         
-        // Start thread to consume output
         Thread logThread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(localGrpcProcess.getInputStream(), StandardCharsets.UTF_8))) {
@@ -144,7 +139,6 @@ public abstract class ExternalTestBase {
         logThread.setDaemon(true);
         logThread.start();
         
-        // Wait for server to be ready
         waitForServerReady();
         
         log.info("Local tika-grpc server started successfully on port {}", GRPC_PORT);
@@ -178,7 +172,6 @@ public abstract class ExternalTestBase {
                     .build();
                 
                 try {
-                    // Try a simple connection
                     testChannel.getState(true);
                     TimeUnit.MILLISECONDS.sleep(100);
                     if (testChannel.getState(false).toString().contains("READY")) {
@@ -190,7 +183,6 @@ public abstract class ExternalTestBase {
                     testChannel.awaitTermination(1, TimeUnit.SECONDS);
                 }
             } catch (Exception e) {
-                // Server not ready yet
             }
             TimeUnit.SECONDS.sleep(1);
         }
@@ -318,7 +310,6 @@ public abstract class ExternalTestBase {
         }
         
         Assertions.assertNotEquals(0, successes.size(), "Should have some successful fetches");
-        // Note: errors.size() can be 0 if all files parse successfully
         log.info("Processed {} files: {} successes, {} errors", allFetchKeys.size(), successes.size(), errors.size());
         Assertions.assertEquals(keysFromGovdocs1, allFetchKeys, () -> {
             Set<String> missing = new HashSet<>(keysFromGovdocs1);

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.pipes;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.apache.tika.FetchAndParseReply;
+
+/**
+ * Base class for Tika gRPC end-to-end tests.
+ * Can run with either local server (default in CI) or Docker Compose.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Testcontainers
+@Slf4j
+@Tag("E2ETest")
+public abstract class ExternalTestBase {
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final int MAX_STARTUP_TIMEOUT = 120;
+    public static final String GOV_DOCS_FOLDER = "/tika/govdocs1";
+    public static final File TEST_FOLDER = new File("target", "govdocs1");
+    public static final int GOV_DOCS_FROM_IDX = Integer.parseInt(System.getProperty("govdocs1.fromIndex", "1"));
+    public static final int GOV_DOCS_TO_IDX = Integer.parseInt(System.getProperty("govdocs1.toIndex", "1"));
+    public static final String DIGITAL_CORPORA_ZIP_FILES_URL = "https://corp.digitalcorpora.org/corpora/files/govdocs1/zipfiles";
+    private static final boolean USE_LOCAL_SERVER = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "false"));
+    private static final int GRPC_PORT = Integer.parseInt(System.getProperty("tika.e2e.grpcPort", "50052"));
+    
+    public static DockerComposeContainer<?> composeContainer;
+    private static Process localGrpcProcess;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        loadGovdocs1();
+        
+        if (USE_LOCAL_SERVER) {
+            startLocalGrpcServer();
+        } else {
+            startDockerGrpcServer();
+        }
+    }
+    
+    private static void startLocalGrpcServer() throws Exception {
+        log.info("Starting local tika-grpc server using Maven exec");
+        
+        Path tikaGrpcDir = findTikaGrpcDirectory();
+        Path configFile = Path.of("src/test/resources/tika-config.json").toAbsolutePath();
+        
+        if (!Files.exists(configFile)) {
+            throw new IllegalStateException("Config file not found: " + configFile);
+        }
+        
+        log.info("Using tika-grpc from: {}", tikaGrpcDir);
+        log.info("Using config file: {}", configFile);
+        
+        String javaHome = System.getProperty("java.home");
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        String javaCmd = javaHome + (isWindows ? "\\bin\\java.exe" : "/bin/java");
+        String mvnCmd = isWindows ? "mvn.cmd" : "mvn";
+        
+        ProcessBuilder pb = new ProcessBuilder(
+            mvnCmd,
+            "exec:exec",
+            "-Dexec.executable=" + javaCmd,
+            "-Dexec.args=" +
+                "--add-opens=java.base/java.lang=ALL-UNNAMED " +
+                "--add-opens=java.base/java.nio=ALL-UNNAMED " +
+                "--add-opens=java.base/java.util=ALL-UNNAMED " +
+                "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED " +
+                "-classpath %classpath " +
+                "org.apache.tika.pipes.grpc.TikaGrpcServer " +
+                "-c " + configFile + " " +
+                "-p " + GRPC_PORT
+        );
+        
+        pb.directory(tikaGrpcDir.toFile());
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+        
+        localGrpcProcess = pb.start();
+        
+        // Start thread to consume output
+        Thread logThread = new Thread(() -> {
+            try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                    new java.io.InputStreamReader(localGrpcProcess.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    log.info("tika-grpc: {}", line);
+                }
+            } catch (IOException e) {
+                log.error("Error reading server output", e);
+            }
+        });
+        logThread.setDaemon(true);
+        logThread.start();
+        
+        // Wait for server to be ready
+        waitForServerReady();
+        
+        log.info("Local tika-grpc server started successfully on port {}", GRPC_PORT);
+    }
+    
+    private static Path findTikaGrpcDirectory() {
+        Path currentDir = Path.of("").toAbsolutePath();
+        Path tikaRootDir = currentDir;
+        
+        while (tikaRootDir != null && 
+               !(Files.exists(tikaRootDir.resolve("tika-grpc")) && 
+                 Files.exists(tikaRootDir.resolve("tika-e2e-tests")))) {
+            tikaRootDir = tikaRootDir.getParent();
+        }
+        
+        if (tikaRootDir == null) {
+            throw new IllegalStateException("Cannot find tika root directory. " +
+                "Current dir: " + currentDir);
+        }
+        
+        return tikaRootDir.resolve("tika-grpc");
+    }
+    
+    private static void waitForServerReady() throws Exception {
+        int maxAttempts = 60;
+        for (int i = 0; i < maxAttempts; i++) {
+            try {
+                ManagedChannel testChannel = ManagedChannelBuilder
+                    .forAddress("localhost", GRPC_PORT)
+                    .usePlaintext()
+                    .build();
+                
+                try {
+                    // Try a simple connection
+                    testChannel.getState(true);
+                    TimeUnit.MILLISECONDS.sleep(100);
+                    if (testChannel.getState(false).toString().contains("READY")) {
+                        log.info("gRPC server is ready!");
+                        return;
+                    }
+                } finally {
+                    testChannel.shutdown();
+                    testChannel.awaitTermination(1, TimeUnit.SECONDS);
+                }
+            } catch (Exception e) {
+                // Server not ready yet
+            }
+            TimeUnit.SECONDS.sleep(1);
+        }
+        
+        if (localGrpcProcess != null && localGrpcProcess.isAlive()) {
+            localGrpcProcess.destroyForcibly();
+        }
+        throw new RuntimeException("Local gRPC server failed to start within timeout");
+    }
+    
+    private static void startDockerGrpcServer() {
+        log.info("Starting Docker Compose tika-grpc server");
+        
+        composeContainer = new DockerComposeContainer<>(
+                new File("src/test/resources/docker-compose.yml"))
+                .withEnv("HOST_GOVDOCS1_DIR", TEST_FOLDER.getAbsolutePath())
+                .withStartupTimeout(Duration.of(MAX_STARTUP_TIMEOUT, ChronoUnit.SECONDS))
+                .withExposedService("tika-grpc", 50052, 
+                    Wait.forLogMessage(".*Server started.*\\n", 1))
+                .withLogConsumer("tika-grpc", new Slf4jLogConsumer(log));
+        
+        composeContainer.start();
+        
+        log.info("Docker Compose containers started successfully");
+    }
+
+    private static void loadGovdocs1() throws IOException, InterruptedException {
+        int retries = 3;
+        int attempt = 0;
+        while (true) {
+            try {
+                downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
+                break;
+            } catch (IOException e) {
+                attempt++;
+                if (attempt >= retries) {
+                    throw e;
+                }
+                log.warn("Download attempt {} failed, retrying in 10 seconds...", attempt, e);
+                TimeUnit.SECONDS.sleep(10);
+            }
+        }
+    }
+
+    @AfterAll
+    void close() {
+        if (USE_LOCAL_SERVER && localGrpcProcess != null) {
+            log.info("Stopping local gRPC server");
+            localGrpcProcess.destroy();
+            try {
+                if (!localGrpcProcess.waitFor(10, TimeUnit.SECONDS)) {
+                    localGrpcProcess.destroyForcibly();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                localGrpcProcess.destroyForcibly();
+            }
+        } else if (composeContainer != null) {
+            composeContainer.close();
+        }
+    }
+
+    public static void downloadAndUnzipGovdocs1(int fromIndex, int toIndex) throws IOException {
+        Path targetDir = TEST_FOLDER.toPath();
+        Files.createDirectories(targetDir);
+
+        for (int i = fromIndex; i <= toIndex; i++) {
+            String zipName = String.format(java.util.Locale.ROOT, "%03d.zip", i);
+            String url = DIGITAL_CORPORA_ZIP_FILES_URL + "/" + zipName;
+            Path zipPath = targetDir.resolve(zipName);
+            
+            if (Files.exists(zipPath)) {
+                log.info("{} already exists, skipping download", zipName);
+                continue;
+            }
+
+            log.info("Downloading {} from {}...", zipName, url);
+            try (InputStream in = new URL(url).openStream()) {
+                Files.copy(in, zipPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            log.info("Unzipping {}...", zipName);
+            try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath.toFile()))) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    Path outPath = targetDir.resolve(entry.getName());
+                    if (entry.isDirectory()) {
+                        Files.createDirectories(outPath);
+                    } else {
+                        Files.createDirectories(outPath.getParent());
+                        try (OutputStream out = Files.newOutputStream(outPath)) {
+                            zis.transferTo(out);
+                        }
+                    }
+                    zis.closeEntry();
+                }
+            }
+        }
+        
+        log.info("Finished downloading and extracting govdocs1 files");
+    }
+
+    public static void assertAllFilesFetched(Path baseDir, List<FetchAndParseReply> successes, 
+                                            List<FetchAndParseReply> errors) {
+        Set<String> allFetchKeys = new HashSet<>();
+        for (FetchAndParseReply reply : successes) {
+            allFetchKeys.add(reply.getFetchKey());
+        }
+        for (FetchAndParseReply reply : errors) {
+            allFetchKeys.add(reply.getFetchKey());
+        }
+        
+        Set<String> keysFromGovdocs1 = new HashSet<>();
+        try (Stream<Path> paths = Files.walk(baseDir)) {
+            paths.filter(Files::isRegularFile)
+                    .forEach(file -> {
+                        String relPath = baseDir.relativize(file).toString();
+                        if (Pattern.compile("\\d{3}\\.zip").matcher(relPath).find()) {
+                            return;
+                        }
+                        keysFromGovdocs1.add(relPath);
+                    });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        
+        Assertions.assertNotEquals(0, successes.size(), "Should have some successful fetches");
+        // Note: errors.size() can be 0 if all files parse successfully
+        log.info("Processed {} files: {} successes, {} errors", allFetchKeys.size(), successes.size(), errors.size());
+        Assertions.assertEquals(keysFromGovdocs1, allFetchKeys, () -> {
+            Set<String> missing = new HashSet<>(keysFromGovdocs1);
+            missing.removeAll(allFetchKeys);
+            return "Missing fetch keys: " + missing;
+        });
+    }
+
+    public static ManagedChannel getManagedChannel() {
+        if (USE_LOCAL_SERVER) {
+            return ManagedChannelBuilder
+                    .forAddress("localhost", GRPC_PORT)
+                    .usePlaintext()
+                    .executor(Executors.newCachedThreadPool())
+                    .maxInboundMessageSize(160 * 1024 * 1024)
+                    .build();
+        } else {
+            return ManagedChannelBuilder
+                    .forAddress(composeContainer.getServiceHost("tika-grpc", 50052), 
+                               composeContainer.getServicePort("tika-grpc", 50052))
+                    .usePlaintext()
+                    .executor(Executors.newCachedThreadPool())
+                    .maxInboundMessageSize(160 * 1024 * 1024)
+                    .build();
+        }
+    }
+}

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -68,7 +68,7 @@ public abstract class ExternalTestBase {
     public static final int GOV_DOCS_FROM_IDX = Integer.parseInt(System.getProperty("govdocs1.fromIndex", "1"));
     public static final int GOV_DOCS_TO_IDX = Integer.parseInt(System.getProperty("govdocs1.toIndex", "1"));
     public static final String DIGITAL_CORPORA_ZIP_FILES_URL = "https://corp.digitalcorpora.org/corpora/files/govdocs1/zipfiles";
-    private static final boolean USE_LOCAL_SERVER = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "false"));
+    private static final boolean USE_LOCAL_SERVER = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "true"));
     private static final int GRPC_PORT = Integer.parseInt(System.getProperty("tika.e2e.grpcPort", "50052"));
     
     public static DockerComposeContainer<?> composeContainer;
@@ -114,7 +114,7 @@ public abstract class ExternalTestBase {
                 "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED " +
                 "-classpath %classpath " +
                 "org.apache.tika.pipes.grpc.TikaGrpcServer " +
-                "-c " + configFile + " " +
+                "-c \"" + configFile + "\" " +
                 "-p " + GRPC_PORT
         );
         

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -16,12 +16,15 @@
  */
 package org.apache.tika.pipes;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -29,6 +32,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -100,7 +104,7 @@ public abstract class ExternalTestBase {
         log.info("Using config file: {}", configFile);
         
         String javaHome = System.getProperty("java.home");
-        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
         String javaCmd = javaHome + (isWindows ? "\\bin\\java.exe" : "/bin/java");
         String mvnCmd = isWindows ? "mvn.cmd" : "mvn";
         
@@ -127,8 +131,8 @@ public abstract class ExternalTestBase {
         
         // Start thread to consume output
         Thread logThread = new Thread(() -> {
-            try (java.io.BufferedReader reader = new java.io.BufferedReader(
-                    new java.io.InputStreamReader(localGrpcProcess.getInputStream()))) {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(localGrpcProcess.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     log.info("tika-grpc: {}", line);

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -216,9 +216,9 @@ public abstract class ExternalTestBase {
     }
 
     private static void loadGovdocs1() throws IOException, InterruptedException {
-        if (System.getProperty("govdocs1.fromIndex") != null) {
-            // Opt-in: download the actual GovDocs1 corpus when explicitly requested.
-            // Default CI runs use committed test fixtures instead to avoid network dependency.
+        if (Boolean.parseBoolean(System.getProperty("tika.e2e.useGovdocs", "false"))) {
+            // Opt-in: download the actual GovDocs1 corpus when explicitly requested via -Dtika.e2e.useGovdocs=true.
+            // Default CI runs use committed test fixtures to avoid any network dependency.
             int retries = 3;
             int attempt = 0;
             while (true) {
@@ -239,7 +239,7 @@ public abstract class ExternalTestBase {
         }
     }
 
-    private static void copyTestFixtures() throws IOException {
+    public static void copyTestFixtures() throws IOException {
         Path targetDir = TEST_FOLDER.toPath();
         Files.createDirectories(targetDir);
         String[] fixtures = {"sample.txt", "sample.html", "sample.csv", "sample.xml"};

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -219,21 +219,44 @@ public abstract class ExternalTestBase {
     }
 
     private static void loadGovdocs1() throws IOException, InterruptedException {
-        int retries = 3;
-        int attempt = 0;
-        while (true) {
-            try {
-                downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
-                break;
-            } catch (IOException e) {
-                attempt++;
-                if (attempt >= retries) {
-                    throw e;
+        if (System.getProperty("govdocs1.fromIndex") != null) {
+            // Opt-in: download the actual GovDocs1 corpus when explicitly requested.
+            // Default CI runs use committed test fixtures instead to avoid network dependency.
+            int retries = 3;
+            int attempt = 0;
+            while (true) {
+                try {
+                    downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
+                    break;
+                } catch (IOException e) {
+                    attempt++;
+                    if (attempt >= retries) {
+                        throw e;
+                    }
+                    log.warn("Download attempt {} failed, retrying in 10 seconds...", attempt, e);
+                    TimeUnit.SECONDS.sleep(10);
                 }
-                log.warn("Download attempt {} failed, retrying in 10 seconds...", attempt, e);
-                TimeUnit.SECONDS.sleep(10);
+            }
+        } else {
+            copyTestFixtures();
+        }
+    }
+
+    private static void copyTestFixtures() throws IOException {
+        Path targetDir = TEST_FOLDER.toPath();
+        Files.createDirectories(targetDir);
+        String[] fixtures = {"sample.txt", "sample.html", "sample.csv", "sample.xml"};
+        for (String fixture : fixtures) {
+            URL resource = ExternalTestBase.class.getClassLoader()
+                    .getResource("test-fixtures/" + fixture);
+            if (resource == null) {
+                throw new IllegalStateException("Test fixture not found: test-fixtures/" + fixture);
+            }
+            try (InputStream in = resource.openStream()) {
+                Files.copy(in, targetDir.resolve(fixture), StandardCopyOption.REPLACE_EXISTING);
             }
         }
+        log.info("Copied {} test fixtures to {}", fixtures.length, targetDir);
     }
 
     @AfterAll

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -55,6 +55,8 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.apache.tika.FetchAndParseReply;
+import org.apache.tika.ListFetchersRequest;
+import org.apache.tika.TikaGrpc;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Testcontainers
@@ -164,29 +166,24 @@ public abstract class ExternalTestBase {
     private static void waitForServerReady() throws Exception {
         int maxAttempts = 60;
         for (int i = 0; i < maxAttempts; i++) {
-            try {
-                ManagedChannel testChannel = ManagedChannelBuilder
+            ManagedChannel testChannel = ManagedChannelBuilder
                     .forAddress("localhost", GRPC_PORT)
                     .usePlaintext()
                     .build();
-                
-                try {
-                    testChannel.getState(true);
-                    TimeUnit.MILLISECONDS.sleep(100);
-                    if (testChannel.getState(false).toString().contains("READY")) {
-                        log.info("gRPC server is ready!");
-                        return;
-                    }
-                } finally {
-                    testChannel.shutdown();
-                    testChannel.awaitTermination(1, TimeUnit.SECONDS);
-                }
+            try {
+                TikaGrpc.TikaBlockingStub stub = TikaGrpc.newBlockingStub(testChannel);
+                stub.listFetchers(ListFetchersRequest.newBuilder().build());
+                log.info("gRPC server is ready");
+                return;
             } catch (Exception e) {
-                log.trace("gRPC server not ready yet: {}", e.getMessage());
+                log.trace("gRPC server not ready yet (attempt {}/{}): {}", i + 1, maxAttempts, e.getMessage());
+            } finally {
+                testChannel.shutdown();
+                testChannel.awaitTermination(1, TimeUnit.SECONDS);
             }
             TimeUnit.SECONDS.sleep(1);
         }
-        
+
         if (localGrpcProcess != null && localGrpcProcess.isAlive()) {
             localGrpcProcess.destroyForcibly();
         }

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -34,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -102,7 +101,7 @@ public abstract class ExternalTestBase {
         String javaHome = System.getProperty("java.home");
         boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
         String javaCmd = javaHome + (isWindows ? "\\bin\\java.exe" : "/bin/java");
-        String mvnCmd = isWindows ? "mvn.cmd" : "mvn";
+        String mvnCmd = tikaGrpcDir.getParent().resolve(isWindows ? "mvnw.cmd" : "mvnw").toString();
         
         ProcessBuilder pb = new ProcessBuilder(
             mvnCmd,
@@ -183,6 +182,7 @@ public abstract class ExternalTestBase {
                     testChannel.awaitTermination(1, TimeUnit.SECONDS);
                 }
             } catch (Exception e) {
+                log.trace("gRPC server not ready yet: {}", e.getMessage());
             }
             TimeUnit.SECONDS.sleep(1);
         }
@@ -196,8 +196,17 @@ public abstract class ExternalTestBase {
     private static void startDockerGrpcServer() {
         log.info("Starting Docker Compose tika-grpc server");
         
-        composeContainer = new DockerComposeContainer<>(
-                new File("src/test/resources/docker-compose.yml"))
+        String composeFilePath = System.getProperty("tika.docker.compose.file");
+        if (composeFilePath == null || composeFilePath.isBlank()) {
+            throw new IllegalStateException(
+                    "Docker Compose mode requires system property 'tika.docker.compose.file' " +
+                    "pointing to a valid docker-compose.yml file.");
+        }
+        File composeFile = new File(composeFilePath);
+        if (!composeFile.isFile()) {
+            throw new IllegalStateException("Docker Compose file not found: " + composeFile.getAbsolutePath());
+        }
+        composeContainer = new DockerComposeContainer<>(composeFile)
                 .withEnv("HOST_GOVDOCS1_DIR", TEST_FOLDER.getAbsolutePath())
                 .withStartupTimeout(Duration.of(MAX_STARTUP_TIMEOUT, ChronoUnit.SECONDS))
                 .withExposedService("tika-grpc", 50052, 
@@ -323,15 +332,13 @@ public abstract class ExternalTestBase {
             return ManagedChannelBuilder
                     .forAddress("localhost", GRPC_PORT)
                     .usePlaintext()
-                    .executor(Executors.newCachedThreadPool())
                     .maxInboundMessageSize(160 * 1024 * 1024)
                     .build();
         } else {
             return ManagedChannelBuilder
-                    .forAddress(composeContainer.getServiceHost("tika-grpc", 50052), 
+                    .forAddress(composeContainer.getServiceHost("tika-grpc", 50052),
                                composeContainer.getServicePort("tika-grpc", 50052))
                     .usePlaintext()
-                    .executor(Executors.newCachedThreadPool())
                     .maxInboundMessageSize(160 * 1024 * 1024)
                     .build();
         }

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ExternalTestBase.java
@@ -282,17 +282,15 @@ public abstract class ExternalTestBase {
             String zipName = String.format(java.util.Locale.ROOT, "%03d.zip", i);
             String url = DIGITAL_CORPORA_ZIP_FILES_URL + "/" + zipName;
             Path zipPath = targetDir.resolve(zipName);
-            
+
             if (Files.exists(zipPath)) {
                 log.info("{} already exists, skipping download", zipName);
-                continue;
+            } else {
+                log.info("Downloading {} from {}...", zipName, url);
+                try (InputStream in = new URL(url).openStream()) {
+                    Files.copy(in, zipPath, StandardCopyOption.REPLACE_EXISTING);
+                }
             }
-
-            log.info("Downloading {} from {}...", zipName, url);
-            try (InputStream in = new URL(url).openStream()) {
-                Files.copy(in, zipPath, StandardCopyOption.REPLACE_EXISTING);
-            }
-
             log.info("Unzipping {}...", zipName);
             try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath.toFile()))) {
                 ZipEntry entry;

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
@@ -103,11 +103,12 @@ class FileSystemFetcherTest extends ExternalTestBase {
 
         int maxDocs = Integer.parseInt(System.getProperty("corpus.numDocs", "-1"));
         try (Stream<Path> paths = Files.walk(TEST_FOLDER.toPath())) {
-            Stream<Path> fileStream = paths.filter(Files::isRegularFile);
+            Stream<Path> fileStream = paths
+                    .filter(Files::isRegularFile)
+                    .filter(p -> !p.toString().endsWith(".zip"));
             if (maxDocs > 0) {
                 fileStream = fileStream.limit(maxDocs);
             }
-            
             fileStream.forEach(file -> {
                         try {
                             String relPath = TEST_FOLDER.toPath().relativize(file).toString();

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
@@ -30,6 +30,8 @@ import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.apache.tika.FetchAndParseReply;
 import org.apache.tika.FetchAndParseRequest;
@@ -40,6 +42,7 @@ import org.apache.tika.pipes.ExternalTestBase;
 import org.apache.tika.pipes.fetcher.fs.FileSystemFetcherConfig;
 
 @Slf4j
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "exec:exec classpath exceeds Windows CreateProcess command-line length limit")
 class FileSystemFetcherTest extends ExternalTestBase {
     
     @Test

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
@@ -49,6 +49,7 @@ class FileSystemFetcherTest extends ExternalTestBase {
     void testFileSystemFetcher() throws Exception {
         String fetcherId = "defaultFetcher";
         ManagedChannel channel = getManagedChannel();
+        try {
         TikaGrpc.TikaBlockingStub blockingStub = TikaGrpc.newBlockingStub(channel);
         TikaGrpc.TikaStub tikaStub = TikaGrpc.newStub(channel);
 
@@ -147,5 +148,16 @@ class FileSystemFetcherTest extends ExternalTestBase {
         
         log.info("Test completed successfully - {} successes, {} errors", 
             successes.size(), errors.size());
+        } finally {
+            channel.shutdown();
+            try {
+                if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                    channel.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                channel.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 }

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
@@ -53,7 +53,7 @@ class FileSystemFetcherTest extends ExternalTestBase {
         TikaGrpc.TikaStub tikaStub = TikaGrpc.newStub(channel);
 
         FileSystemFetcherConfig config = new FileSystemFetcherConfig();
-        boolean useLocalServer = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "false"));
+        boolean useLocalServer = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "true"));
         String basePath = useLocalServer ? TEST_FOLDER.getAbsolutePath() : GOV_DOCS_FOLDER;
         config.setBasePath(basePath);
         

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.pipes.filesystem;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.apache.tika.FetchAndParseReply;
+import org.apache.tika.FetchAndParseRequest;
+import org.apache.tika.SaveFetcherReply;
+import org.apache.tika.SaveFetcherRequest;
+import org.apache.tika.TikaGrpc;
+import org.apache.tika.pipes.ExternalTestBase;
+import org.apache.tika.pipes.fetcher.fs.FileSystemFetcherConfig;
+
+@Slf4j
+class FileSystemFetcherTest extends ExternalTestBase {
+    
+    @Test
+    void testFileSystemFetcher() throws Exception {
+        String fetcherId = "defaultFetcher";
+        ManagedChannel channel = getManagedChannel();
+        TikaGrpc.TikaBlockingStub blockingStub = TikaGrpc.newBlockingStub(channel);
+        TikaGrpc.TikaStub tikaStub = TikaGrpc.newStub(channel);
+
+        // Create and save the fetcher dynamically
+        FileSystemFetcherConfig config = new FileSystemFetcherConfig();
+        // Use local path when running in local mode, Docker path otherwise  
+        boolean useLocalServer = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "false"));
+        String basePath = useLocalServer ? TEST_FOLDER.getAbsolutePath() : GOV_DOCS_FOLDER;
+        config.setBasePath(basePath);
+        
+        String configJson = OBJECT_MAPPER.writeValueAsString(config);
+        log.info("Creating fetcher with config (basePath={}): {}", basePath, configJson);
+        
+        SaveFetcherReply saveReply = blockingStub.saveFetcher(SaveFetcherRequest
+                .newBuilder()
+                .setFetcherId(fetcherId)
+                .setFetcherClass("org.apache.tika.pipes.fetcher.fs.FileSystemFetcher")
+                .setFetcherConfigJson(configJson)
+                .build());
+        
+        log.info("Fetcher created: {}", saveReply.getFetcherId());
+
+        List<FetchAndParseReply> successes = Collections.synchronizedList(new ArrayList<>());
+        List<FetchAndParseReply> errors = Collections.synchronizedList(new ArrayList<>());
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        StreamObserver<FetchAndParseRequest>
+                requestStreamObserver = tikaStub.fetchAndParseBiDirectionalStreaming(new StreamObserver<>() {
+            @Override
+            public void onNext(FetchAndParseReply fetchAndParseReply) {
+                log.debug("Reply from fetch-and-parse - key={}, status={}", 
+                    fetchAndParseReply.getFetchKey(), fetchAndParseReply.getStatus());
+                if ("FETCH_AND_PARSE_EXCEPTION".equals(fetchAndParseReply.getStatus())) {
+                    errors.add(fetchAndParseReply);
+                } else {
+                    successes.add(fetchAndParseReply);
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                log.error("Received an error", throwable);
+                Assertions.fail(throwable);
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                log.info("Finished streaming fetch and parse replies");
+                countDownLatch.countDown();
+            }
+        });
+
+        // Submit all files for parsing
+        int maxDocs = Integer.parseInt(System.getProperty("corpa.numdocs", "-1"));
+        log.info("Document limit: {}", maxDocs == -1 ? "unlimited" : maxDocs);
+        
+        try (Stream<Path> paths = Files.walk(TEST_FOLDER.toPath())) {
+            Stream<Path> fileStream = paths.filter(Files::isRegularFile);
+            
+            // Limit number of documents if specified
+            if (maxDocs > 0) {
+                fileStream = fileStream.limit(maxDocs);
+            }
+            
+            fileStream.forEach(file -> {
+                        try {
+                            String relPath = TEST_FOLDER.toPath().relativize(file).toString();
+                            requestStreamObserver.onNext(FetchAndParseRequest
+                                    .newBuilder()
+                                    .setFetcherId(fetcherId)
+                                    .setFetchKey(relPath)
+                                    .build());
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+        log.info("Done submitting files to fetcher {}", fetcherId);
+
+        requestStreamObserver.onCompleted();
+
+        // Wait for all parsing to complete
+        try {
+            if (!countDownLatch.await(3, TimeUnit.MINUTES)) {
+                log.error("Timed out waiting for parse to complete");
+                Assertions.fail("Timed out waiting for parsing to complete");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assertions.fail("Interrupted while waiting for parsing to complete");
+        }
+        
+        // Verify all files were processed (unless we limited the number)
+        if (maxDocs == -1) {
+            assertAllFilesFetched(TEST_FOLDER.toPath(), successes, errors);
+        } else {
+            int totalProcessed = successes.size() + errors.size();
+            log.info("Processed {} documents (limit was {})", totalProcessed, maxDocs);
+            Assertions.assertTrue(totalProcessed <= maxDocs, 
+                "Should not process more than " + maxDocs + " documents");
+            Assertions.assertTrue(totalProcessed > 0, 
+                "Should have processed at least one document");
+        }
+        
+        log.info("Test completed successfully - {} successes, {} errors", 
+            successes.size(), errors.size());
+    }
+}

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
@@ -101,7 +101,7 @@ class FileSystemFetcherTest extends ExternalTestBase {
             }
         });
 
-        int maxDocs = Integer.parseInt(System.getProperty("corpa.numdocs", "-1"));
+        int maxDocs = Integer.parseInt(System.getProperty("corpus.numDocs", "-1"));
         try (Stream<Path> paths = Files.walk(TEST_FOLDER.toPath())) {
             Stream<Path> fileStream = paths.filter(Files::isRegularFile);
             if (maxDocs > 0) {

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/filesystem/FileSystemFetcherTest.java
@@ -52,9 +52,7 @@ class FileSystemFetcherTest extends ExternalTestBase {
         TikaGrpc.TikaBlockingStub blockingStub = TikaGrpc.newBlockingStub(channel);
         TikaGrpc.TikaStub tikaStub = TikaGrpc.newStub(channel);
 
-        // Create and save the fetcher dynamically
         FileSystemFetcherConfig config = new FileSystemFetcherConfig();
-        // Use local path when running in local mode, Docker path otherwise  
         boolean useLocalServer = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "false"));
         String basePath = useLocalServer ? TEST_FOLDER.getAbsolutePath() : GOV_DOCS_FOLDER;
         config.setBasePath(basePath);
@@ -102,14 +100,9 @@ class FileSystemFetcherTest extends ExternalTestBase {
             }
         });
 
-        // Submit all files for parsing
         int maxDocs = Integer.parseInt(System.getProperty("corpa.numdocs", "-1"));
-        log.info("Document limit: {}", maxDocs == -1 ? "unlimited" : maxDocs);
-        
         try (Stream<Path> paths = Files.walk(TEST_FOLDER.toPath())) {
             Stream<Path> fileStream = paths.filter(Files::isRegularFile);
-            
-            // Limit number of documents if specified
             if (maxDocs > 0) {
                 fileStream = fileStream.limit(maxDocs);
             }
@@ -131,7 +124,6 @@ class FileSystemFetcherTest extends ExternalTestBase {
 
         requestStreamObserver.onCompleted();
 
-        // Wait for all parsing to complete
         try {
             if (!countDownLatch.await(3, TimeUnit.MINUTES)) {
                 log.error("Timed out waiting for parse to complete");
@@ -142,7 +134,6 @@ class FileSystemFetcherTest extends ExternalTestBase {
             Assertions.fail("Interrupted while waiting for parsing to complete");
         }
         
-        // Verify all files were processed (unless we limited the number)
         if (maxDocs == -1) {
             assertAllFilesFetched(TEST_FOLDER.toPath(), successes, errors);
         } else {

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -66,7 +66,7 @@ import org.apache.tika.pipes.fetcher.fs.FileSystemFetcherConfig;
 @Testcontainers
 @Slf4j
 @Tag("E2ETest")
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Maven not on PATH and Docker/Testcontainers not supported on Windows CI")
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows classpath length limit (CreateProcess error=206) exceeded by exec:exec with full Tika classpath")
 class IgniteConfigStoreTest {
     
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -75,7 +75,7 @@ class IgniteConfigStoreTest {
     private static final int GOV_DOCS_FROM_IDX = Integer.parseInt(System.getProperty("govdocs1.fromIndex", "1"));
     private static final int GOV_DOCS_TO_IDX = Integer.parseInt(System.getProperty("govdocs1.toIndex", "1"));
     private static final String DIGITAL_CORPORA_ZIP_FILES_URL = "https://corp.digitalcorpora.org/corpora/files/govdocs1/zipfiles";
-    private static final boolean USE_LOCAL_SERVER = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "false"));
+    private static final boolean USE_LOCAL_SERVER = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "true"));
     private static final int GRPC_PORT = Integer.parseInt(System.getProperty("tika.e2e.grpcPort", "50052"));
     
     private static DockerComposeContainer<?> igniteComposeContainer;

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -166,10 +166,10 @@ class IgniteConfigStoreTest {
                 "--add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED " +
                 "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED " +
                 "-Dio.netty.tryReflectionSetAccessible=true " +
-                "-Dignite.work.dir=" + tikaGrpcDir.resolve("target/ignite-work") + " " +
+                "-Dignite.work.dir=\"" + tikaGrpcDir.resolve("target/ignite-work") + "\" " +
                 "-classpath %classpath " +
                 "org.apache.tika.pipes.grpc.TikaGrpcServer " +
-                "-c " + configFile + " " +
+                "-c \"" + configFile + "\" " +
                 "-p " + GRPC_PORT
         );
         

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -82,7 +82,7 @@ class IgniteConfigStoreTest {
             }
         }
         
-        if (!TEST_FOLDER.exists() || TEST_FOLDER.listFiles().length == 0) {
+        if (!hasExtractedFiles(TEST_FOLDER)) {
             if (Boolean.parseBoolean(System.getProperty("tika.e2e.useGovdocs", "false"))) {
                 ExternalTestBase.downloadAndUnzipGovdocs1(ExternalTestBase.GOV_DOCS_FROM_IDX, ExternalTestBase.GOV_DOCS_TO_IDX);
             } else {
@@ -97,6 +97,15 @@ class IgniteConfigStoreTest {
         }
     }
     
+    /** Returns true only if the folder contains at least one non-zip extracted file. */
+    private static boolean hasExtractedFiles(File folder) {
+        if (!folder.exists()) {
+            return false;
+        }
+        File[] files = folder.listFiles(f -> f.isFile() && !f.getName().endsWith(".zip"));
+        return files != null && files.length > 0;
+    }
+
     private static void startLocalGrpcServer() throws Exception {
         log.info("Starting local tika-grpc server using Maven");
         

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -441,14 +441,14 @@ class IgniteConfigStoreTest {
             log.info("Document limit: {}", maxDocs == -1 ? "unlimited" : maxDocs);
             
             try (Stream<Path> paths = Files.walk(TEST_FOLDER.toPath())) {
-                Stream<Path> fileStream = paths.filter(Files::isRegularFile);
+                Stream<Path> fileStream = paths
+                        .filter(Files::isRegularFile)
+                        .filter(p -> !p.getFileName().toString()
+                                .toLowerCase(Locale.ROOT)
+                                .endsWith(".zip"));
                 
                 if (maxDocs > 0) {
                     fileStream = fileStream.limit(maxDocs);
-                }
-                
-                fileStream.forEach(file -> {
-                    try {
                         String relPath = TEST_FOLDER.toPath().relativize(file).toString();
                         requestStreamObserver.onNext(FetchAndParseRequest
                                 .newBuilder()

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -30,8 +30,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
@@ -140,10 +140,12 @@ class IgniteConfigStoreTest {
         
         // Use mvn exec:exec to run as external process (not exec:java which breaks ServiceLoader)
         String javaHome = System.getProperty("java.home");
-        String javaCmd = javaHome + "/bin/java";
+        boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+        String javaCmd = javaHome + (isWindows ? "\\bin\\java.exe" : "/bin/java");
+        String mvnCmd = tikaRootDir.resolve(isWindows ? "mvnw.cmd" : "mvnw").toString();
         
         ProcessBuilder pb = new ProcessBuilder(
-            "mvn",
+            mvnCmd,
             "exec:exec",
             "-Dexec.executable=" + javaCmd,
             "-Dexec.args=" +
@@ -272,19 +274,24 @@ class IgniteConfigStoreTest {
     
     
     private static void startDockerGrpcServer() {
-        log.info("Starting Docker Compose tika-grpc server");
-        
-        igniteComposeContainer = new DockerComposeContainer<>(
-                new File("src/test/resources/docker-compose-ignite.yml"))
+        String composeFilePath = System.getProperty("tika.docker.compose.ignite.file");
+        if (composeFilePath == null || composeFilePath.isBlank()) {
+            throw new IllegalStateException(
+                    "Docker Compose mode requires system property 'tika.docker.compose.ignite.file' " +
+                    "pointing to a valid docker-compose-ignite.yml file.");
+        }
+        File composeFile = new File(composeFilePath);
+        if (!composeFile.isFile()) {
+            throw new IllegalStateException("Docker Compose file not found: " + composeFile.getAbsolutePath());
+        }
+        igniteComposeContainer = new DockerComposeContainer<>(composeFile)
                 .withEnv("HOST_GOVDOCS1_DIR", TEST_FOLDER.getAbsolutePath())
                 .withStartupTimeout(Duration.of(MAX_STARTUP_TIMEOUT, ChronoUnit.SECONDS))
-                .withExposedService("tika-grpc", 50052, 
+                .withExposedService("tika-grpc", 50052,
                     Wait.forLogMessage(".*Server started.*\\n", 1))
                 .withLogConsumer("tika-grpc", new Slf4jLogConsumer(log));
         
         igniteComposeContainer.start();
-        
-        log.info("Ignite Docker Compose containers started successfully");
     }
     
     @AfterAll
@@ -570,15 +577,13 @@ class IgniteConfigStoreTest {
             return ManagedChannelBuilder
                     .forAddress("localhost", GRPC_PORT)
                     .usePlaintext()
-                    .executor(Executors.newCachedThreadPool())
                     .maxInboundMessageSize(160 * 1024 * 1024)
                     .build();
         } else {
             return ManagedChannelBuilder
-                    .forAddress(igniteComposeContainer.getServiceHost("tika-grpc", 50052), 
+                    .forAddress(igniteComposeContainer.getServiceHost("tika-grpc", 50052),
                                igniteComposeContainer.getServicePort("tika-grpc", 50052))
                     .usePlaintext()
-                    .executor(Executors.newCachedThreadPool())
                     .maxInboundMessageSize(160 * 1024 * 1024)
                     .build();
         }

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -17,14 +17,9 @@
 package org.apache.tika.pipes.ignite;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -34,10 +29,7 @@ import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
@@ -60,6 +52,7 @@ import org.apache.tika.FetchAndParseRequest;
 import org.apache.tika.SaveFetcherReply;
 import org.apache.tika.SaveFetcherRequest;
 import org.apache.tika.TikaGrpc;
+import org.apache.tika.pipes.ExternalTestBase;
 import org.apache.tika.pipes.fetcher.fs.FileSystemFetcherConfig;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -69,12 +62,8 @@ import org.apache.tika.pipes.fetcher.fs.FileSystemFetcherConfig;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows classpath length limit (CreateProcess error=206) exceeded by exec:exec with full Tika classpath")
 class IgniteConfigStoreTest {
     
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final int MAX_STARTUP_TIMEOUT = 120;
-    private static final File TEST_FOLDER = new File("target", "govdocs1");
-    private static final int GOV_DOCS_FROM_IDX = Integer.parseInt(System.getProperty("govdocs1.fromIndex", "1"));
-    private static final int GOV_DOCS_TO_IDX = Integer.parseInt(System.getProperty("govdocs1.toIndex", "1"));
-    private static final String DIGITAL_CORPORA_ZIP_FILES_URL = "https://corp.digitalcorpora.org/corpora/files/govdocs1/zipfiles";
+    private static final int MAX_STARTUP_TIMEOUT = ExternalTestBase.MAX_STARTUP_TIMEOUT;
+    private static final File TEST_FOLDER = ExternalTestBase.TEST_FOLDER;
     private static final boolean USE_LOCAL_SERVER = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "true"));
     private static final int GRPC_PORT = Integer.parseInt(System.getProperty("tika.e2e.grpcPort", "50052"));
     
@@ -94,10 +83,10 @@ class IgniteConfigStoreTest {
         }
         
         if (!TEST_FOLDER.exists() || TEST_FOLDER.listFiles().length == 0) {
-            if (System.getProperty("govdocs1.fromIndex") != null) {
-                downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
+            if (Boolean.parseBoolean(System.getProperty("tika.e2e.useGovdocs", "false"))) {
+                ExternalTestBase.downloadAndUnzipGovdocs1(ExternalTestBase.GOV_DOCS_FROM_IDX, ExternalTestBase.GOV_DOCS_TO_IDX);
             } else {
-                copyTestFixtures();
+                ExternalTestBase.copyTestFixtures();
             }
         }
         
@@ -346,13 +335,22 @@ class IgniteConfigStoreTest {
                 long pid = Long.parseLong(pidStr.trim());
                 long myPid = ProcessHandle.current().pid();
                 
-                // Don't kill ourselves or our parent
                 if (pid == myPid || isParentProcess(pid)) {
                     log.debug("Skipping kill of PID {} on port {} (test process or parent)", pid, port);
                     return;
                 }
                 
-                log.info("Found process {} listening on port {}, killing it", pid, port);
+                // Only kill processes we can identify as tika-grpc or Ignite instances to avoid
+                // accidentally killing unrelated processes that happen to be on the same port.
+                String cmdLine = ProcessHandle.of(pid)
+                        .flatMap(h -> h.info().commandLine())
+                        .orElse("");
+                if (!cmdLine.contains("tika") && !cmdLine.contains("TikaGrpc") && !cmdLine.contains("ignite")) {
+                    log.debug("Skipping kill of PID {} on port {} — not a tika/ignite process: {}", pid, port, cmdLine);
+                    return;
+                }
+                
+                log.info("Found tika/ignite process {} on port {}, killing it", pid, port);
                 
                 ProcessBuilder killPb = new ProcessBuilder("kill", String.valueOf(pid));
                 Process killProcess = killPb.start();
@@ -396,7 +394,7 @@ class IgniteConfigStoreTest {
             String basePath = USE_LOCAL_SERVER ? TEST_FOLDER.getAbsolutePath() : "/tika/govdocs1";
             config.setBasePath(basePath);
             
-            String configJson = OBJECT_MAPPER.writeValueAsString(config);
+            String configJson = ExternalTestBase.OBJECT_MAPPER.writeValueAsString(config);
             log.info("Creating fetcher with Ignite ConfigStore (basePath={}): {}", basePath, configJson);
             
             SaveFetcherReply saveReply = blockingStub.saveFetcher(SaveFetcherRequest
@@ -439,7 +437,7 @@ class IgniteConfigStoreTest {
                 }
             });
 
-            int maxDocs = Integer.parseInt(System.getProperty("corpa.numdocs", "-1"));
+            int maxDocs = Integer.parseInt(System.getProperty("corpus.numDocs", "-1"));
             log.info("Document limit: {}", maxDocs == -1 ? "unlimited" : maxDocs);
             
             try (Stream<Path> paths = Files.walk(TEST_FOLDER.toPath())) {
@@ -477,7 +475,7 @@ class IgniteConfigStoreTest {
             }
             
             if (maxDocs == -1) {
-                assertAllFilesFetched(TEST_FOLDER.toPath(), successes, errors);
+                ExternalTestBase.assertAllFilesFetched(TEST_FOLDER.toPath(), successes, errors);
             } else {
                 int totalProcessed = successes.size() + errors.size();
                 log.info("Processed {} documents with Ignite ConfigStore (limit was {})", 
@@ -501,97 +499,6 @@ class IgniteConfigStoreTest {
                 Thread.currentThread().interrupt();
             }
         }
-    }
-    
-    private static void copyTestFixtures() throws IOException {
-        Path targetDir = TEST_FOLDER.toPath();
-        Files.createDirectories(targetDir);
-        String[] fixtures = {"sample.txt", "sample.html", "sample.csv", "sample.xml"};
-        for (String fixture : fixtures) {
-            java.net.URL resource = IgniteConfigStoreTest.class.getClassLoader()
-                    .getResource("test-fixtures/" + fixture);
-            if (resource == null) {
-                throw new IllegalStateException("Test fixture not found: test-fixtures/" + fixture);
-            }
-            try (java.io.InputStream in = resource.openStream()) {
-                java.nio.file.Files.copy(in, targetDir.resolve(fixture),
-                        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-            }
-        }
-        log.info("Copied {} test fixtures to {}", fixtures.length, targetDir);
-    }
-
-    private static void downloadAndUnzipGovdocs1(int fromIndex, int toIndex) throws IOException {
-        Path targetDir = TEST_FOLDER.toPath();
-        Files.createDirectories(targetDir);
-
-        for (int i = fromIndex; i <= toIndex; i++) {
-            String zipName = String.format(java.util.Locale.ROOT, "%03d.zip", i);
-            String url = DIGITAL_CORPORA_ZIP_FILES_URL + "/" + zipName;
-            Path zipPath = targetDir.resolve(zipName);
-            
-            if (Files.exists(zipPath)) {
-                log.info("{} already exists, skipping download", zipName);
-                continue;
-            }
-
-            log.info("Downloading {} from {}...", zipName, url);
-            try (InputStream in = new URL(url).openStream()) {
-                Files.copy(in, zipPath, StandardCopyOption.REPLACE_EXISTING);
-            }
-
-            log.info("Unzipping {}...", zipName);
-            try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath.toFile()))) {
-                ZipEntry entry;
-                while ((entry = zis.getNextEntry()) != null) {
-                    Path outPath = targetDir.resolve(entry.getName());
-                    if (entry.isDirectory()) {
-                        Files.createDirectories(outPath);
-                    } else {
-                        Files.createDirectories(outPath.getParent());
-                        try (OutputStream out = Files.newOutputStream(outPath)) {
-                            zis.transferTo(out);
-                        }
-                    }
-                    zis.closeEntry();
-                }
-            }
-        }
-        
-        log.info("Finished downloading and extracting govdocs1 files");
-    }
-    
-    private static void assertAllFilesFetched(Path baseDir, List<FetchAndParseReply> successes, 
-                                            List<FetchAndParseReply> errors) {
-        java.util.Set<String> allFetchKeys = new java.util.HashSet<>();
-        for (FetchAndParseReply reply : successes) {
-            allFetchKeys.add(reply.getFetchKey());
-        }
-        for (FetchAndParseReply reply : errors) {
-            allFetchKeys.add(reply.getFetchKey());
-        }
-        
-        java.util.Set<String> keysFromGovdocs1 = new java.util.HashSet<>();
-        try (Stream<Path> paths = Files.walk(baseDir)) {
-            paths.filter(Files::isRegularFile)
-                    .forEach(file -> {
-                        String relPath = baseDir.relativize(file).toString();
-                        if (java.util.regex.Pattern.compile("\\d{3}\\.zip").matcher(relPath).find()) {
-                            return;
-                        }
-                        keysFromGovdocs1.add(relPath);
-                    });
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        
-        Assertions.assertNotEquals(0, successes.size(), "Should have some successful fetches");
-        log.info("Processed {} files: {} successes, {} errors", allFetchKeys.size(), successes.size(), errors.size());
-        Assertions.assertEquals(keysFromGovdocs1, allFetchKeys, () -> {
-            java.util.Set<String> missing = new java.util.HashSet<>(keysFromGovdocs1);
-            missing.removeAll(allFetchKeys);
-            return "Missing fetch keys: " + missing;
-        });
     }
     
     private static ManagedChannel getManagedChannelForIgnite() {

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -62,11 +62,6 @@ import org.apache.tika.SaveFetcherRequest;
 import org.apache.tika.TikaGrpc;
 import org.apache.tika.pipes.fetcher.fs.FileSystemFetcherConfig;
 
-/**
- * End-to-end test for Ignite ConfigStore.
- * Tests that fetchers saved via gRPC are persisted in Ignite
- * and available in the forked PipesServer process.
- */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Testcontainers
 @Slf4j
@@ -88,9 +83,7 @@ class IgniteConfigStoreTest {
     
     @BeforeAll
     static void setupIgnite() throws Exception {
-        // Clean up any orphaned processes from previous runs
         if (USE_LOCAL_SERVER) {
-            log.info("Cleaning up any orphaned processes from previous runs");
             try {
                 killProcessOnPort(GRPC_PORT);
                 killProcessOnPort(3344);
@@ -100,7 +93,6 @@ class IgniteConfigStoreTest {
             }
         }
         
-        // Load govdocs1 if not already loaded
         if (!TEST_FOLDER.exists() || TEST_FOLDER.listFiles().length == 0) {
             downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
         }
@@ -115,11 +107,9 @@ class IgniteConfigStoreTest {
     private static void startLocalGrpcServer() throws Exception {
         log.info("Starting local tika-grpc server using Maven");
         
-        // Find the tika root directory - it should contain both tika-grpc and tika-e2e-tests
         Path currentDir = Path.of("").toAbsolutePath();
         Path tikaRootDir = currentDir;
         
-        // Navigate up to find the directory that contains both tika-grpc and tika-e2e-tests
         while (tikaRootDir != null && 
                !(Files.exists(tikaRootDir.resolve("tika-grpc")) && 
                  Files.exists(tikaRootDir.resolve("tika-e2e-tests")))) {
@@ -137,7 +127,6 @@ class IgniteConfigStoreTest {
             throw new IllegalStateException("Cannot find tika-grpc directory at: " + tikaGrpcDir);
         }
         
-        // Use different config for local vs Docker
         String configFileName = "tika-config-ignite-local.json";
         Path configFile = Path.of("src/test/resources/" + configFileName).toAbsolutePath();
         
@@ -188,10 +177,8 @@ class IgniteConfigStoreTest {
         
         localGrpcProcess = pb.start();
         
-        // Track whether Ignite has started
         final boolean[] igniteStarted = {false};
         
-        // Start a thread to consume and log output, watching for Ignite startup
         Thread logThread = new Thread(() -> {
             try (java.io.BufferedReader reader = new java.io.BufferedReader(
                     new java.io.InputStreamReader(localGrpcProcess.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
@@ -199,7 +186,6 @@ class IgniteConfigStoreTest {
                 while ((line = reader.readLine()) != null) {
                     log.info("tika-grpc: {}", line);
                     
-                    // Look for signs that Ignite has fully started
                     if (line.contains("Ignite server started") ||
                         line.contains("Table") && line.contains("created successfully") ||
                         line.contains("Server started, listening on")) {
@@ -216,9 +202,6 @@ class IgniteConfigStoreTest {
         logThread.setDaemon(true);
         logThread.start();
         
-        // Wait for Ignite to start - check both log messages and gRPC connectivity
-        log.info("Waiting for local gRPC server and Ignite to start (timeout: 180 seconds)...");
-        
         try {
             org.awaitility.Awaitility.await()
                 .atMost(java.time.Duration.ofSeconds(180))
@@ -234,7 +217,6 @@ class IgniteConfigStoreTest {
                         return false;
                     }
                     
-                    // Try to actually test gRPC readiness with a real (lightweight) call
                     try {
                         ManagedChannel testChannel = ManagedChannelBuilder
                             .forAddress("localhost", GRPC_PORT)
@@ -242,7 +224,6 @@ class IgniteConfigStoreTest {
                             .build();
                         
                         try {
-                            // Try to use the health check service
                             io.grpc.health.v1.HealthGrpc.HealthBlockingStub healthStub = 
                                 io.grpc.health.v1.HealthGrpc.newBlockingStub(testChannel)
                                     .withDeadlineAfter(2, TimeUnit.SECONDS);
@@ -312,11 +293,8 @@ class IgniteConfigStoreTest {
             log.info("Stopping local gRPC server and all child processes");
             
             try {
-                // Get the PID of the Maven process
                 long mvnPid = localGrpcProcess.pid();
                 log.info("Maven process PID: {}", mvnPid);
-                
-                // Try graceful shutdown first
                 localGrpcProcess.destroy();
                 
                 if (!localGrpcProcess.waitFor(10, TimeUnit.SECONDS)) {
@@ -325,15 +303,12 @@ class IgniteConfigStoreTest {
                     localGrpcProcess.waitFor(5, TimeUnit.SECONDS);
                 }
                 
-                // Give it a moment for cleanup
                 Thread.sleep(2000);
                 
-                // Kill any remaining child processes by finding processes listening on Ignite/gRPC ports
-                // Only do this if the process is still running
                 try {
-                    killProcessOnPort(GRPC_PORT);  // Kill gRPC server
-                    killProcessOnPort(3344);        // Kill Ignite's internal port
-                    killProcessOnPort(10800);       // Kill Ignite client connector
+                    killProcessOnPort(GRPC_PORT);
+                    killProcessOnPort(3344);
+                    killProcessOnPort(10800);
                 } catch (Exception e) {
                     log.debug("Error killing processes on ports (may already be stopped): {}", e.getMessage());
                 }
@@ -349,7 +324,6 @@ class IgniteConfigStoreTest {
     }
     
     private static void killProcessOnPort(int port) throws IOException, InterruptedException {
-        // Find process listening on the port using lsof
         ProcessBuilder findPb = new ProcessBuilder("lsof", "-ti", ":" + port);
         findPb.redirectErrorStream(true);
         Process findProcess = findPb.start();
@@ -373,7 +347,6 @@ class IgniteConfigStoreTest {
                 Process killProcess = killPb.start();
                 killProcess.waitFor(2, TimeUnit.SECONDS);
                 
-                // If still alive, force kill
                 Thread.sleep(1000);
                 ProcessBuilder forceKillPb = new ProcessBuilder("kill", "-9", String.valueOf(pid));
                 Process forceKillProcess = forceKillPb.start();
@@ -408,9 +381,7 @@ class IgniteConfigStoreTest {
             TikaGrpc.TikaBlockingStub blockingStub = TikaGrpc.newBlockingStub(channel);
             TikaGrpc.TikaStub tikaStub = TikaGrpc.newStub(channel);
 
-            // Create and save the fetcher dynamically
             FileSystemFetcherConfig config = new FileSystemFetcherConfig();
-            // Use local path when running in local mode, Docker path otherwise
             String basePath = USE_LOCAL_SERVER ? TEST_FOLDER.getAbsolutePath() : "/tika/govdocs1";
             config.setBasePath(basePath);
             
@@ -457,7 +428,6 @@ class IgniteConfigStoreTest {
                 }
             });
 
-            // Submit files for parsing - limit to configured number
             int maxDocs = Integer.parseInt(System.getProperty("corpa.numdocs", "-1"));
             log.info("Document limit: {}", maxDocs == -1 ? "unlimited" : maxDocs);
             
@@ -485,7 +455,6 @@ class IgniteConfigStoreTest {
 
             requestStreamObserver.onCompleted();
 
-            // Wait for all parsing to complete
             try {
                 if (!countDownLatch.await(3, TimeUnit.MINUTES)) {
                     log.error("Timed out waiting for parse to complete");
@@ -496,7 +465,6 @@ class IgniteConfigStoreTest {
                 Assertions.fail("Interrupted while waiting for parsing to complete");
             }
             
-            // Verify documents were processed
             if (maxDocs == -1) {
                 assertAllFilesFetched(TEST_FOLDER.toPath(), successes, errors);
             } else {
@@ -512,7 +480,6 @@ class IgniteConfigStoreTest {
             log.info("Ignite ConfigStore test completed successfully - {} successes, {} errors", 
                 successes.size(), errors.size());
         } finally {
-            // Properly shutdown gRPC channel to avoid resource leak
             channel.shutdown();
             try {
                 if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
@@ -525,7 +492,6 @@ class IgniteConfigStoreTest {
         }
     }
     
-    // Helper method for downloading test data
     private static void downloadAndUnzipGovdocs1(int fromIndex, int toIndex) throws IOException {
         Path targetDir = TEST_FOLDER.toPath();
         Files.createDirectories(targetDir);
@@ -566,7 +532,6 @@ class IgniteConfigStoreTest {
         log.info("Finished downloading and extracting govdocs1 files");
     }
     
-    // Helper method to validate all files were fetched
     private static void assertAllFilesFetched(Path baseDir, List<FetchAndParseReply> successes, 
                                             List<FetchAndParseReply> errors) {
         java.util.Set<String> allFetchKeys = new java.util.HashSet<>();
@@ -600,7 +565,6 @@ class IgniteConfigStoreTest {
         });
     }
     
-    // Helper method to create gRPC channel
     private static ManagedChannel getManagedChannelForIgnite() {
         if (USE_LOCAL_SERVER) {
             return ManagedChannelBuilder

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -94,7 +94,11 @@ class IgniteConfigStoreTest {
         }
         
         if (!TEST_FOLDER.exists() || TEST_FOLDER.listFiles().length == 0) {
-            downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
+            if (System.getProperty("govdocs1.fromIndex") != null) {
+                downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
+            } else {
+                copyTestFixtures();
+            }
         }
         
         if (USE_LOCAL_SERVER) {
@@ -499,6 +503,24 @@ class IgniteConfigStoreTest {
         }
     }
     
+    private static void copyTestFixtures() throws IOException {
+        Path targetDir = TEST_FOLDER.toPath();
+        Files.createDirectories(targetDir);
+        String[] fixtures = {"sample.txt", "sample.html", "sample.csv", "sample.xml"};
+        for (String fixture : fixtures) {
+            java.net.URL resource = IgniteConfigStoreTest.class.getClassLoader()
+                    .getResource("test-fixtures/" + fixture);
+            if (resource == null) {
+                throw new IllegalStateException("Test fixture not found: test-fixtures/" + fixture);
+            }
+            try (java.io.InputStream in = resource.openStream()) {
+                java.nio.file.Files.copy(in, targetDir.resolve(fixture),
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+        log.info("Copied {} test fixtures to {}", fixtures.length, targetDir);
+    }
+
     private static void downloadAndUnzipGovdocs1(int fromIndex, int toIndex) throws IOException {
         Path targetDir = TEST_FOLDER.toPath();
         Files.createDirectories(targetDir);

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -458,6 +458,10 @@ class IgniteConfigStoreTest {
                 
                 if (maxDocs > 0) {
                     fileStream = fileStream.limit(maxDocs);
+                }
+
+                fileStream.forEach(file -> {
+                    try {
                         String relPath = TEST_FOLDER.toPath().relativize(file).toString();
                         requestStreamObserver.onNext(FetchAndParseRequest
                                 .newBuilder()

--- a/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
+++ b/tika-e2e-tests/tika-grpc/src/test/java/org/apache/tika/pipes/ignite/IgniteConfigStoreTest.java
@@ -1,0 +1,622 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.pipes.ignite;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.apache.tika.FetchAndParseReply;
+import org.apache.tika.FetchAndParseRequest;
+import org.apache.tika.SaveFetcherReply;
+import org.apache.tika.SaveFetcherRequest;
+import org.apache.tika.TikaGrpc;
+import org.apache.tika.pipes.fetcher.fs.FileSystemFetcherConfig;
+
+/**
+ * End-to-end test for Ignite ConfigStore.
+ * Tests that fetchers saved via gRPC are persisted in Ignite
+ * and available in the forked PipesServer process.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Testcontainers
+@Slf4j
+@Tag("E2ETest")
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Maven not on PATH and Docker/Testcontainers not supported on Windows CI")
+class IgniteConfigStoreTest {
+    
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final int MAX_STARTUP_TIMEOUT = 120;
+    private static final File TEST_FOLDER = new File("target", "govdocs1");
+    private static final int GOV_DOCS_FROM_IDX = Integer.parseInt(System.getProperty("govdocs1.fromIndex", "1"));
+    private static final int GOV_DOCS_TO_IDX = Integer.parseInt(System.getProperty("govdocs1.toIndex", "1"));
+    private static final String DIGITAL_CORPORA_ZIP_FILES_URL = "https://corp.digitalcorpora.org/corpora/files/govdocs1/zipfiles";
+    private static final boolean USE_LOCAL_SERVER = Boolean.parseBoolean(System.getProperty("tika.e2e.useLocalServer", "false"));
+    private static final int GRPC_PORT = Integer.parseInt(System.getProperty("tika.e2e.grpcPort", "50052"));
+    
+    private static DockerComposeContainer<?> igniteComposeContainer;
+    private static Process localGrpcProcess;
+    
+    @BeforeAll
+    static void setupIgnite() throws Exception {
+        // Clean up any orphaned processes from previous runs
+        if (USE_LOCAL_SERVER) {
+            log.info("Cleaning up any orphaned processes from previous runs");
+            try {
+                killProcessOnPort(GRPC_PORT);
+                killProcessOnPort(3344);
+                killProcessOnPort(10800);
+            } catch (Exception e) {
+                log.debug("No orphaned processes to clean up");
+            }
+        }
+        
+        // Load govdocs1 if not already loaded
+        if (!TEST_FOLDER.exists() || TEST_FOLDER.listFiles().length == 0) {
+            downloadAndUnzipGovdocs1(GOV_DOCS_FROM_IDX, GOV_DOCS_TO_IDX);
+        }
+        
+        if (USE_LOCAL_SERVER) {
+            startLocalGrpcServer();
+        } else {
+            startDockerGrpcServer();
+        }
+    }
+    
+    private static void startLocalGrpcServer() throws Exception {
+        log.info("Starting local tika-grpc server using Maven");
+        
+        // Find the tika root directory - it should contain both tika-grpc and tika-e2e-tests
+        Path currentDir = Path.of("").toAbsolutePath();
+        Path tikaRootDir = currentDir;
+        
+        // Navigate up to find the directory that contains both tika-grpc and tika-e2e-tests
+        while (tikaRootDir != null && 
+               !(Files.exists(tikaRootDir.resolve("tika-grpc")) && 
+                 Files.exists(tikaRootDir.resolve("tika-e2e-tests")))) {
+            tikaRootDir = tikaRootDir.getParent();
+        }
+        
+        if (tikaRootDir == null) {
+            throw new IllegalStateException("Cannot find tika root directory. " +
+                "Current dir: " + currentDir + ". " +
+                "Please run from within the tika project.");
+        }
+        
+        Path tikaGrpcDir = tikaRootDir.resolve("tika-grpc");
+        if (!Files.exists(tikaGrpcDir)) {
+            throw new IllegalStateException("Cannot find tika-grpc directory at: " + tikaGrpcDir);
+        }
+        
+        // Use different config for local vs Docker
+        String configFileName = "tika-config-ignite-local.json";
+        Path configFile = Path.of("src/test/resources/" + configFileName).toAbsolutePath();
+        
+        if (!Files.exists(configFile)) {
+            throw new IllegalStateException("Config file not found: " + configFile);
+        }
+        
+        log.info("Tika root: {}", tikaRootDir);
+        log.info("Using tika-grpc from: {}", tikaGrpcDir);
+        log.info("Using config file: {}", configFile);
+        
+        // Use mvn exec:exec to run as external process (not exec:java which breaks ServiceLoader)
+        String javaHome = System.getProperty("java.home");
+        String javaCmd = javaHome + "/bin/java";
+        
+        ProcessBuilder pb = new ProcessBuilder(
+            "mvn",
+            "exec:exec",
+            "-Dexec.executable=" + javaCmd,
+            "-Dexec.args=" +
+                "--add-opens=java.base/java.lang=ALL-UNNAMED " +
+                "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED " +
+                "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED " +
+                "--add-opens=java.base/java.io=ALL-UNNAMED " +
+                "--add-opens=java.base/java.nio=ALL-UNNAMED " +
+                "--add-opens=java.base/java.math=ALL-UNNAMED " +
+                "--add-opens=java.base/java.util=ALL-UNNAMED " +
+                "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED " +
+                "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED " +
+                "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED " +
+                "--add-opens=java.base/java.time=ALL-UNNAMED " +
+                "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED " +
+                "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED " +
+                "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED " +
+                "--add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED " +
+                "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED " +
+                "-Dio.netty.tryReflectionSetAccessible=true " +
+                "-Dignite.work.dir=" + tikaGrpcDir.resolve("target/ignite-work") + " " +
+                "-classpath %classpath " +
+                "org.apache.tika.pipes.grpc.TikaGrpcServer " +
+                "-c " + configFile + " " +
+                "-p " + GRPC_PORT
+        );
+        
+        pb.directory(tikaGrpcDir.toFile());
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+        
+        localGrpcProcess = pb.start();
+        
+        // Track whether Ignite has started
+        final boolean[] igniteStarted = {false};
+        
+        // Start a thread to consume and log output, watching for Ignite startup
+        Thread logThread = new Thread(() -> {
+            try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                    new java.io.InputStreamReader(localGrpcProcess.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    log.info("tika-grpc: {}", line);
+                    
+                    // Look for signs that Ignite has fully started
+                    if (line.contains("Ignite server started") ||
+                        line.contains("Table") && line.contains("created successfully") ||
+                        line.contains("Server started, listening on")) {
+                        synchronized (igniteStarted) {
+                            igniteStarted[0] = true;
+                            igniteStarted.notifyAll();
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                log.error("Error reading server output", e);
+            }
+        });
+        logThread.setDaemon(true);
+        logThread.start();
+        
+        // Wait for Ignite to start - check both log messages and gRPC connectivity
+        log.info("Waiting for local gRPC server and Ignite to start (timeout: 180 seconds)...");
+        
+        try {
+            org.awaitility.Awaitility.await()
+                .atMost(java.time.Duration.ofSeconds(180))
+                .pollInterval(java.time.Duration.ofSeconds(2))
+                .until(() -> {
+                    boolean igniteReady;
+                    synchronized (igniteStarted) {
+                        igniteReady = igniteStarted[0];
+                    }
+                    
+                    if (!igniteReady) {
+                        log.debug("Waiting for Ignite to start...");
+                        return false;
+                    }
+                    
+                    // Try to actually test gRPC readiness with a real (lightweight) call
+                    try {
+                        ManagedChannel testChannel = ManagedChannelBuilder
+                            .forAddress("localhost", GRPC_PORT)
+                            .usePlaintext()
+                            .build();
+                        
+                        try {
+                            // Try to use the health check service
+                            io.grpc.health.v1.HealthGrpc.HealthBlockingStub healthStub = 
+                                io.grpc.health.v1.HealthGrpc.newBlockingStub(testChannel)
+                                    .withDeadlineAfter(2, TimeUnit.SECONDS);
+                            
+                            io.grpc.health.v1.HealthCheckResponse response = healthStub.check(
+                                io.grpc.health.v1.HealthCheckRequest.getDefaultInstance());
+                            
+                            boolean serving = response.getStatus() == 
+                                io.grpc.health.v1.HealthCheckResponse.ServingStatus.SERVING;
+                            
+                            if (serving) {
+                                log.info("gRPC server is healthy and serving!");
+                                return true;
+                            } else {
+                                log.debug("gRPC server responding but not serving yet: {}", response.getStatus());
+                                return false;
+                            }
+                        } finally {
+                            testChannel.shutdown();
+                            testChannel.awaitTermination(1, TimeUnit.SECONDS);
+                        }
+                    } catch (io.grpc.StatusRuntimeException e) {
+                        if (e.getStatus().getCode() == io.grpc.Status.Code.UNIMPLEMENTED) {
+                            // Health check not implemented, just verify channel works
+                            log.info("Health check not available, assuming server is ready");
+                            return true;
+                        }
+                        log.debug("gRPC server not ready yet: {}", e.getMessage());
+                        return false;
+                    } catch (Exception e) {
+                        log.debug("gRPC server not ready yet: {}", e.getMessage());
+                        return false;
+                    }
+                });
+            
+            log.info("Both gRPC server and Ignite are ready!");
+        } catch (org.awaitility.core.ConditionTimeoutException e) {
+            if (localGrpcProcess.isAlive()) {
+                localGrpcProcess.destroyForcibly();
+            }
+            throw new RuntimeException("Local gRPC server or Ignite failed to start within timeout", e);
+        }
+        
+        log.info("Local tika-grpc server started successfully on port {}", GRPC_PORT);
+    }
+    
+    
+    private static void startDockerGrpcServer() {
+        log.info("Starting Docker Compose tika-grpc server");
+        
+        igniteComposeContainer = new DockerComposeContainer<>(
+                new File("src/test/resources/docker-compose-ignite.yml"))
+                .withEnv("HOST_GOVDOCS1_DIR", TEST_FOLDER.getAbsolutePath())
+                .withStartupTimeout(Duration.of(MAX_STARTUP_TIMEOUT, ChronoUnit.SECONDS))
+                .withExposedService("tika-grpc", 50052, 
+                    Wait.forLogMessage(".*Server started.*\\n", 1))
+                .withLogConsumer("tika-grpc", new Slf4jLogConsumer(log));
+        
+        igniteComposeContainer.start();
+        
+        log.info("Ignite Docker Compose containers started successfully");
+    }
+    
+    @AfterAll
+    static void teardownIgnite() {
+        if (USE_LOCAL_SERVER && localGrpcProcess != null) {
+            log.info("Stopping local gRPC server and all child processes");
+            
+            try {
+                // Get the PID of the Maven process
+                long mvnPid = localGrpcProcess.pid();
+                log.info("Maven process PID: {}", mvnPid);
+                
+                // Try graceful shutdown first
+                localGrpcProcess.destroy();
+                
+                if (!localGrpcProcess.waitFor(10, TimeUnit.SECONDS)) {
+                    log.warn("Process didn't stop gracefully, forcing shutdown");
+                    localGrpcProcess.destroyForcibly();
+                    localGrpcProcess.waitFor(5, TimeUnit.SECONDS);
+                }
+                
+                // Give it a moment for cleanup
+                Thread.sleep(2000);
+                
+                // Kill any remaining child processes by finding processes listening on Ignite/gRPC ports
+                // Only do this if the process is still running
+                try {
+                    killProcessOnPort(GRPC_PORT);  // Kill gRPC server
+                    killProcessOnPort(3344);        // Kill Ignite's internal port
+                    killProcessOnPort(10800);       // Kill Ignite client connector
+                } catch (Exception e) {
+                    log.debug("Error killing processes on ports (may already be stopped): {}", e.getMessage());
+                }
+                
+                log.info("Local gRPC server stopped");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                localGrpcProcess.destroyForcibly();
+            }
+        } else if (igniteComposeContainer != null) {
+            igniteComposeContainer.close();
+        }
+    }
+    
+    private static void killProcessOnPort(int port) throws IOException, InterruptedException {
+        // Find process listening on the port using lsof
+        ProcessBuilder findPb = new ProcessBuilder("lsof", "-ti", ":" + port);
+        findPb.redirectErrorStream(true);
+        Process findProcess = findPb.start();
+        
+        try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                new java.io.InputStreamReader(findProcess.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
+            String pidStr = reader.readLine();
+            if (pidStr != null && !pidStr.trim().isEmpty()) {
+                long pid = Long.parseLong(pidStr.trim());
+                long myPid = ProcessHandle.current().pid();
+                
+                // Don't kill ourselves or our parent
+                if (pid == myPid || isParentProcess(pid)) {
+                    log.debug("Skipping kill of PID {} on port {} (test process or parent)", pid, port);
+                    return;
+                }
+                
+                log.info("Found process {} listening on port {}, killing it", pid, port);
+                
+                ProcessBuilder killPb = new ProcessBuilder("kill", String.valueOf(pid));
+                Process killProcess = killPb.start();
+                killProcess.waitFor(2, TimeUnit.SECONDS);
+                
+                // If still alive, force kill
+                Thread.sleep(1000);
+                ProcessBuilder forceKillPb = new ProcessBuilder("kill", "-9", String.valueOf(pid));
+                Process forceKillProcess = forceKillPb.start();
+                forceKillProcess.waitFor(2, TimeUnit.SECONDS);
+            }
+        }
+        
+        findProcess.waitFor(2, TimeUnit.SECONDS);
+    }
+    
+    private static boolean isParentProcess(long pid) {
+        try {
+            ProcessHandle current = ProcessHandle.current();
+            while (current.parent().isPresent()) {
+                current = current.parent().get();
+                if (current.pid() == pid) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Error checking parent process", e);
+        }
+        return false;
+    }
+    
+    @Test
+    void testIgniteConfigStore() throws Exception {
+        String fetcherId = "dynamicIgniteFetcher";
+        ManagedChannel channel = getManagedChannelForIgnite();
+        
+        try {
+            TikaGrpc.TikaBlockingStub blockingStub = TikaGrpc.newBlockingStub(channel);
+            TikaGrpc.TikaStub tikaStub = TikaGrpc.newStub(channel);
+
+            // Create and save the fetcher dynamically
+            FileSystemFetcherConfig config = new FileSystemFetcherConfig();
+            // Use local path when running in local mode, Docker path otherwise
+            String basePath = USE_LOCAL_SERVER ? TEST_FOLDER.getAbsolutePath() : "/tika/govdocs1";
+            config.setBasePath(basePath);
+            
+            String configJson = OBJECT_MAPPER.writeValueAsString(config);
+            log.info("Creating fetcher with Ignite ConfigStore (basePath={}): {}", basePath, configJson);
+            
+            SaveFetcherReply saveReply = blockingStub.saveFetcher(SaveFetcherRequest
+                    .newBuilder()
+                    .setFetcherId(fetcherId)
+                    .setFetcherClass("org.apache.tika.pipes.fetcher.fs.FileSystemFetcher")
+                    .setFetcherConfigJson(configJson)
+                    .build());
+            
+            log.info("Fetcher saved to Ignite: {}", saveReply.getFetcherId());
+
+            List<FetchAndParseReply> successes = Collections.synchronizedList(new ArrayList<>());
+            List<FetchAndParseReply> errors = Collections.synchronizedList(new ArrayList<>());
+
+            CountDownLatch countDownLatch = new CountDownLatch(1);
+            StreamObserver<FetchAndParseRequest>
+                    requestStreamObserver = tikaStub.fetchAndParseBiDirectionalStreaming(new StreamObserver<>() {
+                @Override
+                public void onNext(FetchAndParseReply fetchAndParseReply) {
+                    log.debug("Reply from fetch-and-parse - key={}, status={}", 
+                        fetchAndParseReply.getFetchKey(), fetchAndParseReply.getStatus());
+                    if ("FETCH_AND_PARSE_EXCEPTION".equals(fetchAndParseReply.getStatus())) {
+                        errors.add(fetchAndParseReply);
+                    } else {
+                        successes.add(fetchAndParseReply);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    log.error("Received an error", throwable);
+                    Assertions.fail(throwable);
+                    countDownLatch.countDown();
+                }
+
+                @Override
+                public void onCompleted() {
+                    log.info("Finished streaming fetch and parse replies");
+                    countDownLatch.countDown();
+                }
+            });
+
+            // Submit files for parsing - limit to configured number
+            int maxDocs = Integer.parseInt(System.getProperty("corpa.numdocs", "-1"));
+            log.info("Document limit: {}", maxDocs == -1 ? "unlimited" : maxDocs);
+            
+            try (Stream<Path> paths = Files.walk(TEST_FOLDER.toPath())) {
+                Stream<Path> fileStream = paths.filter(Files::isRegularFile);
+                
+                if (maxDocs > 0) {
+                    fileStream = fileStream.limit(maxDocs);
+                }
+                
+                fileStream.forEach(file -> {
+                    try {
+                        String relPath = TEST_FOLDER.toPath().relativize(file).toString();
+                        requestStreamObserver.onNext(FetchAndParseRequest
+                                .newBuilder()
+                                .setFetcherId(fetcherId)
+                                .setFetchKey(relPath)
+                                .build());
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+            log.info("Done submitting files to Ignite-backed fetcher {}", fetcherId);
+
+            requestStreamObserver.onCompleted();
+
+            // Wait for all parsing to complete
+            try {
+                if (!countDownLatch.await(3, TimeUnit.MINUTES)) {
+                    log.error("Timed out waiting for parse to complete");
+                    Assertions.fail("Timed out waiting for parsing to complete");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Assertions.fail("Interrupted while waiting for parsing to complete");
+            }
+            
+            // Verify documents were processed
+            if (maxDocs == -1) {
+                assertAllFilesFetched(TEST_FOLDER.toPath(), successes, errors);
+            } else {
+                int totalProcessed = successes.size() + errors.size();
+                log.info("Processed {} documents with Ignite ConfigStore (limit was {})", 
+                    totalProcessed, maxDocs);
+                Assertions.assertTrue(totalProcessed <= maxDocs, 
+                    "Should not process more than " + maxDocs + " documents");
+                Assertions.assertTrue(totalProcessed > 0, 
+                    "Should have processed at least one document");
+            }
+            
+            log.info("Ignite ConfigStore test completed successfully - {} successes, {} errors", 
+                successes.size(), errors.size());
+        } finally {
+            // Properly shutdown gRPC channel to avoid resource leak
+            channel.shutdown();
+            try {
+                if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                    channel.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                channel.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+    
+    // Helper method for downloading test data
+    private static void downloadAndUnzipGovdocs1(int fromIndex, int toIndex) throws IOException {
+        Path targetDir = TEST_FOLDER.toPath();
+        Files.createDirectories(targetDir);
+
+        for (int i = fromIndex; i <= toIndex; i++) {
+            String zipName = String.format(java.util.Locale.ROOT, "%03d.zip", i);
+            String url = DIGITAL_CORPORA_ZIP_FILES_URL + "/" + zipName;
+            Path zipPath = targetDir.resolve(zipName);
+            
+            if (Files.exists(zipPath)) {
+                log.info("{} already exists, skipping download", zipName);
+                continue;
+            }
+
+            log.info("Downloading {} from {}...", zipName, url);
+            try (InputStream in = new URL(url).openStream()) {
+                Files.copy(in, zipPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            log.info("Unzipping {}...", zipName);
+            try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath.toFile()))) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    Path outPath = targetDir.resolve(entry.getName());
+                    if (entry.isDirectory()) {
+                        Files.createDirectories(outPath);
+                    } else {
+                        Files.createDirectories(outPath.getParent());
+                        try (OutputStream out = Files.newOutputStream(outPath)) {
+                            zis.transferTo(out);
+                        }
+                    }
+                    zis.closeEntry();
+                }
+            }
+        }
+        
+        log.info("Finished downloading and extracting govdocs1 files");
+    }
+    
+    // Helper method to validate all files were fetched
+    private static void assertAllFilesFetched(Path baseDir, List<FetchAndParseReply> successes, 
+                                            List<FetchAndParseReply> errors) {
+        java.util.Set<String> allFetchKeys = new java.util.HashSet<>();
+        for (FetchAndParseReply reply : successes) {
+            allFetchKeys.add(reply.getFetchKey());
+        }
+        for (FetchAndParseReply reply : errors) {
+            allFetchKeys.add(reply.getFetchKey());
+        }
+        
+        java.util.Set<String> keysFromGovdocs1 = new java.util.HashSet<>();
+        try (Stream<Path> paths = Files.walk(baseDir)) {
+            paths.filter(Files::isRegularFile)
+                    .forEach(file -> {
+                        String relPath = baseDir.relativize(file).toString();
+                        if (java.util.regex.Pattern.compile("\\d{3}\\.zip").matcher(relPath).find()) {
+                            return;
+                        }
+                        keysFromGovdocs1.add(relPath);
+                    });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        
+        Assertions.assertNotEquals(0, successes.size(), "Should have some successful fetches");
+        log.info("Processed {} files: {} successes, {} errors", allFetchKeys.size(), successes.size(), errors.size());
+        Assertions.assertEquals(keysFromGovdocs1, allFetchKeys, () -> {
+            java.util.Set<String> missing = new java.util.HashSet<>(keysFromGovdocs1);
+            missing.removeAll(allFetchKeys);
+            return "Missing fetch keys: " + missing;
+        });
+    }
+    
+    // Helper method to create gRPC channel
+    private static ManagedChannel getManagedChannelForIgnite() {
+        if (USE_LOCAL_SERVER) {
+            return ManagedChannelBuilder
+                    .forAddress("localhost", GRPC_PORT)
+                    .usePlaintext()
+                    .executor(Executors.newCachedThreadPool())
+                    .maxInboundMessageSize(160 * 1024 * 1024)
+                    .build();
+        } else {
+            return ManagedChannelBuilder
+                    .forAddress(igniteComposeContainer.getServiceHost("tika-grpc", 50052), 
+                               igniteComposeContainer.getServicePort("tika-grpc", 50052))
+                    .usePlaintext()
+                    .executor(Executors.newCachedThreadPool())
+                    .maxInboundMessageSize(160 * 1024 * 1024)
+                    .build();
+        }
+    }
+}

--- a/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.csv
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.csv
@@ -1,0 +1,4 @@
+name,value,description
+alpha,1,first entry
+beta,2,second entry
+gamma,3,third entry

--- a/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.html
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Sample E2E Test Document</title></head>
+<body>
+<h1>Hello from Tika</h1>
+<p>This HTML fixture is used by the tika-grpc end-to-end tests.</p>
+</body>
+</html>

--- a/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.txt
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.txt
@@ -1,0 +1,3 @@
+This is a sample plain text document used by the tika-grpc e2e tests.
+It contains several lines so the parser has something to work with.
+Apache Tika extracts text and metadata from a wide variety of document formats.

--- a/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.xml
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/test-fixtures/sample.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+  <title>Sample E2E Test Document</title>
+  <body>This XML fixture is used by the tika-grpc end-to-end tests.</body>
+</document>

--- a/tika-e2e-tests/tika-grpc/src/test/resources/tika-config-ignite-local.json
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/tika-config-ignite-local.json
@@ -3,7 +3,7 @@
   "pipes": {
     "numClients": 1,
     "configStoreType": "ignite",
-    "configStoreParams": "{\"tableName\": \"tika_e2e_test\", \"igniteInstanceName\": \"TikaE2ETest\", \"replicas\": 2, \"partitions\": 10, \"autoClose\": true}",
+    "configStoreParams": "{\"tableName\": \"tika_e2e_test\", \"igniteInstanceName\": \"TikaE2ETest\", \"replicas\": 1, \"partitions\": 10, \"autoClose\": true}",
     "forkedJvmArgs": [
       "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
       "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",

--- a/tika-e2e-tests/tika-grpc/src/test/resources/tika-config-ignite-local.json
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/tika-config-ignite-local.json
@@ -1,0 +1,52 @@
+{
+  "plugin-roots": ["/var/cache/tika/plugins"],
+  "pipes": {
+    "numClients": 1,
+    "configStoreType": "ignite",
+    "configStoreParams": "{\"tableName\": \"tika_e2e_test\", \"igniteInstanceName\": \"TikaE2ETest\", \"replicas\": 2, \"partitions\": 10, \"autoClose\": true}",
+    "forkedJvmArgs": [
+      "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
+      "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+      "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
+      "--add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED",
+      "--add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED",
+      "--add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED",
+      "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+      "--add-opens=java.base/java.io=ALL-UNNAMED",
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+      "--add-opens=java.base/java.net=ALL-UNNAMED",
+      "--add-opens=java.base/java.util=ALL-UNNAMED",
+      "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+      "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+      "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+      "--add-opens=java.base/java.math=ALL-UNNAMED",
+      "--add-opens=java.sql/java.sql=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+      "--add-opens=java.base/java.time=ALL-UNNAMED",
+      "--add-opens=java.base/java.text=ALL-UNNAMED",
+      "--add-opens=java.management/sun.management=ALL-UNNAMED",
+      "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+    ]
+  },
+  "fetchers": [
+    {
+      "fs": {
+        "staticFetcher": {
+          "basePath": "/home/ndipiazza/source/github/apache/tika/tika_e2e_tests/tika-grpc/target/govdocs1"
+        }
+      }
+    }
+  ],
+  "emitters": [
+    {
+      "fs": {
+        "defaultEmitter": {
+          "basePath": "/tmp/output"
+        }
+      }
+    }
+  ]
+}

--- a/tika-e2e-tests/tika-grpc/src/test/resources/tika-config-ignite.json
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/tika-config-ignite.json
@@ -1,0 +1,52 @@
+{
+  "plugin-roots": ["/var/cache/tika/plugins"],
+  "pipes": {
+    "numClients": 1,
+    "configStoreType": "ignite",
+    "configStoreParams": "{\"tableName\": \"tika_e2e_test\", \"igniteInstanceName\": \"TikaE2ETest\", \"replicas\": 2, \"partitions\": 10, \"autoClose\": true}",
+    "forkedJvmArgs": [
+      "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
+      "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+      "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
+      "--add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED",
+      "--add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED",
+      "--add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED",
+      "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+      "--add-opens=java.base/java.io=ALL-UNNAMED",
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+      "--add-opens=java.base/java.net=ALL-UNNAMED",
+      "--add-opens=java.base/java.util=ALL-UNNAMED",
+      "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+      "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+      "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+      "--add-opens=java.base/java.math=ALL-UNNAMED",
+      "--add-opens=java.sql/java.sql=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+      "--add-opens=java.base/java.time=ALL-UNNAMED",
+      "--add-opens=java.base/java.text=ALL-UNNAMED",
+      "--add-opens=java.management/sun.management=ALL-UNNAMED",
+      "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+    ]
+  },
+  "fetchers": [
+    {
+      "fs": {
+        "staticFetcher": {
+          "basePath": "/tika/govdocs1"
+        }
+      }
+    }
+  ],
+  "emitters": [
+    {
+      "fs": {
+        "defaultEmitter": {
+          "basePath": "/tmp/output"
+        }
+      }
+    }
+  ]
+}

--- a/tika-e2e-tests/tika-grpc/src/test/resources/tika-config.json
+++ b/tika-e2e-tests/tika-grpc/src/test/resources/tika-config.json
@@ -2,8 +2,6 @@
   "plugin-roots": ["/var/cache/tika/plugins"],
   "pipes": {
     "numClients": 1,
-    "configStoreType": "ignite",
-    "configStoreParams": "{\"tableName\": \"tika_e2e_test\", \"igniteInstanceName\": \"TikaE2ETest\", \"replicas\": 2, \"partitions\": 10, \"autoClose\": true}",
     "forkedJvmArgs": [
       "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
       "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
@@ -30,23 +28,5 @@
       "--add-opens=java.management/sun.management=ALL-UNNAMED",
       "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
     ]
-  },
-  "fetchers": [
-    {
-      "fs": {
-        "staticFetcher": {
-          "basePath": "target/govdocs1"
-        }
-      }
-    }
-  ],
-  "emitters": [
-    {
-      "fs": {
-        "defaultEmitter": {
-          "basePath": "/tmp/output"
-        }
-      }
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
Adds the `tika-e2e-tests` module and updates the gRPC e2e test suite for Ignite 3.x.

Depends on: #2654 (already merged)

## Changes
- **Root `pom.xml`**: Added `tika-e2e-tests` module
- **`tika-e2e-tests/pom.xml`**: Micronaut version alignment for Ignite 3.x transitive deps; testcontainers 2.0.3; Apache RAT excludes
- **`tika-e2e-tests/tika-grpc/pom.xml`**: Default local server mode (`tika.e2e.useLocalServer=true`); Awaitility; enforcer disabled for Ignite 3.x transitive dep conflicts
- **`tika-config-ignite-local.json`**: Config for local (non-Docker) server mode with `replicas=1` (single-node)
- **`ExternalTestBase`**: Conditional logic to start a local `TikaGrpcServer` vs Docker container
- **`IgniteConfigStoreTest` (e2e)**: Full e2e flow via gRPC against local server
- **`FileSystemFetcherTest`**: e2e test for filesystem fetcher through gRPC pipeline

## Testing
```bash
# Local server mode (default, no Docker):
mvn verify -pl tika-e2e-tests/tika-grpc

# Docker mode:
mvn verify -pl tika-e2e-tests/tika-grpc -Dtika.e2e.useLocalServer=false
```