### PR TITLE
TIKA-4756: Detect unsigned AcroForm signature fields in PDFs

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/metadata/PDF.java
+++ b/tika-core/src/main/java/org/apache/tika/metadata/PDF.java
@@ -151,6 +151,13 @@ public interface PDF {
      */
     Property HAS_ACROFORM_FIELDS = Property.internalBoolean(PDF_PREFIX + "hasAcroFormFields");
 
+    /**
+     * Has > 0 AcroForm signature fields (/FT /Sig), regardless of whether a signature
+     * has been applied. Use {@link TikaCoreProperties#HAS_SIGNATURE} to check for
+     * an actual applied digital signature.
+     */
+    Property HAS_SIGNATURE_FIELDS = Property.internalBoolean(PDF_PREFIX + "hasSignatureFields");
+
     Property HAS_MARKED_CONTENT = Property.internalBoolean(PDF_PREFIX + "hasMarkedContent");
 
     /**

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/PDFParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/main/java/org/apache/tika/parser/pdf/PDFParser.java
@@ -53,6 +53,7 @@ import org.apache.pdfbox.pdmodel.fixup.PDDocumentFixup;
 import org.apache.pdfbox.pdmodel.fixup.processor.AcroFormDefaultsProcessor;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
@@ -398,8 +399,14 @@ public class PDFParser implements Parser, RenderingParser {
     }
 
     private void extractSignatures(PDDocument pdfDocument, Metadata metadata) {
+        List<PDSignatureField> signatureFields = pdfDocument.getSignatureFields();
+        if (!signatureFields.isEmpty()) {
+            metadata.set(PDF.HAS_SIGNATURE_FIELDS, true);
+        }
+
         boolean hasSignature = false;
-        for (PDSignature signature : pdfDocument.getSignatureDictionaries()) {
+        for (PDSignatureField sigField : signatureFields) {
+            PDSignature signature = sigField.getSignature();
             if (signature == null) {
                 continue;
             }
@@ -414,11 +421,10 @@ public class PDFParser implements Parser, RenderingParser {
             PDMetadataExtractor.addNotNull(signature.getLocation(), metadata, TikaCoreProperties.SIGNATURE_LOCATION);
             PDMetadataExtractor.addNotNull(signature.getReason(), metadata, TikaCoreProperties.SIGNATURE_REASON);
             hasSignature = true;
-
         }
 
         if (hasSignature) {
-            metadata.set(TikaCoreProperties.HAS_SIGNATURE, hasSignature);
+            metadata.set(TikaCoreProperties.HAS_SIGNATURE, true);
         }
     }
 

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/java/org/apache/tika/parser/pdf/PDFParserTest.java
@@ -629,7 +629,17 @@ public class PDFParserTest extends TikaTest {
         assertEquals("true", m.get(PDF.HAS_XMP));
         assertEquals("true", m.get(PDF.HAS_ACROFORM_FIELDS));
         assertEquals("false", m.get(PDF.HAS_XFA));
+        assertEquals("true", m.get(PDF.HAS_SIGNATURE_FIELDS));
+        assertNull(m.get(TikaCoreProperties.HAS_SIGNATURE));
         assertContains("<li>aTextField: TIKA-1226</li>", result.xml);
+    }
+
+    //TIKA-4756
+    @Test
+    public void testUnsignedSignatureField() throws Exception {
+        Metadata m = getXML("testPDF_unsigned_sig_field.pdf").metadata;
+        assertEquals("true", m.get(PDF.HAS_SIGNATURE_FIELDS));
+        assertNull(m.get(TikaCoreProperties.HAS_SIGNATURE));
     }
 
     @Test

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/resources/test-documents/testPDF_unsigned_sig_field.pdf
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-pdf-module/src/test/resources/test-documents/testPDF_unsigned_sig_field.pdf
@@ -1,0 +1,25 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R] /SigFlags 3 >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [4 0 R] >>
+endobj
+4 0 obj
+<< /FT /Sig /Type /Annot /Subtype /Widget /Rect [0 0 0 0] /T (Signature1) /P 3 0 R >>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000102 00000 n 
+0000000159 00000 n 
+0000000246 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+347
+%%EOF


### PR DESCRIPTION
## Summary

- Adds `PDF.HAS_SIGNATURE_FIELDS` (`pdf:hasSignatureFields`) metadata property to report the presence of AcroForm `/FT /Sig` fields, regardless of whether a signature has been applied
- Refactors `PDFParser.extractSignatures()` to iterate over `PDDocument.getSignatureFields()` instead of `getSignatureDictionaries()`, so unsigned signature fields are detected; `TikaCoreProperties.HAS_SIGNATURE` is still only set when a field has an actual `PDSignature` applied
- Adds a minimal test PDF (`testPDF_unsigned_sig_field.pdf`) with an unsigned signature field and `/SigFlags 3`
- Updates `testSignatureInAcroForm` to assert the new property and tightens expectations; adds `testUnsignedSignatureField` for TIKA-4756

## Motivation

PDFs that contain AcroForm signature fields (`/FT /Sig`) but have not yet been signed were previously indistinguishable from PDFs with no signature infrastructure. This matters for downstream applications such as PDF/A converters (e.g. OCRmyPDF) that need to skip documents with signature fields to avoid invalidating future signatures.

## Test plan

- [x] `PDFParserTest#testUnsignedSignatureField` — new test asserting `pdf:hasSignatureFields=true` and no `HAS_SIGNATURE` on a PDF with unsigned sig field
- [x] `PDFParserTest#testSignatureInAcroForm` — existing test updated to assert the new property; confirms no actual signature is set on `testPDF_acroform3.pdf`

Fixes: https://issues.apache.org/jira/browse/TIKA-4756

🤖 Generated with [Claude Code](https://claude.com/claude-code)