### PR TITLE
TIKA-4679: Add HTTP/2 support to tika-server via Jetty http2-server

### DIFF
--- a/tika-e2e-tests/pom.xml
+++ b/tika-e2e-tests/pom.xml
@@ -59,6 +59,7 @@
 
     <modules>
         <module>tika-grpc</module>
+        <module>tika-server</module>
     </modules>
 
     <dependencyManagement>

--- a/tika-e2e-tests/tika-server/pom.xml
+++ b/tika-e2e-tests/tika-server/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-e2e-tests</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>tika-e2e-tests-server</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache Tika E2E Tests: REST Server</name>
+    <description>End-to-end tests for tika-server-standard, including HTTP/2 support verification</description>
+
+    <properties>
+        <!-- Path to the tika-server-standard fat-jar built in the same reactor -->
+        <tika.server.jar>${project.basedir}/../../tika-server/tika-server-standard/target/tika-server-standard-${revision}.jar</tika.server.jar>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Skip by default; run with -Pe2e -->
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <inputExcludes>
+                        <inputExclude>**/README*.md</inputExclude>
+                        <inputExclude>src/test/resources/**</inputExclude>
+                    </inputExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>e2e</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <systemPropertyVariables>
+                                <tika.server.jar>${tika.server.jar}</tika.server.jar>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/tika-e2e-tests/tika-server/pom.xml
+++ b/tika-e2e-tests/tika-server/pom.xml
@@ -37,8 +37,10 @@
     <description>End-to-end tests for tika-server-standard, including HTTP/2 support verification</description>
 
     <properties>
-        <!-- Path to the tika-server-standard fat-jar built in the same reactor -->
-        <tika.server.jar>${project.basedir}/../../tika-server/tika-server-standard/target/tika-server-standard-${revision}.jar</tika.server.jar>
+        <!-- Path to the tika-server-standard binary assembly zip built in the same reactor -->
+        <tika.server.zip>${project.basedir}/../../tika-server/tika-server-standard/target/tika-server-standard-${revision}-bin.zip</tika.server.zip>
+        <!-- Directory where the assembly is unpacked before tests run -->
+        <tika.server.home>${project.build.directory}/tika-server-dist</tika.server.home>
     </properties>
 
     <dependencies>
@@ -96,11 +98,37 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-tika-server</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.apache.tika</groupId>
+                                            <artifactId>tika-server-standard</artifactId>
+                                            <version>${revision}</version>
+                                            <classifier>bin</classifier>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${tika.server.home}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skipTests>false</skipTests>
                             <systemPropertyVariables>
-                                <tika.server.jar>${tika.server.jar}</tika.server.jar>
+                                <tika.server.home>${tika.server.home}</tika.server.home>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
+++ b/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
@@ -26,12 +26,14 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -53,7 +55,7 @@ import org.slf4j.LoggerFactory;
 public class TikaServerHttp2Test {
 
     private static final Logger log = LoggerFactory.getLogger(TikaServerHttp2Test.class);
-    private static final long SERVER_STARTUP_TIMEOUT_MS = 60_000;
+    private static final long SERVER_STARTUP_TIMEOUT_MS = 90_000;
     private static final String STATUS_PATH = "/status";
 
     private Process serverProcess;
@@ -81,6 +83,11 @@ public class TikaServerHttp2Test {
                     .toString() + "/tika-server-standard-" +
                     System.getProperty("tika.version", "4.0.0-SNAPSHOT") + ".jar";
         }
+
+        Path jar = Paths.get(jarPath);
+        Assumptions.assumeTrue(Files.exists(jar),
+                "Fat-jar not found at " + jarPath + "; skipping HTTP/2 e2e test. " +
+                "Build with: mvn package -pl tika-server/tika-server-standard -DskipTests");
 
         log.info("Starting tika-server-standard from: {}", jarPath);
         ProcessBuilder pb = new ProcessBuilder(
@@ -165,7 +172,7 @@ public class TikaServerHttp2Test {
                 .connectTimeout(Duration.ofSeconds(2))
                 .build();
         HttpRequest pollRequest = HttpRequest.newBuilder()
-                .uri(URI.create(endPoint + "/"))
+                .uri(URI.create(endPoint + STATUS_PATH))
                 .GET()
                 .build();
 

--- a/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
+++ b/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.server.e2e;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * End-to-end test verifying that tika-server-standard supports HTTP/2 (h2c cleartext).
+ *
+ * Starts the real fat-jar, sends a request using Java's HttpClient configured for HTTP/2,
+ * and asserts the response was served over HTTP/2. This validates the runtime classpath
+ * has the Jetty http2-server jar and CXF negotiates h2c correctly.
+ *
+ * Run with: mvn test -pl tika-e2e-tests/tika-server -Pe2e
+ *
+ * Inspired by Lawrence Moorehead's original contribution (elemdisc/tika PR#1, TIKA-4679).
+ */
+@Tag("E2ETest")
+public class TikaServerHttp2Test {
+
+    private static final Logger log = LoggerFactory.getLogger(TikaServerHttp2Test.class);
+    private static final long SERVER_STARTUP_TIMEOUT_MS = 60_000;
+    private static final String STATUS_PATH = "/status";
+
+    private Process serverProcess;
+    private int port;
+    private String endPoint;
+
+    @BeforeEach
+    void startServer() throws Exception {
+        port = findFreePort();
+        endPoint = "http://localhost:" + port;
+
+        String jarPath = System.getProperty("tika.server.jar");
+        if (jarPath == null) {
+            // fall back to conventional location relative to this module
+            Path moduleDir = Paths.get("").toAbsolutePath();
+            Path repoRoot = moduleDir;
+            while (repoRoot != null && !repoRoot.resolve("tika-server").toFile().isDirectory()) {
+                repoRoot = repoRoot.getParent();
+            }
+            if (repoRoot == null) {
+                throw new IllegalStateException("Cannot locate tika root. Pass -Dtika.server.jar=/path/to/tika-server-standard.jar");
+            }
+            jarPath = repoRoot.resolve("tika-server/tika-server-standard/target")
+                    .toAbsolutePath()
+                    .toString() + "/tika-server-standard-" +
+                    System.getProperty("tika.version", "4.0.0-SNAPSHOT") + ".jar";
+        }
+
+        log.info("Starting tika-server-standard from: {}", jarPath);
+        ProcessBuilder pb = new ProcessBuilder(
+                "java", "-jar", jarPath,
+                "-p", String.valueOf(port),
+                "-h", "localhost"
+        );
+        pb.redirectErrorStream(true);
+        serverProcess = pb.start();
+
+        // Drain output in background so the process doesn't block
+        Thread drainThread = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(serverProcess.getInputStream(), UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    log.debug("tika-server: {}", line);
+                }
+            } catch (Exception e) {
+                log.debug("Server output stream closed", e);
+            }
+        });
+        drainThread.setDaemon(true);
+        drainThread.start();
+
+        awaitServerStartup();
+    }
+
+    @AfterEach
+    void stopServer() throws Exception {
+        if (serverProcess != null && serverProcess.isAlive()) {
+            serverProcess.destroy();
+            serverProcess.waitFor();
+        }
+    }
+
+    @Test
+    void testH2cStatusEndpoint() throws Exception {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(endPoint + STATUS_PATH))
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
+
+        assertEquals(200, response.statusCode(), "Expected 200 from /status");
+        assertEquals(HttpClient.Version.HTTP_2, response.version(),
+                "Expected HTTP/2 protocol; server may be missing http2-server on classpath");
+        log.info("HTTP/2 h2c verified: {} {}", response.statusCode(), response.version());
+    }
+
+    @Test
+    void testH2cParseEndpoint() throws Exception {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+
+        // Send a small plain-text document for parsing
+        byte[] body = "Hello, HTTP/2 world!".getBytes(UTF_8);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(endPoint + "/tika"))
+                .header("Content-Type", "text/plain")
+                .PUT(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
+
+        assertEquals(200, response.statusCode(), "Expected 200 from /tika");
+        assertEquals(HttpClient.Version.HTTP_2, response.version(),
+                "Expected HTTP/2 protocol on /tika endpoint");
+        log.info("HTTP/2 parse endpoint verified: {} bytes returned over {}", response.body().length(), response.version());
+    }
+
+    private void awaitServerStartup() throws Exception {
+        // Use HTTP/1.1 for the health-check poll so we don't depend on HTTP/2 during startup
+        HttpClient pollClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(2))
+                .build();
+        HttpRequest pollRequest = HttpRequest.newBuilder()
+                .uri(URI.create(endPoint + "/"))
+                .GET()
+                .build();
+
+        Instant deadline = Instant.now().plusMillis(SERVER_STARTUP_TIMEOUT_MS);
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                HttpResponse<Void> resp = pollClient.send(pollRequest, HttpResponse.BodyHandlers.discarding());
+                if (resp.statusCode() == 200) {
+                    log.info("tika-server ready on port {}", port);
+                    return;
+                }
+            } catch (Exception e) {
+                log.debug("Waiting for server on port {} ...", port);
+            }
+            Thread.sleep(1000);
+        }
+        throw new IllegalStateException("tika-server did not start within " + SERVER_STARTUP_TIMEOUT_MS + " ms");
+    }
+
+    private static int findFreePort() throws Exception {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+}

--- a/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
+++ b/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
@@ -56,7 +56,8 @@ public class TikaServerHttp2Test {
 
     private static final Logger log = LoggerFactory.getLogger(TikaServerHttp2Test.class);
     private static final long SERVER_STARTUP_TIMEOUT_MS = 90_000;
-    private static final String STATUS_PATH = "/status";
+    /** Health-check polls root (/), which always returns 200 without requiring endpoint config. */
+    private static final String HEALTH_PATH = "/";
 
     private Process serverProcess;
     private int port;
@@ -67,8 +68,8 @@ public class TikaServerHttp2Test {
         port = findFreePort();
         endPoint = "http://localhost:" + port;
 
-        String jarPath = System.getProperty("tika.server.jar");
-        if (jarPath == null) {
+        String serverHome = System.getProperty("tika.server.home");
+        if (serverHome == null) {
             // fall back to conventional location relative to this module
             Path moduleDir = Paths.get("").toAbsolutePath();
             Path repoRoot = moduleDir;
@@ -76,25 +77,24 @@ public class TikaServerHttp2Test {
                 repoRoot = repoRoot.getParent();
             }
             if (repoRoot == null) {
-                throw new IllegalStateException("Cannot locate tika root. Pass -Dtika.server.jar=/path/to/tika-server-standard.jar");
+                throw new IllegalStateException("Cannot locate tika root. Pass -Dtika.server.home=/path/to/extracted-assembly");
             }
-            jarPath = repoRoot.resolve("tika-server/tika-server-standard/target")
-                    .toAbsolutePath()
-                    .toString() + "/tika-server-standard-" +
-                    System.getProperty("tika.version", "4.0.0-SNAPSHOT") + ".jar";
+            serverHome = repoRoot.resolve("tika-e2e-tests/tika-server/target/tika-server-dist").toAbsolutePath().toString();
         }
 
-        Path jar = Paths.get(jarPath);
-        Assumptions.assumeTrue(Files.exists(jar),
-                "Fat-jar not found at " + jarPath + "; skipping HTTP/2 e2e test. " +
-                "Build with: mvn package -pl tika-server/tika-server-standard -DskipTests");
+        Path serverJar = Paths.get(serverHome, "tika-server.jar");
+        Assumptions.assumeTrue(Files.exists(serverJar),
+                "tika-server.jar not found at " + serverJar + "; skipping HTTP/2 e2e test. " +
+                "Build with: mvn package -pl tika-server/tika-server-standard && " +
+                "mvn test -pl tika-e2e-tests/tika-server -Pe2e");
 
-        log.info("Starting tika-server-standard from: {}", jarPath);
+        log.info("Starting tika-server from: {}", serverJar);
         ProcessBuilder pb = new ProcessBuilder(
-                "java", "-jar", jarPath,
+                "java", "-jar", "tika-server.jar",
                 "-p", String.valueOf(port),
                 "-h", "localhost"
         );
+        pb.directory(Paths.get(serverHome).toFile());
         pb.redirectErrorStream(true);
         serverProcess = pb.start();
 
@@ -104,7 +104,7 @@ public class TikaServerHttp2Test {
                     new InputStreamReader(serverProcess.getInputStream(), UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    log.debug("tika-server: {}", line);
+                    log.info("tika-server: {}", line);
                 }
             } catch (Exception e) {
                 log.debug("Server output stream closed", e);
@@ -125,19 +125,19 @@ public class TikaServerHttp2Test {
     }
 
     @Test
-    void testH2cStatusEndpoint() throws Exception {
+    void testH2cTikaEndpoint() throws Exception {
         HttpClient httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_2)
                 .build();
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(endPoint + STATUS_PATH))
-                .header("Accept", "application/json")
+                .uri(URI.create(endPoint + "/tika"))
+                .header("Accept", "text/plain")
                 .GET()
                 .build();
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
 
-        assertEquals(200, response.statusCode(), "Expected 200 from /status");
+        assertEquals(200, response.statusCode(), "Expected 200 from /tika");
         assertEquals(HttpClient.Version.HTTP_2, response.version(),
                 "Expected HTTP/2 protocol; server may be missing http2-server on classpath");
         log.info("HTTP/2 h2c verified: {} {}", response.statusCode(), response.version());
@@ -149,7 +149,14 @@ public class TikaServerHttp2Test {
                 .version(HttpClient.Version.HTTP_2)
                 .build();
 
-        // Send a small plain-text document for parsing
+        // First: GET / to negotiate h2c upgrade, establishing an HTTP/2 connection
+        HttpRequest warmup = HttpRequest.newBuilder()
+                .uri(URI.create(endPoint + "/"))
+                .GET()
+                .build();
+        httpClient.send(warmup, HttpResponse.BodyHandlers.discarding());
+
+        // Now PUT /tika — the existing HTTP/2 connection is reused
         byte[] body = "Hello, HTTP/2 world!".getBytes(UTF_8);
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(endPoint + "/tika"))
@@ -166,26 +173,34 @@ public class TikaServerHttp2Test {
     }
 
     private void awaitServerStartup() throws Exception {
-        // Use HTTP/1.1 for the health-check poll so we don't depend on HTTP/2 during startup
+        // Use HTTP/1.1 for the health-check poll so we don't depend on HTTP/2 during startup.
+        // Both connectTimeout and request timeout are set to avoid hanging when Jetty has bound
+        // the port but CXF has not yet finished initializing (accepts TCP but doesn't respond).
         HttpClient pollClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
-                .connectTimeout(Duration.ofSeconds(2))
-                .build();
-        HttpRequest pollRequest = HttpRequest.newBuilder()
-                .uri(URI.create(endPoint + STATUS_PATH))
-                .GET()
+                .connectTimeout(Duration.ofSeconds(5))
                 .build();
 
         Instant deadline = Instant.now().plusMillis(SERVER_STARTUP_TIMEOUT_MS);
         while (Instant.now().isBefore(deadline)) {
+            if (!serverProcess.isAlive()) {
+                throw new IllegalStateException(
+                        "tika-server process exited unexpectedly with code " + serverProcess.exitValue());
+            }
             try {
+                HttpRequest pollRequest = HttpRequest.newBuilder()
+                        .uri(URI.create(endPoint + HEALTH_PATH))
+                        .timeout(Duration.ofSeconds(5))
+                        .GET()
+                        .build();
                 HttpResponse<Void> resp = pollClient.send(pollRequest, HttpResponse.BodyHandlers.discarding());
                 if (resp.statusCode() == 200) {
                     log.info("tika-server ready on port {}", port);
                     return;
                 }
+                log.debug("Server returned {} on {}; still waiting...", resp.statusCode(), HEALTH_PATH);
             } catch (Exception e) {
-                log.debug("Waiting for server on port {} ...", port);
+                log.debug("Waiting for server on port {}: {}", port, e.getMessage());
             }
             Thread.sleep(1000);
         }

--- a/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
+++ b/tika-e2e-tests/tika-server/src/test/java/org/apache/tika/server/e2e/TikaServerHttp2Test.java
@@ -71,8 +71,7 @@ public class TikaServerHttp2Test {
         String serverHome = System.getProperty("tika.server.home");
         if (serverHome == null) {
             // fall back to conventional location relative to this module
-            Path moduleDir = Paths.get("").toAbsolutePath();
-            Path repoRoot = moduleDir;
+            Path repoRoot = Paths.get("").toAbsolutePath();
             while (repoRoot != null && !repoRoot.resolve("tika-server").toFile().isDirectory()) {
                 repoRoot = repoRoot.getParent();
             }
@@ -120,7 +119,10 @@ public class TikaServerHttp2Test {
     void stopServer() throws Exception {
         if (serverProcess != null && serverProcess.isAlive()) {
             serverProcess.destroy();
-            serverProcess.waitFor();
+            if (!serverProcess.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                serverProcess.destroyForcibly();
+                serverProcess.waitFor(30, java.util.concurrent.TimeUnit.SECONDS);
+            }
         }
     }
 

--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -587,6 +587,11 @@
         <version>${jetty.http2.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty.http2</groupId>
+        <artifactId>http2-server</artifactId>
+        <version>${jetty.http2.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
         <version>${jsoup.version}</version>

--- a/tika-server/tika-server-core/pom.xml
+++ b/tika-server/tika-server-core/pom.xml
@@ -90,6 +90,10 @@
       <artifactId>cxf-rt-transports-http-jetty</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.http2</groupId>
+      <artifactId>http2-server</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-security-cors</artifactId>
     </dependency>

--- a/tika-server/tika-server-core/src/test/java/org/apache/tika/server/core/TikaServerIntegrationTest.java
+++ b/tika-server/tika-server-core/src/test/java/org/apache/tika/server/core/TikaServerIntegrationTest.java
@@ -24,7 +24,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -98,6 +102,24 @@ public class TikaServerIntegrationTest extends IntegrationTestBase {
         // Test that pipes-based parsing works for normal documents
         startProcess(new String[]{"-config", getConfig("tika-config-server-pipes-basic.json")});
         testBaseline();
+    }
+
+    @Test
+    public void testH2c() throws Exception {
+        startProcess(new String[]{"-config", getConfig("tika-config-server-basic.json")});
+        awaitServerStartup();
+        // Using HttpClient in order to check Http2 Version
+        HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .build();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(endPoint + STATUS_PATH))
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
+        assertEquals(200, response.statusCode());
+        assertEquals(HttpClient.Version.HTTP_2, response.version());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds HTTP/2 (h2c cleartext) support to tika-server by including the `org.eclipse.jetty.http2:http2-server` jar on the classpath. When this jar is present, CXF's Jetty transport automatically negotiates HTTP/2 alongside HTTP/1.1 on the existing port (default 9998). Existing HTTP/1.1 clients are completely unaffected.

This implements [TIKA-4679](https://issues.apache.org/jira/browse/TIKA-4679). The core dependency change was originally contributed by Lawrence Moorehead ([@elemdisc](https://github.com/elemdisc)) — see [elemdisc/tika PR#1](https://github.com/elemdisc/tika/pull/1) — and is cherry-picked here with full author credit.

---

## Changes

### tika-parent/pom.xml
- Added `http2-server` to the dependency management block alongside the existing `http2-hpack`, `http2-client`, `http2-common` entries (all at `${jetty.http2.version}`)

### tika-server/tika-server-core/pom.xml _(Lawrence Moorehead's commit)_
- Added `org.eclipse.jetty.http2:http2-server` runtime dependency (version from parent BOM)

### tika-server/tika-server-core/src/test/.../TikaServerIntegrationTest.java _(Lawrence Moorehead's commit)_
- Added `testH2c()` unit test that sends a request via `HttpClient.Version.HTTP_2` and asserts the response was served over HTTP/2

### tika-e2e-tests/tika-server/ _(new module)_
- New e2e module that starts the actual fat-jar process and validates HTTP/2 (h2c) end-to-end
- Tests are skipped by default; run with `-Pe2e`
- Wired into `tika-e2e-tests/pom.xml`

---

## How it works

Adding `http2-server` to the classpath is sufficient for h2c (HTTP/2 cleartext) support. CXF's `JettyHTTPServerEngineFactory` detects the jar at startup and wires in `HTTP2CServerConnectionFactory`. No startup code changes are required.

For h2 over TLS (recommended for production), configure `TlsConfig` in `tika-server.json`. Java 17's built-in ALPN handles protocol negotiation automatically — no separate ALPN agent is needed.

---

## Port management

- Single port (9998 by default) continues to serve both HTTP/1.1 and HTTP/2
- No second port added; Docker `EXPOSE 9998` and health-check are unchanged
- The fat-jar grows by ~500 KB from the new jar

---

## Shutdown note

HTTP/2 multiplexes multiple requests over a single TCP connection. The current `shutdownNow()` path does not send a GOAWAY frame before closing. Under moderate load this is acceptable for h2c, but a future improvement could add a drain timeout for graceful HTTP/2 shutdown.

---

## Backward compatibility

Purely additive classpath change:
- Does **not** change the default port
- Does **not** require TLS (TLS remains opt-in)
- Does **not** break any existing HTTP/1.1 client
- Does **not** change the REST API surface

---

## Testing Instructions

```bash
# Unit test (no external process)
mvn test -pl tika-server/tika-server-core -Dtest=TikaServerIntegrationTest#testH2c

# E2E test (requires fat-jar to be built first)
mvn package -pl tika-server/tika-server-standard -DskipTests
mvn test -pl tika-e2e-tests/tika-server -Pe2e
```

Manually with curl (after starting the server):
```bash
# HTTP/2 cleartext (h2c)
curl --http2-prior-knowledge http://localhost:9998/tika

# HTTP/1.1 — unchanged behavior
curl http://localhost:9998/tika
```

---

## Review Checklist

- [ ] `http2-server` version comes from `${jetty.http2.version}` in parent BOM (not hardcoded)
- [ ] Existing HTTP/1.1 tests still pass
- [ ] `TikaServerIntegrationTest#testH2c` passes
- [ ] E2E module compiles and tests pass with `-Pe2e`
- [ ] No second port introduced

---

## Potential Concerns

- **h2c vs h2**: This PR enables h2c (cleartext). For h2 over TLS an additional `jetty-alpn-java-server` dependency may be needed depending on the Jetty version and JVM. This can be addressed in a follow-up.
- **Reverse proxies**: Most reverse proxies (nginx, AWS ALB, GCP LB) do not support h2c — they require h2 over TLS. For internal service-to-service use h2c is fine; for edge deployments, TLS is recommended.
- **Fat-jar size**: The `http2-server` jar adds ~500 KB to `tika-server-standard`. This also increases the `apache/tika` Docker image slightly.