### PR TITLE
TIKA-4703: Fix tika-grpc Docker image missing runtime dependencies

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -107,18 +107,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Collect tika-grpc runtime dependencies
-        run: mvn -pl tika-grpc dependency:copy-dependencies -DoutputDirectory=target/lib -DincludeScope=runtime -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
-
       - name: Prepare tika-grpc Docker build context
         run: |
           TIKA_VERSION="${{ steps.version.outputs.tag }}"
           OUT_DIR=target/tika-grpc-docker
 
-          mkdir -p "${OUT_DIR}/libs/lib" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
+          mkdir -p "${OUT_DIR}/libs/tika-grpc" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
 
           cp "tika-grpc/target/tika-grpc-${TIKA_VERSION}.jar" "${OUT_DIR}/libs/"
-          cp tika-grpc/target/lib/*.jar "${OUT_DIR}/libs/lib/"
+          mvn -pl tika-grpc dependency:copy-dependencies \
+            -DoutputDirectory="${PWD}/${OUT_DIR}/libs/tika-grpc" \
+            -DincludeScope=runtime -q -B
 
           # Copy tika-pipes plugin zip files
           for dir in tika-pipes/tika-pipes-plugins/*/; do

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -107,14 +107,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Collect tika-grpc runtime dependencies
+        run: mvn -pl tika-grpc dependency:copy-dependencies -DoutputDirectory=target/lib -DincludeScope=runtime -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
       - name: Prepare tika-grpc Docker build context
         run: |
           TIKA_VERSION="${{ steps.version.outputs.tag }}"
           OUT_DIR=target/tika-grpc-docker
 
-          mkdir -p "${OUT_DIR}/libs" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
+          mkdir -p "${OUT_DIR}/libs/lib" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
 
           cp "tika-grpc/target/tika-grpc-${TIKA_VERSION}.jar" "${OUT_DIR}/libs/"
+          cp tika-grpc/target/lib/*.jar "${OUT_DIR}/libs/lib/"
 
           # Copy tika-pipes plugin zip files
           for dir in tika-pipes/tika-pipes-plugins/*/; do

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -69,6 +69,32 @@ jobs:
           tar xzf "tika-server/tika-server-standard/target/tika-server-standard-${TIKA_VERSION}-bin.tgz" -C "${OUT_DIR}/tika-server"
           cp "tika-server/docker-build/minimal/Dockerfile.snapshot" "${OUT_DIR}/Dockerfile"
 
+      - name: Build tika-server minimal image for smoke test
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: target/tika-server-minimal-docker
+          platforms: linux/amd64
+          load: true
+          build-args: |
+            TIKA_VERSION=${{ steps.version.outputs.tika_version }}
+          tags: tika-server-minimal-smoke:ci
+
+      - name: Smoke test tika-server minimal image
+        run: |
+          docker run -d --name tika-server-minimal-smoke -p 9998:9998 tika-server-minimal-smoke:ci
+          for i in $(seq 1 20); do
+            if docker logs tika-server-minimal-smoke 2>&1 | grep -q "Started Apache Tika server"; then
+              echo "tika-server minimal started successfully"
+              docker stop tika-server-minimal-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: tika-server minimal did not start within 40 seconds"
+          docker logs tika-server-minimal-smoke
+          docker stop tika-server-minimal-smoke
+          exit 1
+
       - name: Build and push tika-server minimal snapshot
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -88,6 +114,32 @@ jobs:
           mkdir -p "${OUT_DIR}/tika-server"
           tar xzf "tika-server/tika-server-standard/target/tika-server-standard-${TIKA_VERSION}-bin.tgz" -C "${OUT_DIR}/tika-server"
           cp "tika-server/docker-build/full/Dockerfile.snapshot" "${OUT_DIR}/Dockerfile"
+
+      - name: Build tika-server full image for smoke test
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: target/tika-server-full-docker
+          platforms: linux/amd64
+          load: true
+          build-args: |
+            TIKA_VERSION=${{ steps.version.outputs.tika_version }}
+          tags: tika-server-full-smoke:ci
+
+      - name: Smoke test tika-server full image
+        run: |
+          docker run -d --name tika-server-full-smoke -p 9999:9998 tika-server-full-smoke:ci
+          for i in $(seq 1 20); do
+            if docker logs tika-server-full-smoke 2>&1 | grep -q "Started Apache Tika server"; then
+              echo "tika-server full started successfully"
+              docker stop tika-server-full-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: tika-server full did not start within 40 seconds"
+          docker logs tika-server-full-smoke
+          docker stop tika-server-full-smoke
+          exit 1
 
       - name: Build and push tika-server full snapshot
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -101,18 +101,17 @@ jobs:
             apache/tika:${{ steps.version.outputs.tika_version }}-full
 
       # --- tika-grpc ---
-      - name: Collect tika-grpc runtime dependencies
-        run: mvn -pl tika-grpc dependency:copy-dependencies -DoutputDirectory=target/lib -DincludeScope=runtime -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
-
       - name: Prepare tika-grpc Docker build context
         run: |
           TIKA_VERSION="${{ steps.version.outputs.tika_version }}"
           OUT_DIR=target/tika-grpc-docker
 
-          mkdir -p "${OUT_DIR}/libs/lib" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
+          mkdir -p "${OUT_DIR}/libs/tika-grpc" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
 
           cp "tika-grpc/target/tika-grpc-${TIKA_VERSION}.jar" "${OUT_DIR}/libs/"
-          cp tika-grpc/target/lib/*.jar "${OUT_DIR}/libs/lib/"
+          mvn -pl tika-grpc dependency:copy-dependencies \
+            -DoutputDirectory="${PWD}/${OUT_DIR}/libs/tika-grpc" \
+            -DincludeScope=runtime -q -B
 
           # Copy tika-pipes plugin zip files
           for dir in tika-pipes/tika-pipes-plugins/*/; do
@@ -138,6 +137,32 @@ jobs:
 
           cp "tika-grpc/docker-build/start-tika-grpc.sh" "${OUT_DIR}/bin/"
           cp "tika-grpc/docker-build/Dockerfile" "${OUT_DIR}/Dockerfile"
+
+      - name: Build tika-grpc image for smoke test
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: target/tika-grpc-docker
+          platforms: linux/amd64
+          load: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.tika_version }}
+          tags: tika-grpc-smoke:ci
+
+      - name: Smoke test tika-grpc image
+        run: |
+          docker run -d --name tika-grpc-smoke -p 9090:9090 tika-grpc-smoke:ci
+          for i in $(seq 1 15); do
+            if docker logs tika-grpc-smoke 2>&1 | grep -q "Server started, listening on"; then
+              echo "tika-grpc started successfully"
+              docker stop tika-grpc-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: tika-grpc did not start within 30 seconds"
+          docker logs tika-grpc-smoke
+          docker stop tika-grpc-smoke
+          exit 1
 
       - name: Build and push tika-grpc snapshot
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -81,18 +81,24 @@ jobs:
 
       - name: Smoke test tika-server minimal image
         run: |
+          cleanup() {
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              docker logs tika-server-minimal-smoke || true
+            fi
+            docker rm -f tika-server-minimal-smoke >/dev/null 2>&1 || true
+            exit "$status"
+          }
+          trap cleanup EXIT
           docker run -d --name tika-server-minimal-smoke -p 9998:9998 tika-server-minimal-smoke:ci
           for i in $(seq 1 20); do
             if docker logs tika-server-minimal-smoke 2>&1 | grep -q "Started Apache Tika server"; then
               echo "tika-server minimal started successfully"
-              docker stop tika-server-minimal-smoke
               exit 0
             fi
             sleep 2
           done
           echo "ERROR: tika-server minimal did not start within 40 seconds"
-          docker logs tika-server-minimal-smoke
-          docker stop tika-server-minimal-smoke
           exit 1
 
       - name: Build and push tika-server minimal snapshot
@@ -127,18 +133,24 @@ jobs:
 
       - name: Smoke test tika-server full image
         run: |
+          cleanup() {
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              docker logs tika-server-full-smoke || true
+            fi
+            docker rm -f tika-server-full-smoke >/dev/null 2>&1 || true
+            exit "$status"
+          }
+          trap cleanup EXIT
           docker run -d --name tika-server-full-smoke -p 9999:9998 tika-server-full-smoke:ci
           for i in $(seq 1 20); do
             if docker logs tika-server-full-smoke 2>&1 | grep -q "Started Apache Tika server"; then
               echo "tika-server full started successfully"
-              docker stop tika-server-full-smoke
               exit 0
             fi
             sleep 2
           done
           echo "ERROR: tika-server full did not start within 40 seconds"
-          docker logs tika-server-full-smoke
-          docker stop tika-server-full-smoke
           exit 1
 
       - name: Build and push tika-server full snapshot
@@ -202,18 +214,26 @@ jobs:
 
       - name: Smoke test tika-grpc image
         run: |
+          cleanup() {
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              docker logs tika-grpc-smoke || true
+              docker ps -a --filter "name=^tika-grpc-smoke$" || true
+              docker inspect -f '{{.State.ExitCode}}' tika-grpc-smoke || true
+            fi
+            docker rm -f tika-grpc-smoke >/dev/null 2>&1 || true
+            exit "$status"
+          }
+          trap cleanup EXIT
           docker run -d --name tika-grpc-smoke -p 9090:9090 tika-grpc-smoke:ci
           for i in $(seq 1 15); do
             if docker logs tika-grpc-smoke 2>&1 | grep -q "Server started, listening on"; then
               echo "tika-grpc started successfully"
-              docker stop tika-grpc-smoke
               exit 0
             fi
             sleep 2
           done
           echo "ERROR: tika-grpc did not start within 30 seconds"
-          docker logs tika-grpc-smoke
-          docker stop tika-grpc-smoke
           exit 1
 
       - name: Build and push tika-grpc snapshot

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -101,14 +101,18 @@ jobs:
             apache/tika:${{ steps.version.outputs.tika_version }}-full
 
       # --- tika-grpc ---
+      - name: Collect tika-grpc runtime dependencies
+        run: mvn -pl tika-grpc dependency:copy-dependencies -DoutputDirectory=target/lib -DincludeScope=runtime -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
       - name: Prepare tika-grpc Docker build context
         run: |
           TIKA_VERSION="${{ steps.version.outputs.tika_version }}"
           OUT_DIR=target/tika-grpc-docker
 
-          mkdir -p "${OUT_DIR}/libs" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
+          mkdir -p "${OUT_DIR}/libs/lib" "${OUT_DIR}/plugins" "${OUT_DIR}/config" "${OUT_DIR}/bin"
 
           cp "tika-grpc/target/tika-grpc-${TIKA_VERSION}.jar" "${OUT_DIR}/libs/"
+          cp tika-grpc/target/lib/*.jar "${OUT_DIR}/libs/lib/"
 
           # Copy tika-pipes plugin zip files
           for dir in tika-pipes/tika-pipes-plugins/*/; do

--- a/tika-grpc/pom.xml
+++ b/tika-grpc/pom.xml
@@ -474,7 +474,7 @@
             <manifest>
               <mainClass>org.apache.tika.pipes.grpc.TikaGrpcServer</mainClass>
               <addClasspath>true</addClasspath>
-              <classpathPrefix>lib/</classpathPrefix>
+              <classpathPrefix>tika-grpc/</classpathPrefix>
             </manifest>
           </archive>
         </configuration>

--- a/tika-grpc/src/main/assembly/assembly.xml
+++ b/tika-grpc/src/main/assembly/assembly.xml
@@ -25,7 +25,7 @@
 
   <dependencySets>
     <dependencySet>
-      <outputDirectory>lib</outputDirectory>
+      <outputDirectory>tika-grpc</outputDirectory>
       <useProjectArtifact>false</useProjectArtifact>
       <unpack>false</unpack>
       <scope>runtime</scope>


### PR DESCRIPTION
## Summary

The `tika-grpc` Docker image was failing to start with:

```
Error: Unable to initialize main class org.apache.tika.pipes.grpc.TikaGrpcServer
Caused by: java.lang.NoClassDefFoundError: io/grpc/BindableService
```

## Root Cause

The Docker build context only copied the thin jar (`tika-grpc-X.jar`) but not its runtime dependencies. The jar's `MANIFEST.MF` has `Class-Path: tika-grpc/grpc-stub-X.jar tika-grpc/grpc-netty-shaded-X.jar ...` (set by `classpathPrefix` in `maven-jar-plugin`), so Java looks for deps relative to the jar — and they were not present in the image.

## Changes

- **`tika-grpc/pom.xml`**: Changed `classpathPrefix` from `lib/` to `tika-grpc/` so the `MANIFEST.MF` Class-Path entries match the actual directory layout in the image
- **`docker-snapshot.yml` / `docker-release.yml`**: Use `mvn dependency:copy-dependencies` to collect runtime deps into `libs/tika-grpc/` alongside the main jar; consolidate into a single Prepare step
- **Smoke tests**: All three images (tika-server minimal, tika-server full, tika-grpc) now have a smoke test step that builds a single-arch image with `--load`, starts the container, and polls for the startup log line before the final multi-arch push — CI fails if the server doesn't start within the timeout

## Final image layout

```
/tika/libs/tika-grpc-X.jar        ← main jar
/tika/libs/tika-grpc/*.jar         ← runtime deps (matches MANIFEST Class-Path)
```

## Critical Files

- `tika-grpc/pom.xml`
- `.github/workflows/docker-snapshot.yml`
- `.github/workflows/docker-release.yml`

## Testing

Smoke tested locally — all three images start cleanly:
- `tika-grpc`: `Server started, listening on 9090`
- `tika-server minimal`: `Started Apache Tika server ... at http://0.0.0.0:9998/`