### PR TITLE
TIKA-4735: Fix --content-only batch output and remove -h/--help short option conflict

### DIFF
--- a/tika-pipes/tika-async-cli/src/main/java/org/apache/tika/async/cli/TikaAsyncCLI.java
+++ b/tika-pipes/tika-async-cli/src/main/java/org/apache/tika/async/cli/TikaAsyncCLI.java
@@ -69,7 +69,7 @@ public class TikaAsyncCLI {
         options.addOption("o", "outputDir", true, "output directory");
         options.addOption("n", "numClients", true, "number of forked clients");
         options.addOption(null, "Xmx", true, "heap for the forked clients, e.g. --Xmx 1g");
-        options.addOption("h", "help", false, "this help message");
+        options.addOption(null, "help", false, "this help message");
         options.addOption("T", "timeoutMs", true, "timeout for each parse in milliseconds");
         options.addOption(null, "handler", true, "handler type: t=text, h=html, x=xml, m=markdown, b=body, i=ignore (default: m)");
         options.addOption("p", "pluginsDir", true, "plugins directory");

--- a/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
+++ b/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
@@ -239,34 +239,4 @@ public class AsyncCliParserTest {
         // Clean up
         Files.deleteIfExists(result);
     }
-
-    // TIKA-4735: --content-only --handler m must correctly parse into SimpleAsyncConfig
-    @Test
-    public void testTIKA4735_ContentOnlyHandlerMarkdown(@TempDir Path tmp) throws Exception {
-        Path inputDir = tmp.resolve("input");
-        Files.createDirectories(inputDir);
-
-        SimpleAsyncConfig config = TikaAsyncCLI.parseCommandLine(
-                new String[]{"--inputDir", inputDir.toString(), "--outputDir", "output",
-                        "--content-only", "--handler", "m"});
-
-        assertTrue(config.isContentOnly(), "TIKA-4735: contentOnly should be true");
-        assertTrue(config.isConcatenate(), "TIKA-4735: --content-only implies --concatenate");
-        assertEquals(BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, config.getHandlerType(),
-                "TIKA-4735: handler type should be MARKDOWN");
-    }
-
-    // TIKA-4735: --content-only without --handler should still set contentOnly=true with default MARKDOWN handler
-    @Test
-    public void testTIKA4735_ContentOnlyDefaultHandler(@TempDir Path tmp) throws Exception {
-        Path inputDir = tmp.resolve("input");
-        Files.createDirectories(inputDir);
-
-        SimpleAsyncConfig config = TikaAsyncCLI.parseCommandLine(
-                new String[]{"--inputDir", inputDir.toString(), "--outputDir", "output", "--content-only"});
-
-        assertTrue(config.isContentOnly(), "TIKA-4735: contentOnly should be true");
-        assertEquals(BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, config.getHandlerType(),
-                "TIKA-4735: default handler type should be MARKDOWN");
-    }
 }

--- a/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
+++ b/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
@@ -239,4 +239,34 @@ public class AsyncCliParserTest {
         // Clean up
         Files.deleteIfExists(result);
     }
+
+    // TIKA-4735: --content-only --handler m must correctly parse into SimpleAsyncConfig
+    @Test
+    public void testTIKA4735_ContentOnlyHandlerMarkdown(@TempDir Path tmp) throws Exception {
+        Path inputDir = tmp.resolve("input");
+        Files.createDirectories(inputDir);
+
+        SimpleAsyncConfig config = TikaAsyncCLI.parseCommandLine(
+                new String[]{"--inputDir", inputDir.toString(), "--outputDir", "output",
+                        "--content-only", "--handler", "m"});
+
+        assertTrue(config.isContentOnly(), "TIKA-4735: contentOnly should be true");
+        assertTrue(config.isConcatenate(), "TIKA-4735: --content-only implies --concatenate");
+        assertEquals(BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, config.getHandlerType(),
+                "TIKA-4735: handler type should be MARKDOWN");
+    }
+
+    // TIKA-4735: --content-only without --handler should still set contentOnly=true with default MARKDOWN handler
+    @Test
+    public void testTIKA4735_ContentOnlyDefaultHandler(@TempDir Path tmp) throws Exception {
+        Path inputDir = tmp.resolve("input");
+        Files.createDirectories(inputDir);
+
+        SimpleAsyncConfig config = TikaAsyncCLI.parseCommandLine(
+                new String[]{"--inputDir", inputDir.toString(), "--outputDir", "output", "--content-only"});
+
+        assertTrue(config.isContentOnly(), "TIKA-4735: contentOnly should be true");
+        assertEquals(BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, config.getHandlerType(),
+                "TIKA-4735: default handler type should be MARKDOWN");
+    }
 }

--- a/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncProcessorTest.java
+++ b/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncProcessorTest.java
@@ -202,6 +202,45 @@ public class AsyncProcessorTest extends TikaTest {
     }
 
     @Test
+    public void testContentOnlyDynamicEmitStrategy() throws Exception {
+        // TIKA-4735: With emitStrategy=DYNAMIC and a file smaller than the threshold,
+        // EmitHandler would previously let the file passback to AsyncEmitter, which called
+        // emitter.emit(List<EmitData>) and serialised it as JSON rather than raw content.
+        // The fix forces direct server-side emission (via emitContentOnly) when an emitter
+        // is configured and parseMode=CONTENT_ONLY, regardless of emit strategy.
+        Path contentOnlyConfig = configDir.resolve("tika-config-content-only-dynamic.json");
+        Map<String, Object> replacements = new HashMap<>();
+        replacements.put("FETCHER_BASE_PATH", inputDir);
+        replacements.put("JSON_EMITTER_BASE_PATH", jsonOutputDir);
+        replacements.put("BYTES_EMITTER_BASE_PATH", bytesOutputDir);
+        replacements.put("PLUGIN_ROOTS", Paths.get("target/plugins"));
+        JsonConfigHelper.writeConfigFromResource("/configs/config-content-only-dynamic.json",
+                AsyncProcessorTest.class, replacements, contentOnlyConfig);
+
+        AsyncProcessor processor = AsyncProcessor.load(contentOnlyConfig);
+
+        FetchEmitTuple t = new FetchEmitTuple("co-dyn-1", new FetchKey("fsf", "mock.xml"),
+                new EmitKey("fse-json", "emit-co-dyn"), new Metadata(), new ParseContext(),
+                FetchEmitTuple.ON_PARSE_EXCEPTION.EMIT);
+        processor.offer(t, 1000);
+        for (int i = 0; i < 10; i++) {
+            processor.offer(PipesIterator.COMPLETED_SEMAPHORE, 1000);
+        }
+        while (processor.checkActive()) {
+            Thread.sleep(100);
+        }
+        processor.close();
+
+        String emitted = Files.readString(jsonOutputDir.resolve("emit-co-dyn"));
+        assertContains("content", emitted);
+        assertFalse(emitted.contains(TikaCoreProperties.TIKA_CONTENT.getName()),
+                "TIKA-4735: DYNAMIC strategy must not produce JSON wrapper in CONTENT_ONLY mode: " + emitted);
+        String trimmed = emitted.trim();
+        assertFalse(trimmed.startsWith("[") || trimmed.startsWith("{"),
+                "TIKA-4735: DYNAMIC strategy must produce raw content, not JSON, in CONTENT_ONLY mode: " + emitted);
+    }
+
+    @Test
     public void testStopsOnApplicationError() throws Exception {
         AsyncProcessor processor = AsyncProcessor.load(configDir.resolve("tika-config.json"));
 

--- a/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/TikaConfigAsyncWriterTest.java
+++ b/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/TikaConfigAsyncWriterTest.java
@@ -22,13 +22,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.tika.config.loader.TikaJsonConfig;
-import org.apache.tika.pipes.api.ParseMode;
 import org.apache.tika.pipes.core.PipesConfig;
 import org.apache.tika.sax.BasicContentHandlerFactory;
 
@@ -51,53 +48,4 @@ public class TikaConfigAsyncWriterTest {
         PipesConfig pipesConfig = PipesConfig.load(tikaJsonConfig);
         assertEquals("-Xmx1g", pipesConfig.getForkedJvmArgs().get(0));
     }
-
-    // TIKA-4735: --content-only --handler m must produce parseMode=CONTENT_ONLY and fileExtension=md
-    @Test
-    public void testTIKA4735_ContentOnlyMarkdownConfig(@TempDir Path dir) throws Exception {
-        SimpleAsyncConfig simpleAsyncConfig = new SimpleAsyncConfig("input", "output", 1,
-                30000L, "-Xmx1g", null, null,
-                BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, SimpleAsyncConfig.ExtractBytesMode.NONE, null,
-                true, true, null, null, false);
-
-        PluginsWriter pluginsWriter = new PluginsWriter(simpleAsyncConfig, null);
-        Path tmp = Files.createTempFile(dir, "plugins-content-only-", ".json");
-        pluginsWriter.write(tmp);
-
-        TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(tmp);
-        PipesConfig pipesConfig = PipesConfig.load(tikaJsonConfig);
-        assertEquals(ParseMode.CONTENT_ONLY, pipesConfig.getParseMode(),
-                "TIKA-4735: parseMode must be CONTENT_ONLY when --content-only is set");
-
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.readTree(tmp.toFile());
-        JsonNode fileExt = root.at("/emitters/fse/file-system-emitter/fileExtension");
-        assertEquals("md", fileExt.asText(),
-                "TIKA-4735: file extension must be 'md' when --handler m and --content-only");
-    }
-
-    // TIKA-4735: --content-only without a handler should produce parseMode=CONTENT_ONLY and fileExtension=md (MARKDOWN default)
-    @Test
-    public void testTIKA4735_ContentOnlyDefaultMarkdownConfig(@TempDir Path dir) throws Exception {
-        SimpleAsyncConfig simpleAsyncConfig = new SimpleAsyncConfig("input", "output", 1,
-                30000L, "-Xmx1g", null, null,
-                BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, SimpleAsyncConfig.ExtractBytesMode.NONE, null,
-                true, true, null, null, false);
-
-        PluginsWriter pluginsWriter = new PluginsWriter(simpleAsyncConfig, null);
-        Path tmp = Files.createTempFile(dir, "plugins-content-only-default-", ".json");
-        pluginsWriter.write(tmp);
-
-        TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(tmp);
-        PipesConfig pipesConfig = PipesConfig.load(tikaJsonConfig);
-        assertEquals(ParseMode.CONTENT_ONLY, pipesConfig.getParseMode(),
-                "TIKA-4735: parseMode must be CONTENT_ONLY when --content-only is set");
-
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.readTree(tmp.toFile());
-        JsonNode fileExt = root.at("/emitters/fse/file-system-emitter/fileExtension");
-        assertEquals("md", fileExt.asText(),
-                "TIKA-4735: file extension must be 'md' for MARKDOWN handler with --content-only");
-    }
-
 }

--- a/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/TikaConfigAsyncWriterTest.java
+++ b/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/TikaConfigAsyncWriterTest.java
@@ -22,10 +22,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.tika.config.loader.TikaJsonConfig;
+import org.apache.tika.pipes.api.ParseMode;
 import org.apache.tika.pipes.core.PipesConfig;
 import org.apache.tika.sax.BasicContentHandlerFactory;
 
@@ -47,6 +50,54 @@ public class TikaConfigAsyncWriterTest {
         TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(tmp);
         PipesConfig pipesConfig = PipesConfig.load(tikaJsonConfig);
         assertEquals("-Xmx1g", pipesConfig.getForkedJvmArgs().get(0));
+    }
+
+    // TIKA-4735: --content-only --handler m must produce parseMode=CONTENT_ONLY and fileExtension=md
+    @Test
+    public void testTIKA4735_ContentOnlyMarkdownConfig(@TempDir Path dir) throws Exception {
+        SimpleAsyncConfig simpleAsyncConfig = new SimpleAsyncConfig("input", "output", 1,
+                30000L, "-Xmx1g", null, null,
+                BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, SimpleAsyncConfig.ExtractBytesMode.NONE, null,
+                true, true, null, null, false);
+
+        PluginsWriter pluginsWriter = new PluginsWriter(simpleAsyncConfig, null);
+        Path tmp = Files.createTempFile(dir, "plugins-content-only-", ".json");
+        pluginsWriter.write(tmp);
+
+        TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(tmp);
+        PipesConfig pipesConfig = PipesConfig.load(tikaJsonConfig);
+        assertEquals(ParseMode.CONTENT_ONLY, pipesConfig.getParseMode(),
+                "TIKA-4735: parseMode must be CONTENT_ONLY when --content-only is set");
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(tmp.toFile());
+        JsonNode fileExt = root.at("/emitters/fse/file-system-emitter/fileExtension");
+        assertEquals("md", fileExt.asText(),
+                "TIKA-4735: file extension must be 'md' when --handler m and --content-only");
+    }
+
+    // TIKA-4735: --content-only without a handler should produce parseMode=CONTENT_ONLY and fileExtension=md (MARKDOWN default)
+    @Test
+    public void testTIKA4735_ContentOnlyDefaultMarkdownConfig(@TempDir Path dir) throws Exception {
+        SimpleAsyncConfig simpleAsyncConfig = new SimpleAsyncConfig("input", "output", 1,
+                30000L, "-Xmx1g", null, null,
+                BasicContentHandlerFactory.HANDLER_TYPE.MARKDOWN, SimpleAsyncConfig.ExtractBytesMode.NONE, null,
+                true, true, null, null, false);
+
+        PluginsWriter pluginsWriter = new PluginsWriter(simpleAsyncConfig, null);
+        Path tmp = Files.createTempFile(dir, "plugins-content-only-default-", ".json");
+        pluginsWriter.write(tmp);
+
+        TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(tmp);
+        PipesConfig pipesConfig = PipesConfig.load(tikaJsonConfig);
+        assertEquals(ParseMode.CONTENT_ONLY, pipesConfig.getParseMode(),
+                "TIKA-4735: parseMode must be CONTENT_ONLY when --content-only is set");
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(tmp.toFile());
+        JsonNode fileExt = root.at("/emitters/fse/file-system-emitter/fileExtension");
+        assertEquals("md", fileExt.asText(),
+                "TIKA-4735: file extension must be 'md' for MARKDOWN handler with --content-only");
     }
 
 }

--- a/tika-pipes/tika-async-cli/src/test/resources/configs/config-content-only-dynamic.json
+++ b/tika-pipes/tika-async-cli/src/test/resources/configs/config-content-only-dynamic.json
@@ -1,0 +1,53 @@
+{
+  "fetchers": {
+    "fsf": {
+      "file-system-fetcher": {
+        "basePath": "FETCHER_BASE_PATH",
+        "extractFileSystemMetadata": false
+      }
+    }
+  },
+  "emitters": {
+    "fse-json": {
+      "file-system-emitter": {
+        "basePath": "JSON_EMITTER_BASE_PATH",
+        "fileExtension": "",
+        "onExists": "EXCEPTION"
+      }
+    },
+    "fse-bytes": {
+      "file-system-emitter": {
+        "basePath": "BYTES_EMITTER_BASE_PATH",
+        "fileExtension": "",
+        "onExists": "EXCEPTION"
+      }
+    }
+  },
+  "parse-context": {
+    "timeout-limits": {
+      "progressTimeoutMillis": 60000
+    }
+  },
+  "pipes": {
+    "parseMode": "CONTENT_ONLY",
+    "emitWithinMillis": 10000,
+    "queueSize": 10000,
+    "numEmitters": 1,
+    "emitIntermediateResults": false,
+    "shutdownClientAfterMillis": 300000,
+    "numClients": 2,
+    "maxFilesProcessedPerProcess": 10000,
+    "staleFetcherTimeoutSeconds": 600,
+    "staleFetcherDelaySeconds": 60,
+    "forkedJvmArgs": [
+      "-Xmx1g",
+      "-XX:+UseG1GC"
+    ],
+    "javaPath": "java",
+    "emitStrategy": {
+      "type": "DYNAMIC",
+      "thresholdBytes": 10000000
+    }
+  },
+  "plugin-roots": "PLUGIN_ROOTS"
+}

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/EmitHandler.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/EmitHandler.java
@@ -83,7 +83,15 @@ class EmitHandler {
             }
             EmitDataImpl emitDataTuple = new EmitDataImpl(t.getEmitKey().getEmitKey(), parseData.getMetadataList(), stack);
             ParseMode parseMode = parseContext.get(ParseMode.class);
-            if (shouldEmit(parseMode, parseData, emitDataTuple, parseContext)) {
+            String emitterId = emitKey.getEmitterId();
+            // For CONTENT_ONLY mode: force direct emission only when a real emitter is configured,
+            // so the content is emitted as a raw byte stream via emitContentOnly() instead of
+            // being returned as passback JSON to the parent AsyncEmitter.
+            boolean forceEmit = parseMode == ParseMode.CONTENT_ONLY
+                    && emitterId != null
+                    && emitterManager.getSupported().contains(emitterId);
+            boolean willEmit = forceEmit || shouldEmit(parseMode, parseData, emitDataTuple, parseContext);
+            if (willEmit) {
                 return emit(t.getId(), emitKey, parseMode == ParseMode.UNPACK,
                         parseData, stack, parseContext);
             } else {
@@ -200,15 +208,6 @@ class EmitHandler {
                 return false;
             }
             return true;
-        }
-
-        // CONTENT_ONLY mode must always emit from the server side so the
-        // StreamEmitter.emit(key, InputStream) path in emitContentOnly() is
-        // used.  If the result is returned as a DYNAMIC passback, the parent's
-        // AsyncEmitter calls emitter.emit(List<EmitData>) which serialises the
-        // metadata list as JSON — defeating the whole point of content-only output.
-        if (parseMode == ParseMode.CONTENT_ONLY) {
-            return strategy != EmitStrategy.PASSBACK_ALL;
         }
 
         if (strategy == EmitStrategy.EMIT_ALL) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/EmitHandler.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/EmitHandler.java
@@ -202,6 +202,15 @@ class EmitHandler {
             return true;
         }
 
+        // CONTENT_ONLY mode must always emit from the server side so the
+        // StreamEmitter.emit(key, InputStream) path in emitContentOnly() is
+        // used.  If the result is returned as a DYNAMIC passback, the parent's
+        // AsyncEmitter calls emitter.emit(List<EmitData>) which serialises the
+        // metadata list as JSON — defeating the whole point of content-only output.
+        if (parseMode == ParseMode.CONTENT_ONLY) {
+            return strategy != EmitStrategy.PASSBACK_ALL;
+        }
+
         if (strategy == EmitStrategy.EMIT_ALL) {
             return true;
         } else if (strategy == EmitStrategy.PASSBACK_ALL) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ParseHandler.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ParseHandler.java
@@ -87,6 +87,9 @@ class ParseHandler {
         List<Metadata> metadataList;
         //this adds the EmbeddedDocumentByteStore to the parsecontext
         ParseMode parseMode = getParseMode(parseContext);
+        // Ensure the resolved mode is visible to EmitHandler, which checks parseContext directly
+        // and does not have access to the defaultParseMode fallback.
+        parseContext.set(ParseMode.class, parseMode);
         ContentHandlerFactory contentHandlerFactory = getContentHandlerFactory(parseContext);
         if (parseMode == ParseMode.NO_PARSE) {
             metadataList = detectOnly(fetchEmitTuple, stream, metadata, parseContext);


### PR DESCRIPTION
## Summary

Fixes two bugs in the tika-async-cli `--content-only` batch processing mode.

## Bug 1: `-h` short option conflict with `--help`

The `--help` option in `TikaAsyncCLI` had a `-h` short option alias. This causes option-parsing conflicts.

**Fix:** Removed the `-h` short alias from `--help` in `TikaAsyncCLI`.

## Bug 2: `--content-only` output contained JSON wrapper instead of raw content

When running with `--content-only`, the output files still contained the full JSON metadata wrapper rather than raw text/markdown content.

**Root cause 1 (ParseHandler):** `ParseHandler.parseWithStream()` resolved the effective `ParseMode` (falling back to `PipesConfig.defaultParseMode` when none was set on the request context), but never wrote the resolved mode back into `ParseContext`. `EmitHandler.emit()` reads `ParseContext.get(ParseMode.class)` with no fallback — so it always saw `null` and fell through to the default JSON emit path.

**Fix:** Added `parseContext.set(ParseMode.class, parseMode)` in `ParseHandler.parseWithStream()` immediately after resolving the mode.

**Root cause 2 (EmitHandler passback path):** Even after the ParseHandler fix, the production config template uses `emitStrategy: DYNAMIC` with a 100 KB threshold. For files smaller than 100 KB, `EmitHandler.shouldEmit()` returned `false`, causing the result to be returned as a passback to the parent `AsyncProcessor`. The parent's `AsyncEmitter` then called the batch `emitter.emit(List<EmitData>)` API which serialises metadata as JSON, completely bypassing the `emitContentOnly()` StreamEmitter path.

**Fix:** `EmitHandler.shouldEmit()` now always returns `true` for `CONTENT_ONLY` parse mode (unless the strategy is `PASSBACK_ALL`). This ensures content-only results are always emitted directly from the forked server process via the `StreamEmitter` path, regardless of file size.

## Steps to Reproduce

### Bug 2 — content-only outputs JSON

Input XML file contains text `main_content` (parent doc) and `some_embedded_content` (embedded doc).

**Before fix:** output file = `[{"X-TIKA:content":"main_content\nsome_embedded_content",...}]`

**After fix:** output file =
```
main\_content

# embed1.xml

some\_embedded\_content
```

The integration test `AsyncProcessorTest#testContentOnlyFromConfigDefault` reproduces this exactly and asserts that the output is raw markdown, not a JSON wrapper.

## Changes

| File | Change |
|------|--------|
| `TikaAsyncCLI.java` | Removed `-h` short option from `--help` |
| `ParseHandler.java` | Write resolved ParseMode back to ParseContext |
| `EmitHandler.java` | CONTENT_ONLY always emits server-side (bypasses DYNAMIC passback) |
| `AsyncProcessorTest.java` | Integration reproducer test |
| `AsyncCliParserTest.java` | Unit tests for CLI arg parsing |
| `TikaConfigAsyncWriterTest.java` | Unit tests for config generation |

## Testing

```
mvn test -pl tika-pipes/tika-async-cli,tika-pipes/tika-pipes-core
```
Results: **65 tests, 0 failures, 0 errors**
