### PR TITLE
TIKA-4703: Pin docker/* actions to SHA digests per ASF policy (INFRA-27837)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -37,19 +37,19 @@ jobs:
           echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up QEMU for multi-arch
-        uses: docker/setup-qemu-action@v3
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push tika-server minimal
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           file: tika-server/docker-build/minimal/Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/s390x
@@ -61,7 +61,7 @@ jobs:
             apache/tika:latest
 
       - name: Build and push tika-server full
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           file: tika-server/docker-build/full/Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/s390x
@@ -96,13 +96,13 @@ jobs:
         run: mvn clean install -DskipTests -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up QEMU for multi-arch
-        uses: docker/setup-qemu-action@v3
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -142,7 +142,7 @@ jobs:
           cp "tika-grpc/docker-build/Dockerfile" "${OUT_DIR}/Dockerfile"
 
       - name: Build and push tika-grpc
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: target/tika-grpc-docker
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -49,13 +49,13 @@ jobs:
         run: mvn clean install -DskipTests -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up QEMU for multi-arch
-        uses: docker/setup-qemu-action@v3
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
           cp "tika-server/docker-build/minimal/Dockerfile.snapshot" "${OUT_DIR}/Dockerfile"
 
       - name: Build and push tika-server minimal snapshot
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: target/tika-server-minimal-docker
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/s390x
@@ -90,7 +90,7 @@ jobs:
           cp "tika-server/docker-build/full/Dockerfile.snapshot" "${OUT_DIR}/Dockerfile"
 
       - name: Build and push tika-server full snapshot
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: target/tika-server-full-docker
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/s390x
@@ -136,7 +136,7 @@ jobs:
           cp "tika-grpc/docker-build/Dockerfile" "${OUT_DIR}/Dockerfile"
 
       - name: Build and push tika-grpc snapshot
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: target/tika-grpc-docker
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Pin all `docker/*` GitHub Actions to exact commit SHAs to comply with the Apache GitHub Actions allowlist policy, as recommended by Dianjin Wang (ASF Infra) on [INFRA-27837](https://issues.apache.org/jira/browse/INFRA-27837). This mirrors the same fix applied in [apache/cloudberry#1688](https://github.com/apache/cloudberry/pull/1688).

## Changes

| Action | Before | After |
|--------|--------|-------|
| `docker/setup-buildx-action` | `@v3` | `@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` (v3.12.0) |
| `docker/login-action` | `@v3` | `@c94ce9fb468520275223c153574b00df6fe4bcc9` (v3.7.0) |
| `docker/build-push-action` | `@v6` | `@10e90e3645eae34f1e60eeb005ba3a3d33f178e8` (v6.19.2) |
| `docker/setup-qemu-action` | `@v3` action | Native CLI: `docker run --privileged tonistiigi/binfmt --install all` |

`docker/setup-qemu-action` is replaced with a native CLI step because it is still not on the ASF allowlist (noted by INFRA team as an open issue).

## Critical Files

- `.github/workflows/docker-snapshot.yml`
- `.github/workflows/docker-release.yml`