### PR TITLE
TIKA-4852: EpubParser emits the OPF cover image as a THUMBNAIL embedded document

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 Release 4.1.0 - unreleased
 
+   * EpubParser emits the cover image named by the OPF (the EPUB 3
+     cover-image manifest property, or the EPUB 2 cover meta) as a THUMBNAIL
+     embedded document (TIKA-4852).
+
    * RawTiffParser marks only the largest embedded JPEG preview as the
      THUMBNAIL embedded document; the smaller previews of the same image are
      INLINE images named image-N.jpg. Previously every preview was a

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/main/java/org/apache/tika/parser/epub/EpubParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/main/java/org/apache/tika/parser/epub/EpubParser.java
@@ -468,7 +468,8 @@ public class EpubParser implements Parser {
         xhtml.startElement("div", "class", "embedded");
         try {
             boolean outputHtml = true;
-            if (hRefMediaPair.media.contains("font") || hRefMediaPair.href.startsWith("fonts")) {
+            if ((hRefMediaPair.media != null && hRefMediaPair.media.contains("font"))
+                    || hRefMediaPair.href.startsWith("fonts")) {
                 outputHtml = false;
             }
             embeddedDocumentExtractor

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/main/java/org/apache/tika/parser/epub/EpubParser.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/main/java/org/apache/tika/parser/epub/EpubParser.java
@@ -282,8 +282,9 @@ public class EpubParser implements Parser {
                     continue;
                 }
                 if (shouldHandleEmbedded(hRefMediaPair.media)) {
-                    handleEmbedded(zipFile, relativePath, hRefMediaPair, embeddedDocumentExtractor,
-                            xhtml, metadata, context);
+                    handleEmbedded(zipFile, relativePath, hRefMediaPair,
+                            id.equals(contentOrderScraper.getCoverId()),
+                            embeddedDocumentExtractor, xhtml, metadata, context);
                 }
             }
         }
@@ -423,7 +424,12 @@ public class EpubParser implements Parser {
         return true;
     }
 
+    /**
+     * @param cover whether this is the publication's cover image, emitted as
+     *              the {@link TikaCoreProperties.EmbeddedResourceType#THUMBNAIL}
+     */
     private void handleEmbedded(ZipFile zipFile, String relativePath, HRefMediaPair hRefMediaPair,
+                                boolean cover,
                                 EmbeddedDocumentExtractor embeddedDocumentExtractor,
                                 XHTMLContentHandler xhtml, Metadata parentMetadata,
                                 ParseContext context)
@@ -442,6 +448,10 @@ public class EpubParser implements Parser {
             embeddedMetadata.set(HttpHeaders.CONTENT_TYPE, hRefMediaPair.media);
         }
         embeddedMetadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, fullPath);
+        if (cover) {
+            embeddedMetadata.set(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE,
+                    TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString());
+        }
         if (!embeddedDocumentExtractor.shouldParseEmbedded(embeddedMetadata, context)) {
             return;
         }
@@ -524,8 +534,19 @@ public class EpubParser implements Parser {
 
         Map<String, HRefMediaPair> locationMap = new HashMap<>();
         List<String> contentItems = new ArrayList<>();
+        //the cover image: EPUB 3 marks its manifest item with the
+        //cover-image property, EPUB 2 names the item id in a cover meta
+        String coverImageItem;
+        String coverMetaItem;
         boolean inManifest = false;
         boolean inSpine = false;
+
+        /**
+         * The manifest id of the cover image, or null if the OPF names none.
+         */
+        String getCoverId() {
+            return coverImageItem != null ? coverImageItem : coverMetaItem;
+        }
 
         @Override
         public void startElement(String uri, String localName, String name, Attributes atts)
@@ -547,7 +568,19 @@ public class EpubParser implements Parser {
                             //swallow
                         }
                         locationMap.put(id, new HRefMediaPair(href, mime));
+                        String properties = XMLReaderUtils.getAttrValue("properties", atts);
+                        if (coverImageItem == null && properties != null
+                                && Arrays.asList(properties.trim().split("\\s+"))
+                                .contains("cover-image")) {
+                            coverImageItem = id;
+                        }
                     }
+                }
+            } else if ("meta".equalsIgnoreCase(localName) && coverMetaItem == null
+                    && "cover".equals(XMLReaderUtils.getAttrValue("name", atts))) {
+                String content = XMLReaderUtils.getAttrValue("content", atts);
+                if (!StringUtils.isBlank(content)) {
+                    coverMetaItem = content.trim();
                 }
             }
             if (inSpine) {

--- a/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/test/java/org/apache/tika/parser/epub/EpubParserTest.java
+++ b/tika-parsers/tika-parsers-standard/tika-parsers-standard-modules/tika-parser-miscoffice-module/src/test/java/org/apache/tika/parser/epub/EpubParserTest.java
@@ -17,6 +17,8 @@
 package org.apache.tika.parser.epub;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -74,6 +76,11 @@ public class EpubParserTest extends TikaTest {
         //test attachments
         assertEquals(2, metadataList.size());
         assertEquals("image/jpeg", metadataList.get(1).get(HttpHeaders.CONTENT_TYPE));
+        //the EPUB 2 cover meta names the cover image, emitted as the thumbnail
+        assertEquals("OPS/CoverDesign.jpg",
+                metadataList.get(1).get(TikaCoreProperties.RESOURCE_NAME_KEY));
+        assertEquals(TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString(),
+                metadataList.get(1).get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE));
         String xml = metadataList.get(0).get(TikaCoreProperties.TIKA_CONTENT);
         int tocIndex = xml.indexOf("h3 class=\"toc_heading\">Table of Contents<");
         int ch1 = xml.indexOf("<h1>Chapter 1");
@@ -122,6 +129,27 @@ public class EpubParserTest extends TikaTest {
 
         List<Metadata> metadataList = getRecursiveMetadata("cole-voyage-of-life.epub");
         assertEquals("pre-paginated", metadataList.get(0).get(Epub.RENDITION_LAYOUT));
+    }
+
+    /**
+     * The EPUB 3 cover-image manifest property names the cover; the other
+     * images are not thumbnails.
+     */
+    @Test
+    public void testEpub3CoverImageIsTheThumbnail() throws Exception {
+        List<Metadata> metadataList = getRecursiveMetadata("testEPUB_multi-metadata-vals.epub");
+        Metadata cover = null;
+        for (Metadata m : metadataList) {
+            if ("epub/images/cover.jpg".equals(m.get(TikaCoreProperties.RESOURCE_NAME_KEY))) {
+                cover = m;
+            } else {
+                assertNotEquals(TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString(),
+                        m.get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE));
+            }
+        }
+        assertNotNull(cover);
+        assertEquals(TikaCoreProperties.EmbeddedResourceType.THUMBNAIL.toString(),
+                cover.get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE));
     }
 
     @Test


### PR DESCRIPTION
EpubParser emitted every image as an untyped embedded document, so a client had no way to tell the cover from the other images. The OPF names it: EPUB 3 with the `cover-image` property on the manifest item, EPUB 2 with `<meta name="cover" content="<item id>"/>`. The parser now resolves the cover (property first, meta as fallback) and emits that image as the THUMBNAIL embedded document, like the preview image of the other container formats. Both fixtures cover one of the two ways.

https://issues.apache.org/jira/browse/TIKA-4852
