### PR TITLE
TIKA-4853: DWGReadParser emits the drawing thumbnail as THUMBNAIL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 Release 4.1.0 - unreleased
 
+   * DWGReadParser emits the drawing's THUMBNAILIMAGE as a THUMBNAIL embedded
+     document instead of INLINE (TIKA-4853).
+
    * RawTiffParser marks only the largest embedded JPEG preview as the
      THUMBNAIL embedded document; the smaller previews of the same image are
      INLINE images named image-N.jpg. Previously every preview was a

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/src/main/java/org/apache/tika/parser/dwg/DWGReadParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/src/main/java/org/apache/tika/parser/dwg/DWGReadParser.java
@@ -416,7 +416,7 @@ public class DWGReadParser extends AbstractDWGParser {
                 EmbeddedDocumentUtil.getEmbeddedDocumentExtractor(context);
         Metadata embeddedMetadata = new Metadata();
         embeddedMetadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "thumbnail");
-        //the drawing's preview image, not a picture placed in the drawing
+        // The drawing's preview image, not a picture placed in the drawing
         embeddedMetadata.set(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE,
                 TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString());
         if (!embeddedDocumentExtractor.shouldParseEmbedded(embeddedMetadata, context)) {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/src/main/java/org/apache/tika/parser/dwg/DWGReadParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/src/main/java/org/apache/tika/parser/dwg/DWGReadParser.java
@@ -416,8 +416,9 @@ public class DWGReadParser extends AbstractDWGParser {
                 EmbeddedDocumentUtil.getEmbeddedDocumentExtractor(context);
         Metadata embeddedMetadata = new Metadata();
         embeddedMetadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "thumbnail");
+        //the drawing's preview image, not a picture placed in the drawing
         embeddedMetadata.set(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE,
-                TikaCoreProperties.EmbeddedResourceType.INLINE.toString());
+                TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString());
         if (!embeddedDocumentExtractor.shouldParseEmbedded(embeddedMetadata, context)) {
             return;
         }

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/src/test/java/org/apache/tika/parser/dwg/DWGParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-cad-module/src/test/java/org/apache/tika/parser/dwg/DWGParserTest.java
@@ -276,16 +276,17 @@ public class DWGParserTest extends TikaTest {
         assertNotNull(root.get(DWG.APPLICATION_COMMENT));
         assertContains("AutoCAD", root.get(DWG.PRODUCT_INFO));
 
-        // Thumbnail embedded as INLINE
+        // the THUMBNAILIMAGE section is the drawing's THUMBNAIL embedded document
         Metadata thumb = null;
         for (int i = 1; i < metadataList.size(); i++) {
             String type = metadataList.get(i).get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE);
-            if (TikaCoreProperties.EmbeddedResourceType.INLINE.name().equals(type)) {
+            if (TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.name().equals(type)) {
                 thumb = metadataList.get(i);
                 break;
             }
         }
-        assertNotNull(thumb, "Expected an INLINE thumbnail attachment");
+        assertNotNull(thumb, "Expected a THUMBNAIL embedded document");
+        assertEquals("thumbnail", thumb.get(TikaCoreProperties.RESOURCE_NAME_KEY));
     }
 
     @Test


### PR DESCRIPTION
The THUMBNAILIMAGE section is the drawing's preview image, not a picture placed in the drawing, so mark it THUMBNAIL like the preview image of the other container formats. One-line change plus the test assertion.

https://issues.apache.org/jira/browse/TIKA-4853
