### PR TITLE
TIKA-4703: Fix tika-grpc container permissions for /tika/plugins directory

### DIFF
--- a/tika-grpc/docker-build/Dockerfile
+++ b/tika-grpc/docker-build/Dockerfile
@@ -49,7 +49,8 @@ RUN set -eux \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN chmod +x "/tika/bin/start-tika-grpc.sh"
+RUN chmod +x "/tika/bin/start-tika-grpc.sh" \
+    && chown -R ${UID_GID} /tika
 
 USER $UID_GID
 


### PR DESCRIPTION
## Summary

Fixes the tika-grpc Docker container startup crash (IOException: Failed to create directory) caused by pf4j being unable to write temp dirs inside /tika/plugins when running as non-root user 35002:35002.

## Root Cause

pf4j creates temp directories alongside plugin zip files when unzipping them (e.g. tika-pipes-google-drive-4.0.0-SNAPSHOT.tmp.<uuid>). The COPY instruction runs as root so /tika is owned by root. The non-root container user cannot write there.

## Changes

- tika-grpc/docker-build/Dockerfile: add chown -R ${UID_GID} /tika in the same RUN step as chmod, before the USER switch.

## Testing

Built and ran locally. Server starts successfully with all 15 pf4j plugins loaded and logs: Server started, listening on 9090. Previously the container crashed immediately with IOException.