### PR TITLE
TIKA-4833 - update plugin stages to avoid flaky hudson issues

### DIFF
--- a/docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc
+++ b/docs/modules/ROOT/pages/maintainers/release-guides/release-artifacts.adoc
@@ -146,13 +146,23 @@ API or embedding it programmatically.
 Mechanism: `maven-assembly-plugin` with `<attach>false</attach>` in each
 plugin pom (TIKA-4723). Because `<attach>false</attach>` also skips the
 local-repo install, each plugin pom additionally runs
-`maven-install-plugin:install-file` during the `install` phase, writing
+`maven-install-plugin:install-file` during the `package` phase, writing
 the zip into the local repo at canonical coordinates
 (`<groupId>:<artifactId>:zip:<version>`). Sibling modules
 (`tika-pipes-fork-parser`, `tika-server-*`, `tika-grpc`, integration
 tests) declare the zip as a test-scope Maven dep and rely on this
 mechanism to resolve it from the local repo without ever publishing it
 to Central.
+
+The `package` binding is deliberate and must not be moved to `install`.
+A reactor `mvn package` — what the `tika-main-jdk21` and `tika-main-jdk26`
+Jenkins jobs run, and what a contributor building the tree runs — never
+reaches the `install` phase, so an `install`-bound `install-file` leaves
+the zip unresolvable and every consuming module fails dependency
+resolution. It builds only where a previous `mvn install`/`deploy` on the
+same machine happened to leave a matching zip in the local repo, which
+made the breakage look intermittent until the `4.0.0` → `4.1.0-SNAPSHOT`
+bump invalidated every cached copy.
 
 === tika-grpc
 

--- a/tika-app/pom.xml
+++ b/tika-app/pom.xml
@@ -105,6 +105,14 @@
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-file-system</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tika-e2e-tests/tika-server/pom.xml
+++ b/tika-e2e-tests/tika-server/pom.xml
@@ -94,6 +94,16 @@
     <profiles>
         <profile>
             <id>e2e</id>
+            <!-- The zip dep is what forces reactor ordering; the zip is consumed by dependency-plugin below. -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>tika-server-standard</artifactId>
+                    <version>${revision}</version>
+                    <scope>test</scope>
+                    <type>zip</type>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/tika-grpc/pom.xml
+++ b/tika-grpc/pom.xml
@@ -230,6 +230,77 @@
       <scope>test</scope>
       <type>zip</type>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-az-blob</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-csv</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-gcs</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-jdbc</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-json</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-kafka</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-microsoft-graph</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-opensearch</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-s3</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-solr</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jsonSchema</artifactId>

--- a/tika-integration-tests/tika-pipes-es-integration-tests/pom.xml
+++ b/tika-integration-tests/tika-pipes-es-integration-tests/pom.xml
@@ -42,6 +42,14 @@
       <scope>test</scope>
       <type>zip</type>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tika-pipes-es</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>tika-pipes-es</artifactId>

--- a/tika-integration-tests/tika-pipes-opensearch-integration-tests/pom.xml
+++ b/tika-integration-tests/tika-pipes-opensearch-integration-tests/pom.xml
@@ -42,6 +42,14 @@
       <scope>test</scope>
       <type>zip</type>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tika-pipes-opensearch</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>tika-pipes-opensearch</artifactId>

--- a/tika-integration-tests/tika-pipes-solr-integration-tests/pom.xml
+++ b/tika-integration-tests/tika-pipes-solr-integration-tests/pom.xml
@@ -52,6 +52,14 @@
       <scope>test</scope>
       <type>zip</type>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tika-pipes-solr</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>tika-core</artifactId>

--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -1504,9 +1504,6 @@
         <version>3.3.1</version>
         <configuration>
           <autoVersionSubmodules>true</autoVersionSubmodules>
-          <!-- 'install' (not the default 'verify') so the install-only pf4j plugin zips
-               (attach=false, installed via install:install-file; see tika-pipes plugins)
-               are available in the local repo for sibling modules that depend on them. -->
           <preparationGoals>clean install</preparationGoals>
         </configuration>
         <dependencies>

--- a/tika-pipes/tika-pipes-integration-tests/pom.xml
+++ b/tika-pipes/tika-pipes-integration-tests/pom.xml
@@ -94,6 +94,14 @@
       <type>pom</type>
       <scope>test</scope>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-file-system</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-atlassian-jwt/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-atlassian-jwt/pom.xml
@@ -131,15 +131,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-az-blob/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-az-blob/pom.xml
@@ -117,15 +117,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-csv/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-csv/pom.xml
@@ -109,15 +109,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-es/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-es/pom.xml
@@ -128,15 +128,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-file-system/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-file-system/pom.xml
@@ -121,15 +121,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-gcs/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-gcs/pom.xml
@@ -113,15 +113,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-google-drive/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-google-drive/pom.xml
@@ -181,15 +181,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-http/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-http/pom.xml
@@ -197,15 +197,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-jdbc/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-jdbc/pom.xml
@@ -113,15 +113,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-json/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-json/pom.xml
@@ -111,15 +111,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-kafka/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-kafka/pom.xml
@@ -120,15 +120,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-microsoft-graph/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-microsoft-graph/pom.xml
@@ -210,15 +210,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-opensearch/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-opensearch/pom.xml
@@ -124,15 +124,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-s3/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-s3/pom.xml
@@ -124,15 +124,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-pipes/tika-pipes-plugins/tika-pipes-solr/pom.xml
+++ b/tika-pipes/tika-pipes-plugins/tika-pipes-solr/pom.xml
@@ -143,15 +143,15 @@
         <artifactId>maven-install-plugin</artifactId>
         <executions>
           <!--
-            The assembly attaches the zip with <attach>false</attach> (TIKA-4723)
-            so it is not added to the Maven artifact set and therefore is not
-            deployed to Maven Central. Sibling modules declare this plugin zip
-            as a test-scope Maven dep, so we install-file it locally to satisfy
-            reactor resolution without making it part of the project artifacts.
+            The assembly builds the zip with <attach>false</attach> (TIKA-4723) so it
+            stays out of the Maven artifact set and off Maven Central. Sibling modules
+            declare it as a test-scope zip dep, so install-file puts it in the local
+            repo instead. Bound to package, not install: CI and contributors run
+            `mvn package`, which has to resolve it too.
           -->
           <execution>
             <id>install-plugin-zip-locally</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>install-file</goal>
             </goals>

--- a/tika-server/tika-server-core/pom.xml
+++ b/tika-server/tika-server-core/pom.xml
@@ -124,6 +124,14 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-file-system</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tika-server/tika-server-standard/pom.xml
+++ b/tika-server/tika-server-standard/pom.xml
@@ -107,6 +107,14 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- The zip deps are what force reactor ordering; the zips are consumed by dependency-plugin below. -->
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-pipes-file-system</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>zip</type>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
To be clear, this isn't a hudson issue. It was showing up on hudson because we're not `install`ing there.