### PR TITLE
TIKA-4703: Fix Docker Hub secret name (DOCKERHUB_USERNAME -> DOCKERHUB_USER)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push tika-server minimal
@@ -104,7 +104,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Prepare tika-grpc Docker build context

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # --- tika-server (minimal) ---


### PR DESCRIPTION
## Summary

The Docker Hub org secret is named `DOCKERHUB_USER`, not `DOCKERHUB_USERNAME`. This caused the Docker login step to fail silently with an empty username.

## Changes

- `.github/workflows/docker-snapshot.yml`: 1 occurrence fixed
- `.github/workflows/docker-release.yml`: 2 occurrences fixed