### PR TITLE
fix 'occured' -> 'occurred' in JoshuaNetworkTranslator log

### DIFF
--- a/tika-translate/src/main/java/org/apache/tika/language/translate/impl/JoshuaNetworkTranslator.java
+++ b/tika-translate/src/main/java/org/apache/tika/language/translate/impl/JoshuaNetworkTranslator.java
@@ -95,7 +95,7 @@ public class JoshuaNetworkTranslator extends AbstractTranslator {
                 networkServer = props.getProperty(JOSHUA_SERVER);
             }
         } catch (IOException e) {
-            LOG.error("An error occured whilst reading translator.joshua.properties file", e);
+            LOG.error("An error occurred whilst reading translator.joshua.properties file", e);
         }
     }
 


### PR DESCRIPTION
Trivial spelling fix in a `LOG.error` message emitted when reading the Joshua translator properties file fails:

`An error occurred whilst reading translator.joshua.properties file`

No functional changes.