### PR TITLE
Add maxPages option to PDFParserConfig to limit page processing

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-integration-tests/src/test/resources/config-examples/pdf-parser-full.json
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-integration-tests/src/test/resources/config-examples/pdf-parser-full.json
@@ -25,6 +25,7 @@
         "imageStrategy": "NONE",
         "maxIncrementalUpdates": 10,
         "maxMainMemoryBytes": 536870912,
+        "maxPages": -1,
         "ocr": {
           "dpi": 300,
           // Options: PNG, TIFF, JPEG

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
@@ -1486,7 +1486,11 @@ class AbstractPDF2XHTML extends PDFTextStripper {
      */
     @Override
     protected void processPages(PDPageTree pages) throws IOException {
+        int maxPages = config.getMaxPages();
         for (PDPage page : pages) {
+            if (maxPages > 0 && getCurrentPageNo() > maxPages) {
+                break;
+            }
             if (getCurrentPageNo() >= getStartPage() && getCurrentPageNo() <= getEndPage()) {
                 processPage(page);
             }

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/AbstractPDF2XHTML.java
@@ -1487,12 +1487,14 @@ class AbstractPDF2XHTML extends PDFTextStripper {
     @Override
     protected void processPages(PDPageTree pages) throws IOException {
         int maxPages = config.getMaxPages();
+        int pagesProcessed = 0;
         for (PDPage page : pages) {
-            if (maxPages > 0 && getCurrentPageNo() > maxPages) {
+            if (maxPages > 0 && pagesProcessed >= maxPages) {
                 break;
             }
             if (getCurrentPageNo() >= getStartPage() && getCurrentPageNo() <= getEndPage()) {
                 processPage(page);
+                pagesProcessed++;
             }
             pageIndex++;
         }

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/PDFParserConfig.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/PDFParserConfig.java
@@ -147,6 +147,8 @@ public class PDFParserConfig implements Serializable {
 
     int maxIncrementalUpdates = 10;
 
+    private int maxPages = -1;
+
     private boolean throwOnEncryptedPayload = false;
 
     /**
@@ -768,6 +770,28 @@ public class PDFParserConfig implements Serializable {
      */
     public void setMaxIncrementalUpdates(int maxIncrementalUpdates) {
         this.maxIncrementalUpdates = maxIncrementalUpdates;
+    }
+
+    /**
+     * @return maximum number of pages to process, or -1 for no limit
+     */
+    public int getMaxPages() {
+        return maxPages;
+    }
+
+    /**
+     * Set the maximum number of pages to process per document.
+     * Use -1 (the default) for no limit.
+     *
+     * @param maxPages must be -1 or &gt;= 1
+     * @throws IllegalArgumentException if the value is 0 or less than -1
+     */
+    public void setMaxPages(int maxPages) {
+        if (maxPages != -1 && maxPages < 1) {
+            throw new IllegalArgumentException(
+                    "maxPages must be -1 (no limit) or >= 1, got: " + maxPages);
+        }
+        this.maxPages = maxPages;
     }
 
     public void setThrowOnEncryptedPayload(boolean throwOnEncryptedPayload) {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
@@ -1509,6 +1509,30 @@ public class PDFParserTest extends TikaTest {
         assertArrayEquals(expectedSubjectVals, m.getValues(TikaCoreProperties.SUBJECT));
     }
 
+    @Test
+    public void testMaxPages() throws Exception {
+        PDFParser parser = new PDFParser();
+        PDFParserConfig config = new PDFParserConfig();
+        config.setMaxPages(3);
+        ParseContext context = new ParseContext();
+        context.set(PDFParserConfig.class, config);
+
+        // testJournalParser.pdf has 10 pages; limiting to 3 must yield less content
+        String truncated = getText("testJournalParser.pdf", parser, new Metadata(), context);
+        String full = getText("testJournalParser.pdf", parser);
+        assertTrue(full.length() > truncated.length(),
+                "Full parse should yield more content than a 3-page-limited parse");
+    }
+
+    @Test
+    public void testMaxPagesInvalidValue() {
+        PDFParserConfig config = new PDFParserConfig();
+        assertThrows(IllegalArgumentException.class, () -> config.setMaxPages(0));
+        assertThrows(IllegalArgumentException.class, () -> config.setMaxPages(-2));
+        config.setMaxPages(-1);
+        config.setMaxPages(1);
+    }
+
     /**
     @Test
     public void testWriteLimit() throws Exception {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
@@ -1517,11 +1517,15 @@ public class PDFParserTest extends TikaTest {
         ParseContext context = new ParseContext();
         context.set(PDFParserConfig.class, config);
 
-        // testJournalParser.pdf has 10 pages; limiting to 3 must yield less content
+        // testJournalParser.pdf has 10 pages; limiting to 3 must process only the first 3 pages
         String truncated = getText("testJournalParser.pdf", parser, new Metadata(), context);
         String full = getText("testJournalParser.pdf", parser);
         assertTrue(full.length() > truncated.length(),
                 "Full parse should yield more content than a 3-page-limited parse");
+        assertTrue(truncated.contains("Scalability of Controlling"),
+                "Content from page 1 should be present in truncated output");
+        assertFalse(truncated.contains("CONCLUSION"),
+                "Content from page 10 should not be present in truncated output");
     }
 
     @Test


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                  
  - Adds `maxPages` field to `PDFParserConfig` (default `-1`, no limit)                                                                                                                                                                     
  - `AbstractPDF2XHTML.processPages()` breaks out of the page loop early when the limit is reached, skipping all text extraction, font mapping, and content stream work for subsequent pages
  - Setter validates that the value is -1 or >= 1, throwing `IllegalArgumentException` otherwise                                                                                                                                              
                                                                                                                                                                                                                                              
  ## Performance                                                                                                                                                                                                                              
  Benchmarked on a 738-page PDF:                                                                                                                                                                                                              
  - Full parse: ~1,800 ms                                                                                                                                                                                                                     
  - First 5 pages: ~135 ms (13× faster) 