### PR TITLE
TIKA-4793: make Pipes IPC payload limit configurable

### DIFF
--- a/tika-pipes/tika-pipes-api/src/main/java/org/apache/tika/pipes/api/PipesResult.java
+++ b/tika-pipes/tika-pipes-api/src/main/java/org/apache/tika/pipes/api/PipesResult.java
@@ -66,6 +66,7 @@ public record PipesResult(RESULT_STATUS status, EmitData emitData, String messag
         EMIT_EXCEPTION(CATEGORY.TASK_EXCEPTION),
         FETCHER_NOT_FOUND(CATEGORY.TASK_EXCEPTION),
         EMITTER_NOT_FOUND(CATEGORY.TASK_EXCEPTION),
+        PAYLOAD_LIMIT_EXCEEDED(CATEGORY.TASK_EXCEPTION),
 
         // Process crashes - forked process died, auto-restart
         OOM(CATEGORY.PROCESS_CRASH),

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
@@ -425,8 +425,7 @@ public class PipesClient implements Closeable {
                 return buildFatalResult(t.getId(), t.getEmitKey(), TIMEOUT, intermediateResult.get(),
                         ExceptionUtils.getStackTrace(e));
             } catch (PayloadLimitExceededException e) {
-                // Stream is desynchronized (payload bytes were not consumed) but server is healthy.
-                // Close the connection without restarting the server.
+                // Stream is desynchronized (payload bytes were not consumed); close the connection.
                 LOG.warn("clientId={}: payload too large for id={}: {}", pipesClientId, t.getId(), e.getMessage());
                 closeConnection();
                 return buildFatalResult(t.getId(), t.getEmitKey(),

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
@@ -72,7 +72,6 @@ public class PipesClient implements Closeable {
     public static final int SOCKET_TIMEOUT_MS = 60000;
 
     private final PipesConfig pipesConfig;
-    private final long maxIpcPayloadBytes;
     private final ServerManager serverManager;
     private final boolean ownsServerManager;
     private final int pipesClientId;
@@ -96,7 +95,6 @@ public class PipesClient implements Closeable {
      */
     public PipesClient(PipesConfig pipesConfig, ServerManager serverManager) {
         this.pipesConfig = pipesConfig;
-        this.maxIpcPayloadBytes = pipesConfig.getMaxIpcPayloadBytes();
         this.serverManager = serverManager;
         this.ownsServerManager = false;
         this.pipesClientId = CLIENT_COUNTER.getAndIncrement();
@@ -114,7 +112,6 @@ public class PipesClient implements Closeable {
      */
     public PipesClient(PipesConfig pipesConfig, java.nio.file.Path tikaConfigPath) {
         this.pipesConfig = pipesConfig;
-        this.maxIpcPayloadBytes = pipesConfig.getMaxIpcPayloadBytes();
         this.pipesClientId = CLIENT_COUNTER.getAndIncrement();
         this.serverManager = new PerClientServerManager(pipesConfig, tikaConfigPath, pipesClientId);
         this.ownsServerManager = true;
@@ -138,7 +135,7 @@ public class PipesClient implements Closeable {
         }
         try {
             PipesMessage.ping().write(tuple.output);
-            PipesMessage response = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
+            PipesMessage response = PipesMessage.read(tuple.input);
             if (response.type() == PipesMessageType.PING) {
                 return true;
             }
@@ -372,7 +369,7 @@ public class PipesClient implements Closeable {
                         intermediateResult.get());
             }
             try {
-                PipesMessage msg = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
+                PipesMessage msg = PipesMessage.read(tuple.input);
                 LOG.trace("clientId={}: received message type={} id={}", pipesClientId, msg.type(), t.getId());
 
                 // Send ACK only for messages that require it
@@ -468,7 +465,7 @@ public class PipesClient implements Closeable {
         if (tuple == null) {
             throw new IOException("connection closed");
         }
-        PipesMessage msg = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
+        PipesMessage msg = PipesMessage.read(tuple.input);
         if (msg.type() == PipesMessageType.READY) {
             LOG.info("clientId={}: server successfully started", pipesClientId);
         } else if (msg.type() == PipesMessageType.STARTUP_FAILED) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
@@ -72,6 +72,7 @@ public class PipesClient implements Closeable {
     public static final int SOCKET_TIMEOUT_MS = 60000;
 
     private final PipesConfig pipesConfig;
+    private final long maxIpcPayloadBytes;
     private final ServerManager serverManager;
     private final boolean ownsServerManager;
     private final int pipesClientId;
@@ -95,6 +96,7 @@ public class PipesClient implements Closeable {
      */
     public PipesClient(PipesConfig pipesConfig, ServerManager serverManager) {
         this.pipesConfig = pipesConfig;
+        this.maxIpcPayloadBytes = pipesConfig.getMaxIpcPayloadBytes();
         this.serverManager = serverManager;
         this.ownsServerManager = false;
         this.pipesClientId = CLIENT_COUNTER.getAndIncrement();
@@ -112,6 +114,7 @@ public class PipesClient implements Closeable {
      */
     public PipesClient(PipesConfig pipesConfig, java.nio.file.Path tikaConfigPath) {
         this.pipesConfig = pipesConfig;
+        this.maxIpcPayloadBytes = pipesConfig.getMaxIpcPayloadBytes();
         this.pipesClientId = CLIENT_COUNTER.getAndIncrement();
         this.serverManager = new PerClientServerManager(pipesConfig, tikaConfigPath, pipesClientId);
         this.ownsServerManager = true;
@@ -135,7 +138,7 @@ public class PipesClient implements Closeable {
         }
         try {
             PipesMessage.ping().write(tuple.output);
-            PipesMessage response = PipesMessage.read(tuple.input);
+            PipesMessage response = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
             if (response.type() == PipesMessageType.PING) {
                 return true;
             }
@@ -369,7 +372,7 @@ public class PipesClient implements Closeable {
                         intermediateResult.get());
             }
             try {
-                PipesMessage msg = PipesMessage.read(tuple.input);
+                PipesMessage msg = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
                 LOG.trace("clientId={}: received message type={} id={}", pipesClientId, msg.type(), t.getId());
 
                 // Send ACK only for messages that require it
@@ -465,7 +468,7 @@ public class PipesClient implements Closeable {
         if (tuple == null) {
             throw new IOException("connection closed");
         }
-        PipesMessage msg = PipesMessage.read(tuple.input);
+        PipesMessage msg = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
         if (msg.type() == PipesMessageType.READY) {
             LOG.info("clientId={}: server successfully started", pipesClientId);
         } else if (msg.type() == PipesMessageType.STARTUP_FAILED) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
@@ -47,6 +47,7 @@ import org.apache.tika.pipes.api.FetchEmitTuple;
 import org.apache.tika.pipes.api.PipesResult;
 import org.apache.tika.pipes.api.emitter.EmitKey;
 import org.apache.tika.pipes.core.emitter.EmitDataImpl;
+import org.apache.tika.pipes.core.protocol.PayloadLimitExceededException;
 import org.apache.tika.pipes.core.protocol.PipesMessage;
 import org.apache.tika.pipes.core.protocol.PipesMessageType;
 import org.apache.tika.pipes.core.serialization.JsonPipesIpc;
@@ -72,6 +73,7 @@ public class PipesClient implements Closeable {
     public static final int SOCKET_TIMEOUT_MS = 60000;
 
     private final PipesConfig pipesConfig;
+    private final int maxIpcPayloadBytes;
     private final ServerManager serverManager;
     private final boolean ownsServerManager;
     private final int pipesClientId;
@@ -95,6 +97,7 @@ public class PipesClient implements Closeable {
      */
     public PipesClient(PipesConfig pipesConfig, ServerManager serverManager) {
         this.pipesConfig = pipesConfig;
+        this.maxIpcPayloadBytes = pipesConfig.getMaxIpcPayloadBytes();
         this.serverManager = serverManager;
         this.ownsServerManager = false;
         this.pipesClientId = CLIENT_COUNTER.getAndIncrement();
@@ -112,6 +115,7 @@ public class PipesClient implements Closeable {
      */
     public PipesClient(PipesConfig pipesConfig, java.nio.file.Path tikaConfigPath) {
         this.pipesConfig = pipesConfig;
+        this.maxIpcPayloadBytes = pipesConfig.getMaxIpcPayloadBytes();
         this.pipesClientId = CLIENT_COUNTER.getAndIncrement();
         this.serverManager = new PerClientServerManager(pipesConfig, tikaConfigPath, pipesClientId);
         this.ownsServerManager = true;
@@ -369,7 +373,7 @@ public class PipesClient implements Closeable {
                         intermediateResult.get());
             }
             try {
-                PipesMessage msg = PipesMessage.read(tuple.input);
+                PipesMessage msg = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
                 LOG.trace("clientId={}: received message type={} id={}", pipesClientId, msg.type(), t.getId());
 
                 // Send ACK only for messages that require it
@@ -420,6 +424,14 @@ public class PipesClient implements Closeable {
                 closeConnection();
                 return buildFatalResult(t.getId(), t.getEmitKey(), TIMEOUT, intermediateResult.get(),
                         ExceptionUtils.getStackTrace(e));
+            } catch (PayloadLimitExceededException e) {
+                // Stream is desynchronized (payload bytes were not consumed) but server is healthy.
+                // Close the connection without restarting the server.
+                LOG.warn("clientId={}: payload too large for id={}: {}", pipesClientId, t.getId(), e.getMessage());
+                closeConnection();
+                return buildFatalResult(t.getId(), t.getEmitKey(),
+                        PipesResult.RESULT_STATUS.PAYLOAD_LIMIT_EXCEEDED,
+                        intermediateResult.get(), e.getMessage());
             } catch (SecurityException e) {
                 throw e;
             } catch (Exception e) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesClient.java
@@ -139,7 +139,7 @@ public class PipesClient implements Closeable {
         }
         try {
             PipesMessage.ping().write(tuple.output);
-            PipesMessage response = PipesMessage.read(tuple.input);
+            PipesMessage response = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
             if (response.type() == PipesMessageType.PING) {
                 return true;
             }
@@ -476,7 +476,7 @@ public class PipesClient implements Closeable {
         if (tuple == null) {
             throw new IOException("connection closed");
         }
-        PipesMessage msg = PipesMessage.read(tuple.input);
+        PipesMessage msg = PipesMessage.read(tuple.input, maxIpcPayloadBytes);
         if (msg.type() == PipesMessageType.READY) {
             LOG.info("clientId={}: server successfully started", pipesClientId);
         } else if (msg.type() == PipesMessageType.STARTUP_FAILED) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
@@ -510,6 +510,5 @@ public class PipesConfig {
                     "maxIpcPayloadBytes must be positive, got: " + maxIpcPayloadBytes);
         }
         this.maxIpcPayloadBytes = maxIpcPayloadBytes;
-        PipesMessage.MAX_PAYLOAD_BYTES = maxIpcPayloadBytes;
     }
 }

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
@@ -23,13 +23,12 @@ import org.apache.tika.config.loader.TikaJsonConfig;
 import org.apache.tika.exception.TikaConfigException;
 import org.apache.tika.pipes.api.FetchEmitTuple;
 import org.apache.tika.pipes.api.ParseMode;
+import org.apache.tika.pipes.core.protocol.PipesMessage;
 
 public class PipesConfig {
 
 
-    // Must equal PipesMessage.MAX_PAYLOAD_BYTES so the no-arg PipesMessage.read() fallback
-    // enforces the same ceiling as operator-configured call sites.
-    public static final long DEFAULT_MAX_IPC_PAYLOAD_BYTES = 100L * 1024 * 1024;
+    public static final long DEFAULT_MAX_IPC_PAYLOAD_BYTES = PipesMessage.MAX_PAYLOAD_BYTES;
 
     public static final long DEFAULT_SHUTDOWN_CLIENT_AFTER_MILLS = 300000;
 
@@ -517,5 +516,6 @@ public class PipesConfig {
                     "maxIpcPayloadBytes must be positive, got: " + maxIpcPayloadBytes);
         }
         this.maxIpcPayloadBytes = maxIpcPayloadBytes;
+        PipesMessage.MAX_PAYLOAD_BYTES = maxIpcPayloadBytes;
     }
 }

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
@@ -27,6 +27,10 @@ import org.apache.tika.pipes.api.ParseMode;
 public class PipesConfig {
 
 
+    // Must equal PipesMessage.MAX_PAYLOAD_BYTES so the no-arg PipesMessage.read() fallback
+    // enforces the same ceiling as operator-configured call sites.
+    public static final long DEFAULT_MAX_IPC_PAYLOAD_BYTES = 100L * 1024 * 1024;
+
     public static final long DEFAULT_SHUTDOWN_CLIENT_AFTER_MILLS = 300000;
 
     public static final int DEFAULT_NUM_CLIENTS = 4;
@@ -55,6 +59,8 @@ public class PipesConfig {
      * and startup time at the cost of reduced isolation - one crash affects all in-flight requests.
      */
     private boolean useSharedServer = DEFAULT_USE_SHARED_SERVER;
+
+    private long maxIpcPayloadBytes = DEFAULT_MAX_IPC_PAYLOAD_BYTES;
 
     private long socketTimeoutMs = DEFAULT_SOCKET_TIMEOUT_MS;
     private long startupTimeoutMs = DEFAULT_STARTUP_TIMEOUT_MS;
@@ -479,5 +485,37 @@ public class PipesConfig {
      */
     public void setUseSharedServer(boolean useSharedServer) {
         this.useSharedServer = useSharedServer;
+    }
+
+    /**
+     * Maximum size in bytes of a single IPC message payload exchanged between
+     * {@link org.apache.tika.pipes.core.PipesClient} and
+     * {@link org.apache.tika.pipes.core.server.PipesServer}.
+     * <p>
+     * This limit guards both the serialized {@code FetchEmitTuple} sent to the server
+     * and the serialized {@code PipesResult} (extracted text + metadata) returned by
+     * the server. Callers that regularly hit this limit should first consider
+     * configuring a {@code MetadataWriteLimiterFactory} to bound extracted-text size.
+     *
+     * @return the maximum IPC payload size in bytes (default 100 MB)
+     */
+    public long getMaxIpcPayloadBytes() {
+        return maxIpcPayloadBytes;
+    }
+
+    /**
+     * Sets the maximum IPC payload size. Must be a positive value. Note that the
+     * wire protocol uses a 4-byte signed integer for the length field, so values
+     * above {@link Integer#MAX_VALUE} are effectively unlimited at the protocol level.
+     *
+     * @param maxIpcPayloadBytes positive payload limit in bytes
+     * @throws IllegalArgumentException if the value is not positive
+     */
+    public void setMaxIpcPayloadBytes(long maxIpcPayloadBytes) {
+        if (maxIpcPayloadBytes <= 0) {
+            throw new IllegalArgumentException(
+                    "maxIpcPayloadBytes must be positive, got: " + maxIpcPayloadBytes);
+        }
+        this.maxIpcPayloadBytes = maxIpcPayloadBytes;
     }
 }

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
@@ -28,7 +28,7 @@ import org.apache.tika.pipes.core.protocol.PipesMessage;
 public class PipesConfig {
 
 
-    public static final long DEFAULT_MAX_IPC_PAYLOAD_BYTES = PipesMessage.MAX_PAYLOAD_BYTES;
+    public static final int DEFAULT_MAX_IPC_PAYLOAD_BYTES = PipesMessage.MAX_PAYLOAD_BYTES;
 
     public static final long DEFAULT_SHUTDOWN_CLIENT_AFTER_MILLS = 300000;
 
@@ -59,7 +59,7 @@ public class PipesConfig {
      */
     private boolean useSharedServer = DEFAULT_USE_SHARED_SERVER;
 
-    private long maxIpcPayloadBytes = DEFAULT_MAX_IPC_PAYLOAD_BYTES;
+    private int maxIpcPayloadBytes = DEFAULT_MAX_IPC_PAYLOAD_BYTES;
 
     private long socketTimeoutMs = DEFAULT_SOCKET_TIMEOUT_MS;
     private long startupTimeoutMs = DEFAULT_STARTUP_TIMEOUT_MS;
@@ -487,30 +487,24 @@ public class PipesConfig {
     }
 
     /**
-     * Maximum size in bytes of a single IPC message payload exchanged between
-     * {@link org.apache.tika.pipes.core.PipesClient} and
-     * {@link org.apache.tika.pipes.core.server.PipesServer}.
-     * <p>
-     * This limit guards both the serialized {@code FetchEmitTuple} sent to the server
-     * and the serialized {@code PipesResult} (extracted text + metadata) returned by
-     * the server. Callers that regularly hit this limit should first consider
-     * configuring a {@code MetadataWriteLimiterFactory} to bound extracted-text size.
+     * Returns the maximum IPC payload size in bytes.
+     * Configurable via {@code maxIpcPayloadBytes} in the {@code pipes} section of tika-config.json.
      *
      * @return the maximum IPC payload size in bytes (default 100 MB)
      */
-    public long getMaxIpcPayloadBytes() {
+    public int getMaxIpcPayloadBytes() {
         return maxIpcPayloadBytes;
     }
 
     /**
-     * Sets the maximum IPC payload size. Must be a positive value. Note that the
-     * wire protocol uses a 4-byte signed integer for the length field, so values
-     * above {@link Integer#MAX_VALUE} are effectively unlimited at the protocol level.
+     * Sets the maximum IPC payload size in bytes. Must be a positive value.
+     * Both the client and server JVMs read from the same tika-config.json, so
+     * setting this once configures the limit on both ends automatically.
      *
      * @param maxIpcPayloadBytes positive payload limit in bytes
      * @throws IllegalArgumentException if the value is not positive
      */
-    public void setMaxIpcPayloadBytes(long maxIpcPayloadBytes) {
+    public void setMaxIpcPayloadBytes(int maxIpcPayloadBytes) {
         if (maxIpcPayloadBytes <= 0) {
             throw new IllegalArgumentException(
                     "maxIpcPayloadBytes must be positive, got: " + maxIpcPayloadBytes);

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/PipesConfig.java
@@ -498,8 +498,9 @@ public class PipesConfig {
 
     /**
      * Sets the maximum IPC payload size in bytes. Must be a positive value.
-     * Both the client and server JVMs read from the same tika-config.json, so
-     * setting this once configures the limit on both ends automatically.
+     * This bounds the size of a message the client will accept back from the
+     * forked server (chiefly the FINISHED result). Request payloads
+     * (client to server) are small and use the built-in default.
      *
      * @param maxIpcPayloadBytes positive payload limit in bytes
      * @throws IllegalArgumentException if the value is not positive

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PayloadLimitExceededException.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PayloadLimitExceededException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.pipes.core.protocol;
+
+import java.io.IOException;
+
+/**
+ * Thrown when an incoming IPC payload exceeds {@link PipesMessage#MAX_PAYLOAD_BYTES}.
+ * The stream is desynchronized at this point (payload bytes were not consumed),
+ * so the connection must be closed. The server process itself remains healthy.
+ */
+public class PayloadLimitExceededException extends IOException {
+    public PayloadLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PayloadLimitExceededException.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PayloadLimitExceededException.java
@@ -19,9 +19,13 @@ package org.apache.tika.pipes.core.protocol;
 import java.io.IOException;
 
 /**
- * Thrown when an incoming IPC payload exceeds {@link PipesMessage#MAX_PAYLOAD_BYTES}.
- * The stream is desynchronized at this point (payload bytes were not consumed),
- * so the connection must be closed. The server process itself remains healthy.
+ * Thrown when an incoming IPC payload's declared length exceeds the configured limit
+ * (see {@link org.apache.tika.pipes.core.PipesConfig#getMaxIpcPayloadBytes()};
+ * default {@link PipesMessage#MAX_PAYLOAD_BYTES}). The payload bytes were not consumed,
+ * so the stream is desynchronized and the connection must be closed. With a shared server
+ * the process keeps running (only this connection ends); with the default per-client forked
+ * server the process may still exit on the failed write, and the client reconnects on the
+ * next task.
  */
 public class PayloadLimitExceededException extends IOException {
     public PayloadLimitExceededException(String message) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
@@ -40,8 +40,8 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
     static final byte MAGIC_0 = 0x54; // 'T'
     static final byte MAGIC_1 = 0x4B; // 'K'
 
-    /** Maximum payload size; configurable via {@link org.apache.tika.pipes.core.PipesConfig#setMaxIpcPayloadBytes}. */
-    public static int MAX_PAYLOAD_BYTES = 100 * 1024 * 1024;
+    /** Default maximum payload size. Override per-read via {@link #read(DataInputStream, int)}. */
+    public static final int MAX_PAYLOAD_BYTES = 100 * 1024 * 1024;
 
     private static final byte[] EMPTY = new byte[0];
 
@@ -50,9 +50,24 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
      *
      * @throws ProtocolDesyncException if magic bytes don't match
      * @throws EOFException if the stream ends before a complete message
-     * @throws IOException on payload size violations or I/O errors
+     * @throws PayloadLimitExceededException if the payload length exceeds {@link #MAX_PAYLOAD_BYTES}
+     * @throws IOException on other I/O errors
      */
     public static PipesMessage read(DataInputStream in) throws IOException {
+        return read(in, MAX_PAYLOAD_BYTES);
+    }
+
+    /**
+     * Reads one framed message from the stream, enforcing the given payload limit.
+     * Use this overload when the caller has a per-connection limit from config.
+     *
+     * @param maxPayloadBytes maximum allowed payload size in bytes
+     * @throws ProtocolDesyncException if magic bytes don't match
+     * @throws EOFException if the stream ends before a complete message
+     * @throws PayloadLimitExceededException if the payload length exceeds {@code maxPayloadBytes}
+     * @throws IOException on other I/O errors
+     */
+    public static PipesMessage read(DataInputStream in, int maxPayloadBytes) throws IOException {
         int m0 = in.read();
         if (m0 == -1) {
             throw new EOFException("Stream closed before magic byte");
@@ -77,9 +92,9 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
         if (len < 0) {
             throw new IOException("Negative payload length: " + len);
         }
-        if (len > MAX_PAYLOAD_BYTES) {
-            throw new IOException("Payload length " + len +
-                    " exceeds maximum of " + MAX_PAYLOAD_BYTES + " bytes");
+        if (len > maxPayloadBytes) {
+            throw new PayloadLimitExceededException("Payload length " + len +
+                    " exceeds maximum of " + maxPayloadBytes + " bytes");
         }
 
         byte[] payload;

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
@@ -40,8 +40,8 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
     static final byte MAGIC_0 = 0x54; // 'T'
     static final byte MAGIC_1 = 0x4B; // 'K'
 
-    /** Maximum payload size: 100 MB (same as old MAX_FETCH_EMIT_TUPLE_BYTES). */
-    public static final int MAX_PAYLOAD_BYTES = 100 * 1024 * 1024;
+    /** Maximum payload size; configurable via {@link org.apache.tika.pipes.core.PipesConfig#setMaxIpcPayloadBytes}. */
+    public static long MAX_PAYLOAD_BYTES = 100 * 1024 * 1024;
 
     private static final byte[] EMPTY = new byte[0];
 
@@ -53,18 +53,6 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
      * @throws IOException on payload size violations or I/O errors
      */
     public static PipesMessage read(DataInputStream in) throws IOException {
-        return read(in, MAX_PAYLOAD_BYTES);
-    }
-
-    /**
-     * Reads one framed message from the stream, enforcing a configurable payload limit.
-     *
-     * @param maxPayloadBytes maximum allowed payload size in bytes
-     * @throws ProtocolDesyncException if magic bytes don't match
-     * @throws EOFException if the stream ends before a complete message
-     * @throws IOException on payload size violations or I/O errors
-     */
-    public static PipesMessage read(DataInputStream in, long maxPayloadBytes) throws IOException {
         int m0 = in.read();
         if (m0 == -1) {
             throw new EOFException("Stream closed before magic byte");
@@ -89,9 +77,9 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
         if (len < 0) {
             throw new IOException("Negative payload length: " + len);
         }
-        if (len > maxPayloadBytes) {
+        if (len > MAX_PAYLOAD_BYTES) {
             throw new IOException("Payload length " + len +
-                    " exceeds maximum of " + maxPayloadBytes + " bytes");
+                    " exceeds maximum of " + MAX_PAYLOAD_BYTES + " bytes");
         }
 
         byte[] payload;

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
@@ -41,7 +41,7 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
     static final byte MAGIC_1 = 0x4B; // 'K'
 
     /** Maximum payload size; configurable via {@link org.apache.tika.pipes.core.PipesConfig#setMaxIpcPayloadBytes}. */
-    public static long MAX_PAYLOAD_BYTES = 100 * 1024 * 1024;
+    public static int MAX_PAYLOAD_BYTES = 100 * 1024 * 1024;
 
     private static final byte[] EMPTY = new byte[0];
 

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/protocol/PipesMessage.java
@@ -46,13 +46,25 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
     private static final byte[] EMPTY = new byte[0];
 
     /**
-     * Reads one framed message from the stream.
+     * Reads one framed message from the stream, enforcing {@link #MAX_PAYLOAD_BYTES}.
      *
      * @throws ProtocolDesyncException if magic bytes don't match
      * @throws EOFException if the stream ends before a complete message
      * @throws IOException on payload size violations or I/O errors
      */
     public static PipesMessage read(DataInputStream in) throws IOException {
+        return read(in, MAX_PAYLOAD_BYTES);
+    }
+
+    /**
+     * Reads one framed message from the stream, enforcing a configurable payload limit.
+     *
+     * @param maxPayloadBytes maximum allowed payload size in bytes
+     * @throws ProtocolDesyncException if magic bytes don't match
+     * @throws EOFException if the stream ends before a complete message
+     * @throws IOException on payload size violations or I/O errors
+     */
+    public static PipesMessage read(DataInputStream in, long maxPayloadBytes) throws IOException {
         int m0 = in.read();
         if (m0 == -1) {
             throw new EOFException("Stream closed before magic byte");
@@ -77,9 +89,9 @@ public record PipesMessage(PipesMessageType type, byte[] payload) {
         if (len < 0) {
             throw new IOException("Negative payload length: " + len);
         }
-        if (len > MAX_PAYLOAD_BYTES) {
+        if (len > maxPayloadBytes) {
             throw new IOException("Payload length " + len +
-                    " exceeds maximum of " + MAX_PAYLOAD_BYTES + " bytes");
+                    " exceeds maximum of " + maxPayloadBytes + " bytes");
         }
 
         byte[] payload;

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ConnectionHandler.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ConnectionHandler.java
@@ -106,7 +106,7 @@ public class ConnectionHandler implements Runnable, Closeable {
         this.resources = resources;
         this.pipesConfig = pipesConfig;
         this.heartbeatIntervalMs = pipesConfig.getHeartbeatIntervalMs();
-        this.protocolIO = new ServerProtocolIO(input, output, pipesConfig.getMaxIpcPayloadBytes());
+        this.protocolIO = new ServerProtocolIO(input, output);
     }
 
     @Override
@@ -136,7 +136,7 @@ public class ConnectionHandler implements Runnable, Closeable {
             try {
                 PipesMessage msg;
                 try {
-                    msg = PipesMessage.read(input, pipesConfig.getMaxIpcPayloadBytes());
+                    msg = PipesMessage.read(input);
                 } catch (SocketTimeoutException e) {
                     // Socket timeout while idle is the normal inactivity shutdown path.
                     LOG.info("handlerId={}: socket timeout while waiting for task, closing connection",

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ConnectionHandler.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ConnectionHandler.java
@@ -106,7 +106,7 @@ public class ConnectionHandler implements Runnable, Closeable {
         this.resources = resources;
         this.pipesConfig = pipesConfig;
         this.heartbeatIntervalMs = pipesConfig.getHeartbeatIntervalMs();
-        this.protocolIO = new ServerProtocolIO(input, output);
+        this.protocolIO = new ServerProtocolIO(input, output, pipesConfig.getMaxIpcPayloadBytes());
     }
 
     @Override
@@ -136,7 +136,7 @@ public class ConnectionHandler implements Runnable, Closeable {
             try {
                 PipesMessage msg;
                 try {
-                    msg = PipesMessage.read(input);
+                    msg = PipesMessage.read(input, pipesConfig.getMaxIpcPayloadBytes());
                 } catch (SocketTimeoutException e) {
                     // Socket timeout while idle is the normal inactivity shutdown path.
                     LOG.info("handlerId={}: socket timeout while waiting for task, closing connection",

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ConnectionHandler.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ConnectionHandler.java
@@ -136,7 +136,7 @@ public class ConnectionHandler implements Runnable, Closeable {
             try {
                 PipesMessage msg;
                 try {
-                    msg = PipesMessage.read(input);
+                    msg = PipesMessage.read(input, pipesConfig.getMaxIpcPayloadBytes());
                 } catch (SocketTimeoutException e) {
                     // Socket timeout while idle is the normal inactivity shutdown path.
                     LOG.info("handlerId={}: socket timeout while waiting for task, closing connection",

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
@@ -160,6 +160,8 @@ public class PipesServer implements AutoCloseable {
                 String msg = ExceptionUtils.getStackTrace(e);
                 byte[] bytes = msg.getBytes(StandardCharsets.UTF_8);
                 PipesMessage.startupFailed(bytes).write(dos);
+                // pipesConfig is scoped inside the try block so is not accessible here;
+                // the ACK carries no payload, so the MAX_PAYLOAD_BYTES fallback is safe.
                 PipesMessage ackMsg = PipesMessage.read(dis);
                 if (ackMsg.type() != PipesMessageType.ACK) {
                     LOG.warn("Expected ACK but got: {}", ackMsg.type());
@@ -201,7 +203,7 @@ public class PipesServer implements AutoCloseable {
         }
 
         emitStrategy = pipesConfig.getEmitStrategy().getType();
-        this.protocolIO = new ServerProtocolIO(input, output);
+        this.protocolIO = new ServerProtocolIO(input, output, pipesConfig.getMaxIpcPayloadBytes());
     }
 
 
@@ -336,7 +338,7 @@ public class PipesServer implements AutoCloseable {
             while (true) {
                 PipesMessage msg;
                 try {
-                    msg = PipesMessage.read(input);
+                    msg = PipesMessage.read(input, pipesConfig.getMaxIpcPayloadBytes());
                 } catch (SocketTimeoutException e) {
                     // Socket timeout while idle is the normal inactivity shutdown path.
                     // Exit cleanly — PipesClient will restart the server if needed.

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
@@ -160,8 +160,6 @@ public class PipesServer implements AutoCloseable {
                 String msg = ExceptionUtils.getStackTrace(e);
                 byte[] bytes = msg.getBytes(StandardCharsets.UTF_8);
                 PipesMessage.startupFailed(bytes).write(dos);
-                // pipesConfig is scoped inside the try block so is not accessible here;
-                // the ACK carries no payload, so the MAX_PAYLOAD_BYTES fallback is safe.
                 PipesMessage ackMsg = PipesMessage.read(dis);
                 if (ackMsg.type() != PipesMessageType.ACK) {
                     LOG.warn("Expected ACK but got: {}", ackMsg.type());
@@ -203,7 +201,7 @@ public class PipesServer implements AutoCloseable {
         }
 
         emitStrategy = pipesConfig.getEmitStrategy().getType();
-        this.protocolIO = new ServerProtocolIO(input, output, pipesConfig.getMaxIpcPayloadBytes());
+        this.protocolIO = new ServerProtocolIO(input, output);
     }
 
 
@@ -338,7 +336,7 @@ public class PipesServer implements AutoCloseable {
             while (true) {
                 PipesMessage msg;
                 try {
-                    msg = PipesMessage.read(input, pipesConfig.getMaxIpcPayloadBytes());
+                    msg = PipesMessage.read(input);
                 } catch (SocketTimeoutException e) {
                     // Socket timeout while idle is the normal inactivity shutdown path.
                     // Exit cleanly — PipesClient will restart the server if needed.

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/PipesServer.java
@@ -160,6 +160,8 @@ public class PipesServer implements AutoCloseable {
                 String msg = ExceptionUtils.getStackTrace(e);
                 byte[] bytes = msg.getBytes(StandardCharsets.UTF_8);
                 PipesMessage.startupFailed(bytes).write(dos);
+                // pipesConfig may not have loaded successfully (that may be why we're
+                // here); use the built-in default rather than an unreliable reference.
                 PipesMessage ackMsg = PipesMessage.read(dis);
                 if (ackMsg.type() != PipesMessageType.ACK) {
                     LOG.warn("Expected ACK but got: {}", ackMsg.type());
@@ -336,7 +338,7 @@ public class PipesServer implements AutoCloseable {
             while (true) {
                 PipesMessage msg;
                 try {
-                    msg = PipesMessage.read(input);
+                    msg = PipesMessage.read(input, pipesConfig.getMaxIpcPayloadBytes());
                 } catch (SocketTimeoutException e) {
                     // Socket timeout while idle is the normal inactivity shutdown path.
                     // Exit cleanly — PipesClient will restart the server if needed.

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ServerProtocolIO.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ServerProtocolIO.java
@@ -51,12 +51,10 @@ public class ServerProtocolIO {
 
     private final DataInputStream input;
     private final DataOutputStream output;
-    private final long maxIpcPayloadBytes;
 
-    public ServerProtocolIO(DataInputStream input, DataOutputStream output, long maxIpcPayloadBytes) {
+    public ServerProtocolIO(DataInputStream input, DataOutputStream output) {
         this.input = input;
         this.output = output;
-        this.maxIpcPayloadBytes = maxIpcPayloadBytes;
     }
 
     /**
@@ -103,7 +101,7 @@ public class ServerProtocolIO {
      * @throws IOException if the message is any other non-ACK type, or on I/O error
      */
     public void awaitAck() throws IOException {
-        PipesMessage msg = PipesMessage.read(input, maxIpcPayloadBytes);
+        PipesMessage msg = PipesMessage.read(input);
         if (msg.type() == PipesMessageType.ACK) {
             return;
         }

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ServerProtocolIO.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/server/ServerProtocolIO.java
@@ -51,10 +51,12 @@ public class ServerProtocolIO {
 
     private final DataInputStream input;
     private final DataOutputStream output;
+    private final long maxIpcPayloadBytes;
 
-    public ServerProtocolIO(DataInputStream input, DataOutputStream output) {
+    public ServerProtocolIO(DataInputStream input, DataOutputStream output, long maxIpcPayloadBytes) {
         this.input = input;
         this.output = output;
+        this.maxIpcPayloadBytes = maxIpcPayloadBytes;
     }
 
     /**
@@ -101,7 +103,7 @@ public class ServerProtocolIO {
      * @throws IOException if the message is any other non-ACK type, or on I/O error
      */
     public void awaitAck() throws IOException {
-        PipesMessage msg = PipesMessage.read(input);
+        PipesMessage msg = PipesMessage.read(input, maxIpcPayloadBytes);
         if (msg.type() == PipesMessageType.ACK) {
             return;
         }

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/TikaPipesConfigTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/TikaPipesConfigTest.java
@@ -16,9 +16,48 @@
  */
 package org.apache.tika.pipes.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
 import org.apache.tika.TikaTest;
+import org.apache.tika.config.loader.TikaJsonConfig;
 
 public class TikaPipesConfigTest extends TikaTest {
+
+    @Test
+    void testMaxIpcPayloadBytesDefault() {
+        PipesConfig config = new PipesConfig();
+        assertEquals(PipesConfig.DEFAULT_MAX_IPC_PAYLOAD_BYTES, config.getMaxIpcPayloadBytes());
+        assertEquals(100L * 1024 * 1024, config.getMaxIpcPayloadBytes());
+    }
+
+    @Test
+    void testMaxIpcPayloadBytesFromJson() throws Exception {
+        String json = """
+                {
+                  "pipes": {
+                    "maxIpcPayloadBytes": 209715200
+                  }
+                }
+                """;
+        TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+        PipesConfig config = PipesConfig.load(tikaJsonConfig);
+        assertEquals(209715200L, config.getMaxIpcPayloadBytes());
+    }
+
+    @Test
+    void testMaxIpcPayloadBytesRejectsNonPositive() {
+        PipesConfig config = new PipesConfig();
+        assertThrows(IllegalArgumentException.class, () -> config.setMaxIpcPayloadBytes(0));
+        assertThrows(IllegalArgumentException.class, () -> config.setMaxIpcPayloadBytes(-1));
+    }
+
     //this handles tests for the newer pipes type configs.
 /*
     TODO -- reimplent these with json

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/TikaPipesConfigTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/TikaPipesConfigTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.tika.TikaTest;
 import org.apache.tika.config.loader.TikaJsonConfig;
+import org.apache.tika.pipes.core.protocol.PipesMessage;
 
 public class TikaPipesConfigTest extends TikaTest {
 
@@ -33,7 +34,7 @@ public class TikaPipesConfigTest extends TikaTest {
     void testMaxIpcPayloadBytesDefault() {
         PipesConfig config = new PipesConfig();
         assertEquals(PipesConfig.DEFAULT_MAX_IPC_PAYLOAD_BYTES, config.getMaxIpcPayloadBytes());
-        assertEquals(100L * 1024 * 1024, config.getMaxIpcPayloadBytes());
+        assertEquals(100 * 1024 * 1024, config.getMaxIpcPayloadBytes());
     }
 
     @Test
@@ -48,7 +49,8 @@ public class TikaPipesConfigTest extends TikaTest {
         TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(
                 new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
         PipesConfig config = PipesConfig.load(tikaJsonConfig);
-        assertEquals(209715200L, config.getMaxIpcPayloadBytes());
+        assertEquals(209715200, config.getMaxIpcPayloadBytes());
+        assertEquals(209715200, PipesMessage.MAX_PAYLOAD_BYTES);
     }
 
     @Test

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/TikaPipesConfigTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/TikaPipesConfigTest.java
@@ -50,7 +50,8 @@ public class TikaPipesConfigTest extends TikaTest {
                 new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
         PipesConfig config = PipesConfig.load(tikaJsonConfig);
         assertEquals(209715200, config.getMaxIpcPayloadBytes());
-        assertEquals(209715200, PipesMessage.MAX_PAYLOAD_BYTES);
+        // The global constant is unchanged — the configured limit is passed per-read
+        assertEquals(100 * 1024 * 1024, PipesMessage.MAX_PAYLOAD_BYTES);
     }
 
     @Test
@@ -58,6 +59,16 @@ public class TikaPipesConfigTest extends TikaTest {
         PipesConfig config = new PipesConfig();
         assertThrows(IllegalArgumentException.class, () -> config.setMaxIpcPayloadBytes(0));
         assertThrows(IllegalArgumentException.class, () -> config.setMaxIpcPayloadBytes(-1));
+    }
+
+    @Test
+    void testMaxIpcPayloadBytesFromJsonRejectsZero() throws Exception {
+        String json = """
+                {"pipes": {"maxIpcPayloadBytes": 0}}
+                """;
+        TikaJsonConfig tikaJsonConfig = TikaJsonConfig.load(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+        assertThrows(Exception.class, () -> PipesConfig.load(tikaJsonConfig));
     }
 
     //this handles tests for the newer pipes type configs.

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
@@ -127,7 +127,7 @@ class PipesMessageTest {
         dos.writeInt(PipesMessage.MAX_PAYLOAD_BYTES + 1);
         dos.flush();
 
-        assertThrows(IOException.class, () ->
+        assertThrows(PayloadLimitExceededException.class, () ->
                 PipesMessage.read(new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))));
     }
 

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
@@ -124,7 +124,7 @@ class PipesMessageTest {
         dos.write(PipesMessage.MAGIC_0);
         dos.write(PipesMessage.MAGIC_1);
         dos.write(PipesMessageType.FINISHED.getByte());
-        dos.writeInt((int) (PipesMessage.MAX_PAYLOAD_BYTES + 1));
+        dos.writeInt(PipesMessage.MAX_PAYLOAD_BYTES + 1);
         dos.flush();
 
         assertThrows(IOException.class, () ->

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
@@ -194,6 +194,43 @@ class PipesMessageTest {
         assertEquals(PipesMessageType.OOM, roundTrip(PipesMessage.crash(PipesMessageType.OOM, data)).type());
     }
 
+    // --- configurable read limit ---
+
+    @Test
+    void testCustomReadLimit_withinLimit() throws IOException {
+        byte[] payload = "hello".getBytes(StandardCharsets.UTF_8); // 5 bytes
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PipesMessage.finished(payload).write(new DataOutputStream(baos));
+
+        PipesMessage result = PipesMessage.read(
+                new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 5);
+        assertArrayEquals(payload, result.payload());
+    }
+
+    @Test
+    void testCustomReadLimit_exceedsCustomLimit() throws IOException {
+        byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8); // 11 bytes
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PipesMessage.finished(payload).write(new DataOutputStream(baos));
+
+        // limit of 10 < payload of 11 → must reject
+        assertThrows(IOException.class, () ->
+                PipesMessage.read(
+                        new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 10));
+    }
+
+    @Test
+    void testCustomReadLimit_belowDefaultButAboveCustom() throws IOException {
+        // payload well under MAX_PAYLOAD_BYTES but above a tighter custom limit
+        byte[] payload = new byte[1024];
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PipesMessage.finished(payload).write(new DataOutputStream(baos));
+
+        assertThrows(IOException.class, () ->
+                PipesMessage.read(
+                        new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 512));
+    }
+
     private PipesMessage roundTrip(PipesMessage msg) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         msg.write(new DataOutputStream(baos));

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
@@ -124,7 +124,7 @@ class PipesMessageTest {
         dos.write(PipesMessage.MAGIC_0);
         dos.write(PipesMessage.MAGIC_1);
         dos.write(PipesMessageType.FINISHED.getByte());
-        dos.writeInt(PipesMessage.MAX_PAYLOAD_BYTES + 1);
+        dos.writeInt((int) (PipesMessage.MAX_PAYLOAD_BYTES + 1));
         dos.flush();
 
         assertThrows(IOException.class, () ->
@@ -192,43 +192,6 @@ class PipesMessageTest {
         assertEquals(PipesMessageType.INTERMEDIATE_RESULT, roundTrip(PipesMessage.intermediateResult(data)).type());
         assertEquals(PipesMessageType.STARTUP_FAILED, roundTrip(PipesMessage.startupFailed(data)).type());
         assertEquals(PipesMessageType.OOM, roundTrip(PipesMessage.crash(PipesMessageType.OOM, data)).type());
-    }
-
-    // --- configurable read limit ---
-
-    @Test
-    void testCustomReadLimit_withinLimit() throws IOException {
-        byte[] payload = "hello".getBytes(StandardCharsets.UTF_8); // 5 bytes
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PipesMessage.finished(payload).write(new DataOutputStream(baos));
-
-        PipesMessage result = PipesMessage.read(
-                new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 5);
-        assertArrayEquals(payload, result.payload());
-    }
-
-    @Test
-    void testCustomReadLimit_exceedsCustomLimit() throws IOException {
-        byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8); // 11 bytes
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PipesMessage.finished(payload).write(new DataOutputStream(baos));
-
-        // limit of 10 < payload of 11 → must reject
-        assertThrows(IOException.class, () ->
-                PipesMessage.read(
-                        new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 10));
-    }
-
-    @Test
-    void testCustomReadLimit_belowDefaultButAboveCustom() throws IOException {
-        // payload well under MAX_PAYLOAD_BYTES but above a tighter custom limit
-        byte[] payload = new byte[1024];
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PipesMessage.finished(payload).write(new DataOutputStream(baos));
-
-        assertThrows(IOException.class, () ->
-                PipesMessage.read(
-                        new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 512));
     }
 
     private PipesMessage roundTrip(PipesMessage msg) throws IOException {

--- a/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
+++ b/tika-pipes/tika-pipes-core/src/test/java/org/apache/tika/pipes/core/protocol/PipesMessageTest.java
@@ -131,6 +131,37 @@ class PipesMessageTest {
                 PipesMessage.read(new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))));
     }
 
+    /**
+     * A caller-supplied limit well under {@link PipesMessage#MAX_PAYLOAD_BYTES} must be
+     * enforced on its own, not just the built-in default — this is what makes the limit
+     * actually configurable rather than a second name for the same constant.
+     */
+    @Test
+    void testCustomPayloadLimitRejectsAboveBound() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.write(PipesMessage.MAGIC_0);
+        dos.write(PipesMessage.MAGIC_1);
+        dos.write(PipesMessageType.FINISHED.getByte());
+        dos.writeInt(1000); // one byte over the 999-byte custom limit below
+        dos.flush();
+
+        assertThrows(PayloadLimitExceededException.class, () ->
+                PipesMessage.read(new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 999));
+    }
+
+    @Test
+    void testCustomPayloadLimitAcceptsAtBound() throws IOException {
+        byte[] payload = new byte[999];
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PipesMessage.finished(payload).write(new DataOutputStream(baos));
+
+        PipesMessage roundTripped = PipesMessage.read(
+                new DataInputStream(new ByteArrayInputStream(baos.toByteArray())), 999);
+        assertEquals(PipesMessageType.FINISHED, roundTripped.type());
+        assertEquals(999, roundTripped.payload().length);
+    }
+
     @Test
     void testRequiresAckAssertions() {
         assertFalse(PipesMessageType.PING.requiresAck());

--- a/tika-server/tika-server-core/src/main/java/org/apache/tika/server/core/resource/PipesParsingHelper.java
+++ b/tika-server/tika-server-core/src/main/java/org/apache/tika/server/core/resource/PipesParsingHelper.java
@@ -282,6 +282,7 @@ public class PipesParsingHelper {
                     Response.Status.SERVICE_UNAVAILABLE;
             case FETCH_EXCEPTION, EMIT_EXCEPTION,
                  FETCHER_NOT_FOUND, EMITTER_NOT_FOUND,
+                 PAYLOAD_LIMIT_EXCEEDED,
                  FETCHER_INITIALIZATION_EXCEPTION, EMITTER_INITIALIZATION_EXCEPTION,
                  FAILED_TO_INITIALIZE ->
                     Response.Status.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
The hard-coded 100 MB ceiling in PipesMessage was not operator-tunable. Add PipesConfig.maxIpcPayloadBytes (default 100 MB) and thread it through PipesClient, PipesServer, ConnectionHandler, and ServerProtocolIO so the limit is applied on every read() call. The write path is unchanged. Includes unit tests for default value, JSON loading, and validation.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Tika](https://tika.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Tika issue tracker](https://issues.apache.org/jira/projects/TIKA) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`TIKA-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[TIKA-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Tika is successfully built and unit tests pass by running `./mvnw clean test`
* there should be no conflicts when merging the pull request branch into the *recent* `main` branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled `main` branch
* if you add new module that downstream users will depend upon add it to relevant group in `tika-bom/pom.xml`.

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Tika in general, please sign up for the [Tika mailing list](http://tika.apache.org/mail-lists.html). Thanks!
