### PR TITLE
TIKA-4723 follow-up: fix sqlite3 shade filter and correct docs

### DIFF
--- a/docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc
+++ b/docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc
@@ -170,9 +170,10 @@ plugins) locally; that build output is the build context for the
 `apache/tika-grpc` image and isn't published as a release artifact in its
 own right.
 
-tika-grpc requires at least one pf4j plugin to be loaded at startup; starting
-without plugins logs a `LOG.warn` with a download URL pointing at Apache dist.
-Fetcher-dependent RPC calls will fail at runtime if no plugins are present.
+tika-grpc expects pf4j plugins for full functionality; starting without
+plugins logs a warning with a download URL pointing at Apache dist.
+Most fetcher-dependent RPC calls will fail at runtime if no plugins are
+present.
 
 === Server: slim jar on Central, bin.zip on dist
 

--- a/docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc
+++ b/docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc
@@ -170,9 +170,9 @@ plugins) locally; that build output is the build context for the
 `apache/tika-grpc` image and isn't published as a release artifact in its
 own right.
 
-tika-grpc requires at least one pf4j plugin to be loaded at startup; an
-empty `plugins/` directory triggers a `TikaConfigException` with a
-download URL pointing at Apache dist.
+tika-grpc requires at least one pf4j plugin to be loaded at startup; starting
+without plugins logs a `LOG.warn` with a download URL pointing at Apache dist.
+Fetcher-dependent RPC calls will fail at runtime if no plugins are present.
 
 === Server: slim jar on Central, bin.zip on dist
 

--- a/tika-parsers/tika-parsers-extended/tika-parser-sqlite3-package/pom.xml
+++ b/tika-parsers/tika-parsers-extended/tika-parser-sqlite3-package/pom.xml
@@ -83,11 +83,14 @@
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
+                    <exclude>module-info.class</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>META-INF/DEPENDENCIES</exclude>
                     <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/LICENSE.md</exclude>
+                    <exclude>META-INF/NOTICE.md</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
## Summary

Follow-up fixes for [TIKA-4723](https://issues.apache.org/jira/browse/TIKA-4723) (merged via #2809).

## Changes

### 1. `tika-parser-sqlite3-package/pom.xml` — align shade filter with sister packages

The `maven-shade-plugin` filter in `tika-parser-sqlite3-package` was missing three exclusions present in both `tika-parser-scientific-package` and `tika-parser-nlp-package`:

- `module-info.class` — without this exclusion, shading multiple deps that each carry a `module-info.class` causes a duplicate-entry error in the shaded jar on Java 9+.
- `META-INF/LICENSE.md` — duplicate clutter; the `ApacheLicenseResourceTransformer` already handles the text-format `LICENSE`.
- `META-INF/NOTICE.md` — same rationale as `LICENSE.md`.

### 2. `docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc` — fix incorrect TikaConfigException claim

The doc said:

> _tika-grpc requires at least one pf4j plugin to be loaded at startup; an empty `plugins/` directory triggers a `TikaConfigException` with a download URL pointing at Apache dist._

This is factually wrong. `TikaGrpcServerImpl` (line 133) logs a `LOG.warn` when `pluginManager.getPlugins().isEmpty()` — it does **not** throw a `TikaConfigException`. The server continues to start; fetcher-dependent RPC calls simply fail at runtime. Corrected the description to match the actual code path.

## Review Focus Areas

- `tika-parser-sqlite3-package/pom.xml` shade `<filters>` block — confirm the three new exclusions are correct and complete.
- `release-artifacts.adoc` paragraph about empty plugins — confirm the new wording accurately reflects startup behaviour.

## Critical Files

- `tika-parsers/tika-parsers-extended/tika-parser-sqlite3-package/pom.xml`
- `docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc`

## Testing Instructions

```bash
# Verify the sqlite3 shaded jar builds without duplicate module-info errors
mvn package -pl tika-parsers/tika-parsers-extended/tika-parser-sqlite3-package -am -DskipTests

# Confirm shaded jar exists and no module-info duplication
jar tf tika-parsers/tika-parsers-extended/tika-parser-sqlite3-package/target/tika-parser-sqlite3-package-*-shaded.jar \
  | grep -c module-info   # should be 0
```

## Review Checklist

- [ ] sqlite3 shade filter exclusions match scientific and nlp packages
- [ ] Docs accurately describe tika-grpc startup behaviour when no plugins loaded