### PR TITLE
[TIKA-4796] compile MagicDetector regex once at construction (3.x backport)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Release 3.3.3 - ???
+
+  * MagicDetector now compiles its regular expression once, in the
+    constructor, instead of recompiling it on every match (TIKA-4796).
+
 Release 3.3.2 - 7/16/2026
 
   * Dependency upgrades (TIKA-4738).

--- a/tika-core/src/main/java/org/apache/tika/detect/MagicDetector.java
+++ b/tika-core/src/main/java/org/apache/tika/detect/MagicDetector.java
@@ -39,6 +39,9 @@ import org.apache.tika.mime.MediaType;
  * Because this works on bytes, not characters, by default any string
  * matching is done as ISO_8859_1. To use an explicit different
  * encoding, supply a type other than "string" / "stringignorecase"
+ * <p>
+ * Instances of this class are immutable and safe for use by multiple
+ * concurrent threads.
  *
  * @since Apache Tika 0.3
  */
@@ -91,6 +94,12 @@ public class MagicDetector implements Detector {
      * starts at this offset.
      */
     private final int offsetRangeEnd;
+    /**
+     * The compiled form of {@link #pattern} when {@link #isRegex} is true,
+     * <code>null</code> otherwise. Compiled once here rather than per match,
+     * as every input to it is fixed at construction time.
+     */
+    private final Pattern compiledPattern;
 
     /**
      * Creates a detector for input documents that have the exact given byte
@@ -137,6 +146,15 @@ public class MagicDetector implements Detector {
     /**
      * Creates a detector for input documents that meet the specified
      * magic match.
+     * <p>
+     * When <code>isRegex</code> is true the pattern is compiled here rather
+     * than on each match, so a malformed pattern is reported by this
+     * constructor instead of by the first call to
+     * {@link #detect(InputStream, Metadata)}.
+     *
+     * @throws java.util.regex.PatternSyntaxException if <code>isRegex</code>
+     *         is true and <code>pattern</code> is not a valid regular
+     *         expression
      */
     public MagicDetector(MediaType type, byte[] pattern, byte[] mask, boolean isRegex,
                          boolean isStringIgnoreCase, int offsetRangeBegin, int offsetRangeEnd) {
@@ -178,6 +196,13 @@ public class MagicDetector implements Detector {
             } else {
                 this.pattern[i] = 0;
             }
+        }
+
+        if (this.isRegex) {
+            int flags = this.isStringIgnoreCase ? Pattern.CASE_INSENSITIVE : 0;
+            this.compiledPattern = Pattern.compile(new String(this.pattern, UTF_8), flags);
+        } else {
+            this.compiledPattern = null;
         }
 
         this.offsetRangeBegin = offsetRangeBegin;
@@ -374,16 +399,9 @@ public class MagicDetector implements Detector {
             }
 
             if (this.isRegex) {
-                int flags = 0;
-                if (this.isStringIgnoreCase) {
-                    flags = Pattern.CASE_INSENSITIVE;
-                }
-
-                Pattern p = Pattern.compile(new String(this.pattern, UTF_8), flags);
-
                 ByteBuffer bb = ByteBuffer.wrap(buffer);
                 CharBuffer result = ISO_8859_1.decode(bb);
-                Matcher m = p.matcher(result);
+                Matcher m = compiledPattern.matcher(result);
 
                 boolean match = false;
                 // Loop until we've covered the entire offset range

--- a/tika-core/src/test/java/org/apache/tika/detect/MagicDetectorTest.java
+++ b/tika-core/src/test/java/org/apache/tika/detect/MagicDetectorTest.java
@@ -26,6 +26,12 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -156,6 +162,65 @@ public class MagicDetectorTest {
         assertDetect(detector, html, data);
         assertDetect(detector, html, data1);
         assertDetect(detector, MediaType.OCTET_STREAM, data2);
+    }
+
+    /**
+     * A MagicDetector is built once and reused for the life of the process, so
+     * repeated calls must be independent of each other. Guards the compiled
+     * Pattern against per-call state leaking in.
+     */
+    @Test
+    public void testRegExDetectorRepeatedCallsStable() throws Exception {
+        MediaType html = new MediaType("text", "html");
+        String pattern = "(?s)\\A.{0,1024}\\x3c\\!(?:DOCTYPE|doctype) (?:HTML|html) ";
+        Detector detector =
+                new MagicDetector(html, pattern.getBytes(US_ASCII), null, true, 0, 0);
+
+        String match = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\">";
+        String noMatch = "<html><head><title>plain</title></head>";
+
+        for (int i = 0; i < 100; i++) {
+            assertDetect(detector, html, match);
+            assertDetect(detector, MediaType.OCTET_STREAM, noMatch);
+        }
+    }
+
+    /**
+     * MimeTypes shares one MagicDetector instance per magic clause across every
+     * caller, so the regex path has to be safe to use concurrently.
+     */
+    @Test
+    public void testRegExDetectorConcurrent() throws Exception {
+        MediaType pdf = new MediaType("application", "pdf");
+        Detector detector =
+                new MagicDetector(pdf, "(?s)\\A.{0,144}%PDF-".getBytes(US_ASCII), null, true, 0, 0);
+
+        byte[] match = "%PDF-1.4\nsome trailing content".getBytes(US_ASCII);
+        byte[] noMatch = "not a pdf at all".getBytes(US_ASCII);
+
+        int threads = 8;
+        int iterations = 200;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                futures.add(executor.submit(() -> {
+                    for (int i = 0; i < iterations; i++) {
+                        assertEquals(pdf, detector.detect(new ByteArrayInputStream(match),
+                                new Metadata()));
+                        assertEquals(MediaType.OCTET_STREAM,
+                                detector.detect(new ByteArrayInputStream(noMatch), new Metadata()));
+                    }
+                    return null;
+                }));
+            }
+            for (Future<?> future : futures) {
+                // an assertion failure on a worker surfaces here as an ExecutionException
+                future.get(60, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
Backport of #2968 (`65a2f3ab6`) from `main` to `branch_3x`.

JIRA: https://issues.apache.org/jira/browse/TIKA-4796

## What

`MagicDetector` recompiled its `Pattern` on every regex `detect()` call, even though both inputs to the compile — the pattern bytes and the case-insensitivity flag — are fixed at construction time. This compiles it once in the constructor and reuses it.

`Pattern` is immutable and a new `Matcher` is still created per call, so the regex path remains safe for the shared, long-lived detector instances that `MimeTypes` hands out.

## Not a cherry-pick

3.x compiles the `Pattern` inline in `detect()`; `main` had already extracted the matching logic into `matchesBuffer()` behind `matches(byte[])`. The change is therefore hand-ported to the 3.x structure rather than cherry-picked.

The same applies to the tests. The `main` PR added `testMatchesByteArrayRegEx` to cover the regex branch of `matches(byte[])`, which does not exist on 3.x — and 3.x already exercises the regex `detect()` path through `testDetectRegExPDF`, `testDetectRegExGreedy` and `testDetectRegExOptions`. Only the two guards that apply here are carried over, rewritten against `detect(InputStream, Metadata)`:

- `testRegExDetectorRepeatedCallsStable` — repeated calls on one instance stay independent
- `testRegExDetectorConcurrent` — 8 threads x 200 iterations against a shared detector

## Behavior change

A malformed regex now raises `PatternSyntaxException` from the constructor rather than from the first `detect()`. Via `MagicMatch` this is still lazy, since `getDetector()` builds on first `eval()`, so loading `tika-mimetypes.xml` is unaffected. Documented with `@throws` on the constructor.

## Testing

`./mvnw clean install -pl :tika-core` — 416 tests, 0 failures; `MagicDetectorTest` 13/13. Checkstyle and Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)