### PR TITLE
mask bytes in chm unmarshalUInt32 to avoid sign extension

### DIFF
--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItsfHeader.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmItsfHeader.java
@@ -395,8 +395,10 @@ public class ChmItsfHeader implements ChmAccessor<ChmItsfHeader> {
         if (4 > getDataRemained()) {
             throw new TikaException("4 > dataLenght");
         }
-        dest = data[this.getCurrentPlace()] | data[this.getCurrentPlace() + 1] << 8 |
-                data[this.getCurrentPlace() + 2] << 16 | data[this.getCurrentPlace() + 3] << 24;
+        dest = (data[this.getCurrentPlace()] & 0xff) |
+                (data[this.getCurrentPlace() + 1] & 0xff) << 8 |
+                (data[this.getCurrentPlace() + 2] & 0xff) << 16 |
+                (data[this.getCurrentPlace() + 3] & 0xff) << 24;
 
         setDataRemained(this.getDataRemained() - 4);
         this.setCurrentPlace(this.getCurrentPlace() + 4);

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmLzxcControlData.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/main/java/org/apache/tika/parser/microsoft/chm/ChmLzxcControlData.java
@@ -225,8 +225,10 @@ public class ChmLzxcControlData implements ChmAccessor<ChmLzxcControlData> {
         if (4 > getDataRemained()) {
             throw new ChmParsingException("4 > dataLenght");
         }
-        dest = data[this.getCurrentPlace()] | data[this.getCurrentPlace() + 1] << 8 |
-                data[this.getCurrentPlace() + 2] << 16 | data[this.getCurrentPlace() + 3] << 24;
+        dest = (data[this.getCurrentPlace()] & 0xff) |
+                (data[this.getCurrentPlace() + 1] & 0xff) << 8 |
+                (data[this.getCurrentPlace() + 2] & 0xff) << 16 |
+                (data[this.getCurrentPlace() + 3] & 0xff) << 24;
 
         setDataRemained(this.getDataRemained() - 4);
         this.setCurrentPlace(this.getCurrentPlace() + 4);

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/test/java/org/apache/tika/parser/microsoft/chm/TestChmLzxcControlData.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-microsoft-module/src/test/java/org/apache/tika/parser/microsoft/chm/TestChmLzxcControlData.java
@@ -124,4 +124,22 @@ public class TestChmLzxcControlData {
                 chmLzxcControlData.getSignature().length);
     }
 
+    @Test
+    public void testUInt32HighBitNotSignExtended() throws Exception {
+        // size = 0x00008000 little-endian; the 0x80 byte has bit 7 set, so an
+        // unmasked shift sign-extends it and yields -32768 instead of 32768
+        byte[] data = new byte[ChmConstants.CHM_LZXC_MIN_LEN];
+        data[1] = (byte) 0x80;
+        byte[] sig = ChmConstants.LZXC.getBytes(UTF_8);
+        System.arraycopy(sig, 0, data, 4, sig.length);
+        data[8] = 0x01;  // version
+        data[12] = 0x02; // resetInterval
+        data[16] = 0x02; // windowSize
+        data[20] = 0x02; // windowsPerReset
+
+        ChmLzxcControlData control = new ChmLzxcControlData();
+        control.parse(data, control);
+        assertEquals(0x8000L, control.getSize());
+    }
+
 }


### PR DESCRIPTION
`unmarshalUInt32` in `ChmItsfHeader` and `ChmLzxcControlData` ORs the four little-endian bytes from an untrusted chm without masking each `& 0xff`, so any non-leading byte with bit 7 set is sign-extended and corrupts the value (a `0x8000` size/windowSize/resetInterval field reads back as `-32768`); spotted because the sibling readers in `ChmItspHeader`, `ChmPmgiHeader`, `ChmPmglHeader` and `ChmLzxcResetTable` already mask, so this just brings the two stragglers in line.