### PR TITLE
TIKA-4851: RawTiffParser marks only the largest preview as THUMBNAIL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 Release 4.1.0 - unreleased
 
-   * RawTiffParser emits the largest embedded JPEG preview first, as the
-     THUMBNAIL embedded document; the smaller previews of the same image
-     follow as INLINE images named image-N.jpg. Previously every preview was
-     a THUMBNAIL in IFD order, so the camera's small thumbnail often came
-     first (TIKA-4851).
+   * RawTiffParser marks only the largest embedded JPEG preview as the
+     THUMBNAIL embedded document; the smaller previews of the same image are
+     INLINE images named image-N.jpg. Previously every preview was a
+     THUMBNAIL, so a client had to compare them to find the representative
+     one (TIKA-4851).
 
    * New exception-reporting parse-context config controls how much of an
      exception is written to tk:exception:* metadata for the container and

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,11 @@
 Release 4.1.0 - unreleased
 
+   * RawTiffParser emits the largest embedded JPEG preview first, as the
+     THUMBNAIL embedded document; the smaller previews of the same image
+     follow as INLINE images named image-N.jpg. Previously every preview was
+     a THUMBNAIL in IFD order, so the camera's small thumbnail often came
+     first (TIKA-4851).
+
    * New exception-reporting parse-context config controls how much of an
      exception is written to tk:exception:* metadata for the container and
      embedded documents alike: FULL (default), MESSAGE_REDACTED (stack trace

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/main/java/org/apache/tika/parser/image/RawTiffParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/main/java/org/apache/tika/parser/image/RawTiffParser.java
@@ -70,7 +70,8 @@ import org.apache.tika.sax.XHTMLContentHandler;
  * version 1.7) are supported for preview extraction; for BigTIFF, EXIF
  * metadata extraction is skipped until metadata-extractor supports it.
  * <p>
- * The largest preview is marked
+ * Of the previews that are extracted (see the length limits in
+ * {@link RawTiffParserConfig}), the largest by JPEG byte length is marked
  * {@link TikaCoreProperties.EmbeddedResourceType#THUMBNAIL}, any smaller
  * ones are {@link TikaCoreProperties.EmbeddedResourceType#INLINE} images
  * (TIKA-4851).
@@ -178,10 +179,10 @@ public class RawTiffParser extends TiffParser {
         if (previews.isEmpty()) {
             return;
         }
-        //the largest preview is the file's thumbnail and goes first; the
-        //smaller ones (the camera's own thumbnail, intermediate previews)
-        //are renderings of the same image and follow as inline images.
-        //The JPEG length is a reliable proxy for its dimensions here.
+        //of the extracted previews, the largest by JPEG length is the file's
+        //thumbnail; the smaller ones (the camera's own thumbnail, intermediate
+        //previews) are renderings of the same image and are inline images.
+        //The JPEG length is a reliable proxy for the dimensions here.
         previews.sort(Comparator.comparingLong(Preview::length).reversed());
         EmbeddedDocumentExtractor extractor =
                 EmbeddedDocumentUtil.getEmbeddedDocumentExtractor(context);

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/main/java/org/apache/tika/parser/image/RawTiffParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/main/java/org/apache/tika/parser/image/RawTiffParser.java
@@ -70,10 +70,10 @@ import org.apache.tika.sax.XHTMLContentHandler;
  * version 1.7) are supported for preview extraction; for BigTIFF, EXIF
  * metadata extraction is skipped until metadata-extractor supports it.
  * <p>
- * The largest preview is emitted first, marked
- * {@link TikaCoreProperties.EmbeddedResourceType#THUMBNAIL}; any smaller
- * ones follow as {@link TikaCoreProperties.EmbeddedResourceType#INLINE}
- * images (TIKA-4851).
+ * The largest preview is marked
+ * {@link TikaCoreProperties.EmbeddedResourceType#THUMBNAIL}, any smaller
+ * ones are {@link TikaCoreProperties.EmbeddedResourceType#INLINE} images
+ * (TIKA-4851).
  */
 @TikaComponent
 public class RawTiffParser extends TiffParser {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/main/java/org/apache/tika/parser/image/RawTiffParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/main/java/org/apache/tika/parser/image/RawTiffParser.java
@@ -25,6 +25,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
@@ -68,6 +69,11 @@ import org.apache.tika.sax.XHTMLContentHandler;
  * Both classic TIFF and BigTIFF containers (allowed for DNG since spec
  * version 1.7) are supported for preview extraction; for BigTIFF, EXIF
  * metadata extraction is skipped until metadata-extractor supports it.
+ * <p>
+ * The largest preview is emitted first, marked
+ * {@link TikaCoreProperties.EmbeddedResourceType#THUMBNAIL}; any smaller
+ * ones follow as {@link TikaCoreProperties.EmbeddedResourceType#INLINE}
+ * images (TIKA-4851).
  */
 @TikaComponent
 public class RawTiffParser extends TiffParser {
@@ -172,6 +178,11 @@ public class RawTiffParser extends TiffParser {
         if (previews.isEmpty()) {
             return;
         }
+        //the largest preview is the file's thumbnail and goes first; the
+        //smaller ones (the camera's own thumbnail, intermediate previews)
+        //are renderings of the same image and follow as inline images.
+        //The JPEG length is a reliable proxy for its dimensions here.
+        previews.sort(Comparator.comparingLong(Preview::length).reversed());
         EmbeddedDocumentExtractor extractor =
                 EmbeddedDocumentUtil.getEmbeddedDocumentExtractor(context);
         int count = 0;
@@ -179,11 +190,19 @@ public class RawTiffParser extends TiffParser {
         try (FileChannel channel = FileChannel.open(tis.getPath())) {
             for (Preview preview : previews) {
                 Metadata previewMetadata = Metadata.newInstance(context);
-                previewMetadata.set(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE,
-                        TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString());
                 previewMetadata.set(HttpHeaders.CONTENT_TYPE, JPEG_MIME);
-                EmbeddedDocumentUtil.setGeneratedResourceName(previewMetadata,
-                        EmbeddedDocumentUtil.EmbeddedResourcePrefix.THUMBNAIL, count, JPEG_MIME);
+                if (count == 0) {
+                    previewMetadata.set(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE,
+                            TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString());
+                    EmbeddedDocumentUtil.setGeneratedResourceName(previewMetadata,
+                            EmbeddedDocumentUtil.EmbeddedResourcePrefix.THUMBNAIL, 0, JPEG_MIME);
+                } else {
+                    previewMetadata.set(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE,
+                            TikaCoreProperties.EmbeddedResourceType.INLINE.toString());
+                    EmbeddedDocumentUtil.setGeneratedResourceName(previewMetadata,
+                            EmbeddedDocumentUtil.EmbeddedResourcePrefix.IMAGE, count - 1,
+                            JPEG_MIME);
+                }
                 count++;
                 if (!extractor.shouldParseEmbedded(previewMetadata, context)) {
                     continue;

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/test/java/org/apache/tika/parser/image/RawTiffParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/test/java/org/apache/tika/parser/image/RawTiffParserTest.java
@@ -43,12 +43,27 @@ public class RawTiffParserTest extends TikaTest {
         return getRecursiveMetadata(fileName, metadata);
     }
 
-    private void assertPreview(Metadata preview, int index, int width, int height) {
+    /**
+     * The largest preview: the file's thumbnail, always emitted first.
+     */
+    private void assertThumbnail(Metadata preview, int width, int height) {
+        assertPreview(preview, TikaCoreProperties.EmbeddedResourceType.THUMBNAIL,
+                "thumbnail-0.jpg", width, height);
+    }
+
+    /**
+     * A smaller preview, emitted after the thumbnail as an inline image.
+     */
+    private void assertInlinePreview(Metadata preview, int index, int width, int height) {
+        assertPreview(preview, TikaCoreProperties.EmbeddedResourceType.INLINE,
+                "image-" + index + ".jpg", width, height);
+    }
+
+    private void assertPreview(Metadata preview, TikaCoreProperties.EmbeddedResourceType type,
+                               String name, int width, int height) {
         assertEquals("image/jpeg", preview.get(HttpHeaders.CONTENT_TYPE));
-        assertEquals("thumbnail-" + index + ".jpg",
-                preview.get(TikaCoreProperties.RESOURCE_NAME_KEY));
-        assertEquals(TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString(),
-                preview.get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE));
+        assertEquals(name, preview.get(TikaCoreProperties.RESOURCE_NAME_KEY));
+        assertEquals(type.toString(), preview.get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE));
         assertEquals(Integer.toString(width), preview.get(TIFF.IMAGE_WIDTH));
         assertEquals(Integer.toString(height), preview.get(TIFF.IMAGE_LENGTH));
     }
@@ -63,7 +78,7 @@ public class RawTiffParserTest extends TikaTest {
         assertEquals("NIKON CORPORATION", container.get(TIFF.EQUIPMENT_MAKE));
         assertEquals("NIKON D3000", container.get(TIFF.EQUIPMENT_MODEL));
 
-        assertPreview(metadataList.get(1), 0, 64, 48);
+        assertThumbnail(metadataList.get(1), 64, 48);
     }
 
     @Test
@@ -72,7 +87,7 @@ public class RawTiffParserTest extends TikaTest {
         //it is extracted once, not per referencing IFD
         List<Metadata> metadataList = parseByName("testNEF_dup.nef");
         assertEquals(2, metadataList.size());
-        assertPreview(metadataList.get(1), 0, 64, 48);
+        assertThumbnail(metadataList.get(1), 64, 48);
     }
 
     @Test
@@ -85,9 +100,9 @@ public class RawTiffParserTest extends TikaTest {
         assertEquals("SONY", container.get(TIFF.EQUIPMENT_MAKE));
         assertEquals("NEX-6", container.get(TIFF.EQUIPMENT_MODEL));
 
-        //full-size preview from IFD0, then the thumbnail from IFD1
-        assertPreview(metadataList.get(1), 0, 64, 48);
-        assertPreview(metadataList.get(2), 1, 32, 24);
+        //full-size preview from IFD0, then the camera thumbnail from IFD1
+        assertThumbnail(metadataList.get(1), 64, 48);
+        assertInlinePreview(metadataList.get(2), 0, 32, 24);
     }
 
     @Test
@@ -99,9 +114,10 @@ public class RawTiffParserTest extends TikaTest {
         assertEquals("image/x-raw-pentax", container.get(HttpHeaders.CONTENT_TYPE));
         assertEquals("PENTAX K-7", container.get(TIFF.EQUIPMENT_MODEL));
 
-        //thumbnail from IFD1, then the full-size preview from IFD2
-        assertPreview(metadataList.get(1), 0, 32, 24);
-        assertPreview(metadataList.get(2), 1, 64, 48);
+        //the camera thumbnail comes first in the file (IFD1), the full-size
+        //preview second (IFD2): the larger one is still emitted first
+        assertThumbnail(metadataList.get(1), 64, 48);
+        assertInlinePreview(metadataList.get(2), 0, 32, 24);
     }
 
     @Test
@@ -115,7 +131,7 @@ public class RawTiffParserTest extends TikaTest {
         assertEquals("image/x-raw-adobe", container.get(HttpHeaders.CONTENT_TYPE));
         assertEquals("PENTAX K-x", container.get(TIFF.EQUIPMENT_MODEL));
 
-        assertPreview(metadataList.get(1), 0, 64, 48);
+        assertThumbnail(metadataList.get(1), 64, 48);
     }
 
     @Test
@@ -129,8 +145,8 @@ public class RawTiffParserTest extends TikaTest {
         assertEquals("Canon EOS 7D", container.get(TIFF.EQUIPMENT_MODEL));
 
         //full-size preview stored as a strip in IFD0, thumbnail from IFD1
-        assertPreview(metadataList.get(1), 0, 64, 48);
-        assertPreview(metadataList.get(2), 1, 32, 24);
+        assertThumbnail(metadataList.get(1), 64, 48);
+        assertInlinePreview(metadataList.get(2), 0, 32, 24);
     }
 
     @Test
@@ -151,7 +167,7 @@ public class RawTiffParserTest extends TikaTest {
         assertEquals("image/x-raw-adobe", container.get(HttpHeaders.CONTENT_TYPE));
         assertNull(container.get(TikaCoreProperties.TIKA_META_EXCEPTION_WARNING));
 
-        assertPreview(metadataList.get(1), 0, 64, 48);
+        assertThumbnail(metadataList.get(1), 64, 48);
     }
 
     @Test
@@ -203,7 +219,7 @@ public class RawTiffParserTest extends TikaTest {
                 getRecursiveMetadata("testARW.arw", parser, metadata, new ParseContext(), false);
 
         assertEquals(2, metadataList.size());
-        assertPreview(metadataList.get(1), 0, 64, 48);
+        assertThumbnail(metadataList.get(1), 64, 48);
     }
 
     @Test

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/test/java/org/apache/tika/parser/image/RawTiffParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-image-module/src/test/java/org/apache/tika/parser/image/RawTiffParserTest.java
@@ -44,7 +44,8 @@ public class RawTiffParserTest extends TikaTest {
     }
 
     /**
-     * The largest preview: the file's thumbnail, always emitted first.
+     * The largest extracted preview: the file's thumbnail, which the parser
+     * emits before the smaller ones.
      */
     private void assertThumbnail(Metadata preview, int width, int height) {
         assertPreview(preview, TikaCoreProperties.EmbeddedResourceType.THUMBNAIL,


### PR DESCRIPTION
Every JPEG preview used to be a THUMBNAIL, so for formats that store the camera's small thumbnail ahead of the full-size preview (PEF) the first THUMBNAIL was the smallest one, and a client had to compare the previews to find the representative one. Now only the largest preview (by JPEG length, a reliable proxy for its dimensions) is the `thumbnail-0.jpg` THUMBNAIL and the smaller ones are INLINE `image-N.jpg`. The PEF fixture covers the case where the small one comes first in the file.

https://issues.apache.org/jira/browse/TIKA-4851
