### PR TITLE
Add OCI standard image labels to Docker images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -134,7 +134,7 @@ jobs:
         id: meta
         run: |
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "created=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -200,7 +200,7 @@ jobs:
         id: meta
         run: |
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "created=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -130,6 +130,12 @@ jobs:
             echo "grpc<<EOF";    echo "$grpc";    echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Set build metadata
+        id: meta
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -150,6 +156,8 @@ jobs:
           push: true
           build-args: |
             TIKA_VERSION=${{ env.TAG }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: ${{ steps.tags.outputs.minimal }}
 
       - name: Build and push tika-server full
@@ -160,6 +168,8 @@ jobs:
           push: true
           build-args: |
             TIKA_VERSION=${{ env.TAG }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: ${{ steps.tags.outputs.full }}
 
       # After a successful publish, push a `<tag>-<build_number>` git tag for
@@ -185,6 +195,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref || env.TAG }}
+
+      - name: Set build metadata
+        id: meta
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -266,6 +282,8 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ env.TAG }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           # apache/tika-grpc is new in 4.x with no prior `:latest` to protect, so
           # we track latest from the start (unlike apache/tika the server image,
           # whose :latest stays on 3.x until 4.0.0 GA).

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         run: |
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "created=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Build with Maven (skip tests)
         run: mvn clean install -DskipTests -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -45,6 +45,12 @@ jobs:
           TIKA_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "tika_version=${TIKA_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Set build metadata
+        id: meta
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build with Maven (skip tests)
         run: mvn clean install -DskipTests -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
@@ -77,6 +83,8 @@ jobs:
           load: true
           build-args: |
             TIKA_VERSION=${{ steps.version.outputs.tika_version }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: tika-server-minimal-smoke:ci
 
       - name: Smoke test tika-server minimal image
@@ -109,6 +117,8 @@ jobs:
           push: true
           build-args: |
             TIKA_VERSION=${{ steps.version.outputs.tika_version }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: |
             apache/tika:${{ steps.version.outputs.tika_version }}
 
@@ -129,6 +139,8 @@ jobs:
           load: true
           build-args: |
             TIKA_VERSION=${{ steps.version.outputs.tika_version }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: tika-server-full-smoke:ci
 
       - name: Smoke test tika-server full image
@@ -161,6 +173,8 @@ jobs:
           push: true
           build-args: |
             TIKA_VERSION=${{ steps.version.outputs.tika_version }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: |
             apache/tika:${{ steps.version.outputs.tika_version }}-full
 
@@ -210,6 +224,8 @@ jobs:
           load: true
           build-args: |
             VERSION=${{ steps.version.outputs.tika_version }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: tika-grpc-smoke:ci
 
       - name: Smoke test tika-grpc image
@@ -244,5 +260,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ steps.version.outputs.tika_version }}
+            REVISION=${{ steps.meta.outputs.sha }}
+            CREATED=${{ steps.meta.outputs.created }}
           tags: |
             apache/tika-grpc:${{ steps.version.outputs.tika_version }}

--- a/tika-grpc/docker-build/Dockerfile
+++ b/tika-grpc/docker-build/Dockerfile
@@ -61,4 +61,16 @@ ENV TIKA_GRPC_MAX_OUTBOUND_MESSAGE_SIZE=$TIKA_GRPC_MAX_OUTBOUND_MESSAGE_SIZE
 ENV TIKA_GRPC_NUM_THREADS=$TIKA_GRPC_NUM_THREADS
 ENTRYPOINT ["/tika/bin/start-tika-grpc.sh"]
 
-LABEL maintainer="Apache Tika Developers dev@tika.apache.org"
+ARG REVISION
+ARG CREATED
+LABEL maintainer="Apache Tika Developers dev@tika.apache.org" \
+      org.opencontainers.image.title="Apache Tika gRPC Server" \
+      org.opencontainers.image.description="Apache Tika content detection and analysis server with gRPC interface" \
+      org.opencontainers.image.url="https://hub.docker.com/r/apache/tika-grpc" \
+      org.opencontainers.image.source="https://github.com/apache/tika" \
+      org.opencontainers.image.documentation="https://tika.apache.org/" \
+      org.opencontainers.image.vendor="Apache Software Foundation" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"

--- a/tika-server/docker-build/full/Dockerfile
+++ b/tika-server/docker-build/full/Dockerfile
@@ -89,5 +89,16 @@ EXPOSE 9998
 # tika-server auto-discovers pf4j plugins from /opt/tika-server/plugins/.
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -cp \"/opt/tika-server/*:/opt/tika-server/lib/*:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@"]
 
-LABEL maintainer="Apache Tika Developers dev@tika.apache.org"
-
+ARG REVISION
+ARG CREATED
+LABEL maintainer="Apache Tika Developers dev@tika.apache.org" \
+      org.opencontainers.image.title="Apache Tika Server (full)" \
+      org.opencontainers.image.description="Apache Tika content detection and analysis server with OCR, fonts, and GDAL support" \
+      org.opencontainers.image.url="https://hub.docker.com/r/apache/tika" \
+      org.opencontainers.image.source="https://github.com/apache/tika" \
+      org.opencontainers.image.documentation="https://tika.apache.org/" \
+      org.opencontainers.image.vendor="Apache Software Foundation" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${TIKA_VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"

--- a/tika-server/docker-build/full/Dockerfile.snapshot
+++ b/tika-server/docker-build/full/Dockerfile.snapshot
@@ -53,4 +53,16 @@ USER $UID_GID
 EXPOSE 9998
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -cp \"/opt/tika-server/*:/opt/tika-server/lib/*:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@"]
 
-LABEL maintainer="Apache Tika Developers dev@tika.apache.org"
+ARG REVISION
+ARG CREATED
+LABEL maintainer="Apache Tika Developers dev@tika.apache.org" \
+      org.opencontainers.image.title="Apache Tika Server (full)" \
+      org.opencontainers.image.description="Apache Tika content detection and analysis server with OCR, fonts, and GDAL support" \
+      org.opencontainers.image.url="https://hub.docker.com/r/apache/tika" \
+      org.opencontainers.image.source="https://github.com/apache/tika" \
+      org.opencontainers.image.documentation="https://tika.apache.org/" \
+      org.opencontainers.image.vendor="Apache Software Foundation" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${TIKA_VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"

--- a/tika-server/docker-build/minimal/Dockerfile
+++ b/tika-server/docker-build/minimal/Dockerfile
@@ -81,4 +81,16 @@ EXPOSE 9998
 # tika-server auto-discovers pf4j plugins from /opt/tika-server/plugins/.
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -cp \"/opt/tika-server/*:/opt/tika-server/lib/*:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@"]
 
-LABEL maintainer="Apache Tika Developers dev@tika.apache.org"
+ARG REVISION
+ARG CREATED
+LABEL maintainer="Apache Tika Developers dev@tika.apache.org" \
+      org.opencontainers.image.title="Apache Tika Server" \
+      org.opencontainers.image.description="Apache Tika content detection and analysis server - lightweight JRE-only build" \
+      org.opencontainers.image.url="https://hub.docker.com/r/apache/tika" \
+      org.opencontainers.image.source="https://github.com/apache/tika" \
+      org.opencontainers.image.documentation="https://tika.apache.org/" \
+      org.opencontainers.image.vendor="Apache Software Foundation" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${TIKA_VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"

--- a/tika-server/docker-build/minimal/Dockerfile.snapshot
+++ b/tika-server/docker-build/minimal/Dockerfile.snapshot
@@ -35,4 +35,16 @@ USER $UID_GID
 EXPOSE 9998
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -cp \"/opt/tika-server/*:/opt/tika-server/lib/*:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@"]
 
-LABEL maintainer="Apache Tika Developers dev@tika.apache.org"
+ARG REVISION
+ARG CREATED
+LABEL maintainer="Apache Tika Developers dev@tika.apache.org" \
+      org.opencontainers.image.title="Apache Tika Server" \
+      org.opencontainers.image.description="Apache Tika content detection and analysis server - lightweight JRE-only build" \
+      org.opencontainers.image.url="https://hub.docker.com/r/apache/tika" \
+      org.opencontainers.image.source="https://github.com/apache/tika" \
+      org.opencontainers.image.documentation="https://tika.apache.org/" \
+      org.opencontainers.image.vendor="Apache Software Foundation" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${TIKA_VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"


### PR DESCRIPTION
## Context

Add [OCI Image Spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to all five Dockerfiles published by this repository, and wire the dynamic labels through the two CI workflows.

**This PR touches Docker metadata only — no changes to Tika source code, Maven build, tests, or runtime behaviour.**

Note: JIRA registration is currently closed, so I was unable to file a tracker issue first. If a JIRA ticket is required, I'm happy to create one once registration reopens, or a maintainer can create it and I'll update the PR title accordingly.

## Type

Improvement — Docker metadata only, no functional changes.

## Dockerfiles modified

| Dockerfile | Published image |
|---|---|
| `tika-server/docker-build/minimal/Dockerfile` | `apache/tika:X.Y.Z` |
| `tika-server/docker-build/full/Dockerfile` | `apache/tika:X.Y.Z-full` |
| `tika-server/docker-build/minimal/Dockerfile.snapshot` | `apache/tika:X.Y.Z-SNAPSHOT` |
| `tika-server/docker-build/full/Dockerfile.snapshot` | `apache/tika:X.Y.Z-SNAPSHOT-full` |
| `tika-grpc/docker-build/Dockerfile` | `apache/tika-grpc:X.Y.Z` |

## Labels added

| Label | Value | Type |
|---|---|---|
| `org.opencontainers.image.title` | `"Apache Tika Server"` / `"Apache Tika Server (full)"` / `"Apache Tika gRPC Server"` | Static |
| `org.opencontainers.image.description` | Variant-specific description | Static |
| `org.opencontainers.image.url` | `https://hub.docker.com/r/apache/tika` (or `/tika-grpc`) | Static |
| `org.opencontainers.image.source` | `https://github.com/apache/tika` | Static |
| `org.opencontainers.image.documentation` | `https://tika.apache.org/` | Static |
| `org.opencontainers.image.vendor` | `Apache Software Foundation` | Static |
| `org.opencontainers.image.licenses` | `Apache-2.0` | Static |
| `org.opencontainers.image.version` | `${TIKA_VERSION}` / `${VERSION}` | Dynamic (existing ARG) |
| `org.opencontainers.image.revision` | `${REVISION}` — git SHA at build time | Dynamic (new ARG + CI) |
| `org.opencontainers.image.created` | `${CREATED}` — RFC 3339 build timestamp | Dynamic (new ARG + CI) |

The existing `maintainer` label is preserved as-is in all files.

## CI changes

A new `Set build metadata` step is added to each Docker job in both workflows (`docker-release.yml` and `docker-snapshot.yml`). It captures `git rev-parse HEAD` (the exact checked-out commit, not `GITHUB_SHA`, so it is correct for the `workflow_dispatch`-with-`source_ref` path) and the current UTC timestamp, then passes them as `REVISION` and `CREATED` build-args to every `docker/build-push-action` call.

If `REVISION` or `CREATED` are not supplied (e.g. a local `docker build` without the build-args), the ARGs default to empty strings — the labels are still present but unpopulated, which is harmless.

## Benefits

- **Dependency bot changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to link release notes in update PRs
- **Registry UI**: GHCR, Docker Hub display title, description, license, and source link from OCI labels
- **Image provenance**: `revision` + `created` allow pinpointing the exact source commit and build time for security audits and CVE investigations
- **Standardisation**: Aligns with OCI Image Spec best practices widely adopted across the container ecosystem

## How to verify

After the next CI build, inspect the published image:

```bash
docker pull apache/tika:latest
docker inspect apache/tika:latest --format '{{ json .Config.Labels }}' | jq .
```

All `org.opencontainers.image.*` keys should be present and populated.

## References

- [OCI Image Spec — Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [Docker — Manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)
