### PR TITLE
AGENTS.md: link the project's security model for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,13 @@ conventions, pre-commit checks.
 | `.skills/tika-eval-encoding-regression/SKILL.md` | Charset-detector regression hunts |
 | `.skills/tika-eval-h2-query/SKILL.md` | Querying the tika-eval H2 database directly |
 | `.skills/update-site-for-release/SKILL.md` | Updating tika.apache.org for a release |
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` before
+reporting issues. It links Tika's published
+[security model](https://tika.apache.org/security-model.html), which states
+what the project does and does not treat as a vulnerability — in particular
+its position on untrusted data, untrusted callers, and denial of service.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

This adds a `## Security` section to `AGENTS.md` so an automated scan agent can mechanically discover Tika's security model via the conventional `AGENTS.md → SECURITY.md → model` chain.

### Why

Tim asked ASF Tooling for a Claude security scan of Tika on 2026-08-18, and Dave Fisher confirmed Tika can go into the next batch. The scan agent locates a project's security model by following `AGENTS.md → SECURITY.md`.

Tika's `SECURITY.md` already does its half correctly — it links https://tika.apache.org/security-model.html and frames it exactly right ("review Tika's security model to understand what is and isn't considered a vulnerability"). But `AGENTS.md` currently points only at `.skills/`, so the chain breaks at the first hop and the agent never reaches the model.

This is the one mechanical gap. Everything else about the model is a separate conversation happening on the PMC's private list.

### What this does not change

Nothing about the model's content. The section links the file you already have; the wording of the published security model is untouched.

### Note on the model itself

For what it's worth, Tika's security model is a stronger starting point than most — it draws a real boundary between untrusted data and untrusted callers, and it has demonstrably done its job: several recent reports were correctly routed by that page, two of which the reporter withdrew after reading it.

Questions and pushback welcome — happy to adjust the wording or move the section if the project has a house style.
