### PR TITLE
TIKA-4865 -- tika-grpc: resolve the plugin-roots fallback via Default…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,10 @@
 Release 4.1.0 - unreleased
 
+   * tika-grpc resolves its plugin-roots fallback against the install
+     layout via DefaultPluginsDir instead of a working-directory-relative
+     pf4j default, and a WARN names the resolved directory when no plugins
+     directory exists (TIKA-4865).
+
    * The default plugins directory is resolved against the install layout
      (next to the jar, or next to its lib/ directory) and always as an
      absolute path, shared by tika-server, PipesForkParser and the async

--- a/tika-grpc/src/main/java/org/apache/tika/pipes/grpc/TikaGrpcServerImpl.java
+++ b/tika-grpc/src/main/java/org/apache/tika/pipes/grpc/TikaGrpcServerImpl.java
@@ -54,6 +54,7 @@ import org.apache.tika.pipes.core.PipesException;
 import org.apache.tika.pipes.core.PipesParser;
 import org.apache.tika.pipes.core.config.ConfigStore;
 import org.apache.tika.pipes.core.config.ConfigStoreFactory;
+import org.apache.tika.pipes.core.config.DefaultPluginsDir;
 import org.apache.tika.pipes.core.fetcher.FetcherManager;
 import org.apache.tika.pipes.grpc.proto.DeleteFetcherReply;
 import org.apache.tika.pipes.grpc.proto.DeleteFetcherRequest;
@@ -135,8 +136,20 @@ class TikaGrpcServerImpl extends TikaGrpc.TikaImplBase {
             pluginManager.loadPlugins();
             pluginManager.startPlugins();
         } catch (TikaConfigException e) {
-            LOG.warn("Could not load plugin manager, using default: {}", e.getMessage());
-            pluginManager = new org.pf4j.DefaultPluginManager();
+            // plugin-roots not configured: probe the install layout like the
+            // other pipes entry points (TIKA-4864/TIKA-4865)
+            String defaultRoot = DefaultPluginsDir.resolve(TikaGrpcServerImpl.class);
+            LOG.warn("plugin-roots not configured ({}); falling back to {}",
+                    e.getMessage(), defaultRoot);
+            try {
+                pluginManager = TikaPluginManager.loadFromPaths(defaultRoot);
+                pluginManager.loadPlugins();
+                pluginManager.startPlugins();
+            } catch (TikaConfigException | IOException e2) {
+                LOG.warn("could not load plugins from {}, starting with none: {}",
+                        defaultRoot, e2.getMessage());
+                pluginManager = new org.pf4j.DefaultPluginManager();
+            }
         }
 
         if (pluginManager.getPlugins().isEmpty()) {

--- a/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/config/DefaultPluginsDir.java
+++ b/tika-pipes/tika-pipes-core/src/main/java/org/apache/tika/pipes/core/config/DefaultPluginsDir.java
@@ -19,6 +19,9 @@ package org.apache.tika.pipes.core.config;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Resolves the default {@code plugins} directory when {@code plugin-roots}
  * is not configured (TIKA-4864). The probe order matches the install
@@ -36,6 +39,8 @@ import java.nio.file.Path;
  * parent's, so a relative default would make the two processes disagree.
  */
 public final class DefaultPluginsDir {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultPluginsDir.class);
 
     /**
      * The directory name probed in each location.
@@ -88,6 +93,11 @@ public final class DefaultPluginsDir {
                 }
             }
         }
-        return cwd.resolve(PLUGINS_DIR_NAME).toAbsolutePath();
+        Path fallback = cwd.resolve(PLUGINS_DIR_NAME).toAbsolutePath();
+        if (!Files.isDirectory(fallback)) {
+            LOG.warn("no plugins directory found in the install layout or at {}; "
+                    + "pipes plugins will not load unless plugin-roots is configured", fallback);
+        }
+        return fallback;
     }
 }


### PR DESCRIPTION
…PluginsDir and WARN when no plugins directory exists

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Tika](https://tika.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Tika issue tracker](https://issues.apache.org/jira/projects/TIKA) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`TIKA-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[TIKA-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Tika builds and unit tests pass with `./mvnw clean install` (`clean test` alone cannot resolve the pipes plugin zips)
* if you used a generative AI tool: follow the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) (`Generated-by: <tool>` in the commit message), and consider running the pre-flight in `.skills/devs/pr-review/SKILL.md` — fix what it finds; don't paste its report here
* there should be no conflicts when merging the pull request branch into the *recent* `main` branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled `main` branch
* if you add new module that downstream users will depend upon add it to relevant group in `tika-bom/pom.xml`.

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Tika in general, please sign up for the [Tika mailing list](http://tika.apache.org/mail-lists.html). Thanks!
