### PR TITLE
TIKA-4703: Fix chmod failure in tika-grpc Dockerfile on CI

### DIFF
--- a/tika-grpc/docker-build/Dockerfile
+++ b/tika-grpc/docker-build/Dockerfile
@@ -49,6 +49,8 @@ RUN set -eux \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN chmod +x "/tika/bin/start-tika-grpc.sh"
+
 USER $UID_GID
 
 EXPOSE 9090
@@ -56,7 +58,6 @@ ENV TIKA_VERSION=$VERSION
 ENV TIKA_GRPC_MAX_INBOUND_MESSAGE_SIZE=$TIKA_GRPC_MAX_INBOUND_MESSAGE_SIZE
 ENV TIKA_GRPC_MAX_OUTBOUND_MESSAGE_SIZE=$TIKA_GRPC_MAX_OUTBOUND_MESSAGE_SIZE
 ENV TIKA_GRPC_NUM_THREADS=$TIKA_GRPC_NUM_THREADS
-RUN chmod +x "/tika/bin/start-tika-grpc.sh"
 ENTRYPOINT ["/tika/bin/start-tika-grpc.sh"]
 
 LABEL maintainer="Apache Tika Developers dev@tika.apache.org"


### PR DESCRIPTION
## Summary

The `chmod +x` on `start-tika-grpc.sh` was placed **after** the `USER $UID_GID` directive, causing it to run as the non-root user — which cannot change permissions on a root-owned file. This silently passed locally (the file already had the execute bit on the dev filesystem) but failed in CI where the build context is clean.

## Root Cause

```dockerfile
USER $UID_GID          # switch to non-root
...
RUN chmod +x "/tika/bin/start-tika-grpc.sh"  # ❌ non-root can't chmod root-owned file
```

## Fix

Move the `chmod` to before the `USER` switch so it runs as root:

```dockerfile
RUN chmod +x "/tika/bin/start-tika-grpc.sh"  # ✅ runs as root
USER $UID_GID
```

## Critical Files

- `tika-grpc/docker-build/Dockerfile`