### PR TITLE
TIKA-4721: Fix TOCTOU race in SharedServerManager port assignment

### DIFF
--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/SharedServerManager.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/SharedServerManager.java
@@ -334,7 +334,11 @@ public class SharedServerManager implements ServerManager {
                     String line = reader.readLine();
                     if (line != null && line.startsWith("READY:")) {
                         String portStr = line.substring("READY:".length()).trim();
-                        return Integer.parseInt(portStr);
+                        int port = Integer.parseInt(portStr);
+                        if (port <= 0 || port > 65535) {
+                            throw new IOException("Server reported invalid port: " + port);
+                        }
+                        return port;
                     }
                 } else {
                     // No data available, sleep briefly

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/SharedServerManager.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/SharedServerManager.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -242,14 +241,6 @@ public class SharedServerManager implements ServerManager {
             shutdownUnsafe();
         }
 
-        // Find a free port for the server to listen on
-        int port;
-        try (ServerSocket tempSocket = new ServerSocket()) {
-            tempSocket.setReuseAddress(true);
-            tempSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
-            port = tempSocket.getLocalPort();
-        }
-
         // Generate auth token for this server instance
         byte[] token = new byte[PipesServer.AUTH_TOKEN_LENGTH_BYTES];
         new SecureRandom().nextBytes(token);
@@ -287,7 +278,10 @@ public class SharedServerManager implements ServerManager {
         // Pass port and auth token via environment variables so they are not
         // visible in /proc/<pid>/cmdline. The token is only readable via
         // /proc/<pid>/environ which requires same-uid access.
-        pb.environment().put("TIKA_PIPES_PORT", Integer.toString(port));
+        // Pass port=0 so the server binds to any available ephemeral port.
+        // The actual port is read back from the READY:{port} stdout signal,
+        // eliminating the TOCTOU race between probing a free port and binding it.
+        pb.environment().put("TIKA_PIPES_PORT", "0");
         pb.environment().put("TIKA_PIPES_AUTH_TOKEN", HexFormat.of().formatHex(token));
         // Redirect stderr to inherit, capture stdout to read the READY signal
         pb.redirectErrorStream(false);
@@ -306,13 +300,12 @@ public class SharedServerManager implements ServerManager {
             throw new ServerInitializationException(msg, e);
         }
 
-        // Wait for the server to signal it's ready by printing the port
-        waitForServerReady(port);
-        serverPort = port;
-        LOG.info("Shared server started successfully");
+        // Wait for the server to signal it's ready and report the port it actually bound to
+        serverPort = waitForServerReady();
+        LOG.info("Shared server started successfully on port {}", serverPort);
     }
 
-    private void waitForServerReady(int expectedPort) throws IOException, ServerInitializationException {
+    private int waitForServerReady() throws IOException, ServerInitializationException {
         long startTime = System.currentTimeMillis();
 
         try (BufferedReader reader = new BufferedReader(
@@ -340,13 +333,8 @@ public class SharedServerManager implements ServerManager {
                 if (reader.ready()) {
                     String line = reader.readLine();
                     if (line != null && line.startsWith("READY:")) {
-                        // Server is ready, parse the port
                         String portStr = line.substring("READY:".length()).trim();
-                        int actualPort = Integer.parseInt(portStr);
-                        if (actualPort != expectedPort) {
-                            LOG.warn("Server reported different port {} than expected {}", actualPort, expectedPort);
-                        }
-                        return;
+                        return Integer.parseInt(portStr);
                     }
                 } else {
                     // No data available, sleep briefly

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
@@ -255,8 +255,8 @@ public class PipesServer implements AutoCloseable {
             serverSocket.setReuseAddress(true);
             serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), port), numConnections);
 
-            // Signal readiness to the parent process via stdout
-            System.out.println("READY:" + port);
+            // Signal readiness to the parent process via stdout, reporting the actual bound port
+            System.out.println("READY:" + serverSocket.getLocalPort());
             System.out.flush();
 
             LOG.info("Shared server ready, accepting connections");


### PR DESCRIPTION
## Summary

Fixes the intermittent `testGracefulShutdown` failure in the **main jdk17 windows build (multi-locale)** CI job (tr_TR.UTF-8 / de_DE.UTF-8).

The failure was **not** locale-related despite appearing only in that job. The root cause was a TOCTOU (time-of-check-time-of-use) race in `SharedServerManager.startServer()`:

1. A `ServerSocket` was opened to find a free port → then **closed**
2. The child process was started and told to bind to that same port
3. Between step 1 and step 2, another process (or the OS in TIME_WAIT state, which is far more common on slow Windows runners) could grab the port

When this happened, the child process failed to bind, never printed `READY:{port}`, and the parse on the next iteration returned a non-success result.

## Changes

**`SharedServerManager`**
- Remove the TOCTOU port probe (open/close ServerSocket just to learn a port)
- Pass `TIKA_PIPES_PORT=0` to the child process
- `waitForServerReady()` now returns the actual port read from the `READY:{port}` signal and sets `serverPort` accordingly

**`PipesServer`**
- In `runSharedMode()`, print `READY:{serverSocket.getLocalPort()}` instead of `READY:{port}` so the actual ephemeral port assigned by the OS is reported

## Review Focus Areas

- `SharedServerManager.startServer()` — TOCTOU removal
- `SharedServerManager.waitForServerReady()` — now returns int (actual port)
- `PipesServer.runSharedMode()` — `getLocalPort()` instead of `port`

## Critical Files

- `tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/SharedServerManager.java`
- `tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java`

## Testing Instructions

```bash
cd tika-pipes/tika-pipes-integration-tests
mvn test -Dtest=SharedServerModeTest#testGracefulShutdown
```

The existing CI job **main jdk17 windows build (multi-locale)** should stop failing intermittently once this merges.

## Review Checklist

- [x] No functional behavior change — shared server still starts on a free port, clients connect to the same port
- [x] Removes a latent race condition that was causing intermittent CI failures
- [x] No new dependencies or test infrastructure changes needed

## Potential Concerns

The `READY:{port}` stdout protocol is internal — only `SharedServerManager` reads it. No external consumers are affected by this change.

Closes TIKA-4721