### PR TITLE
TIKA-4864 - fix windows

### DIFF
--- a/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
+++ b/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
@@ -203,6 +203,8 @@ public class AsyncCliParserTest {
         // not the string, so the separator does not break the test on Windows
         assertEquals("plugins", Path.of(pluginRoots).getFileName().toString(),
                 "plugin-roots should name a 'plugins' directory, got: " + pluginRoots);
+        assertTrue(Path.of(pluginRoots).isAbsolute(),
+                "the default plugin-roots must be absolute (TIKA-4864), got: " + pluginRoots);
 
         // Original config values should be preserved
         assertTrue(root.has("pipes"));

--- a/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
+++ b/tika-pipes/tika-async-cli/src/test/java/org/apache/tika/async/cli/AsyncCliParserTest.java
@@ -199,8 +199,10 @@ public class AsyncCliParserTest {
         JsonNode root = mapper.readTree(result.toFile());
         assertTrue(root.has("plugin-roots"), "Merged config should have plugin-roots");
         String pluginRoots = root.get("plugin-roots").asText();
-        assertTrue(pluginRoots.equals("plugins") || pluginRoots.endsWith("/plugins"),
-                "plugin-roots should be 'plugins' or end with '/plugins', got: " + pluginRoots);
+        // the default is an absolute path since TIKA-4864; compare the file name,
+        // not the string, so the separator does not break the test on Windows
+        assertEquals("plugins", Path.of(pluginRoots).getFileName().toString(),
+                "plugin-roots should name a 'plugins' directory, got: " + pluginRoots);
 
         // Original config values should be preserved
         assertTrue(root.has("pipes"));


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Tika](https://tika.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Tika issue tracker](https://issues.apache.org/jira/projects/TIKA) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`TIKA-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[TIKA-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Tika builds and unit tests pass with `./mvnw clean install` (`clean test` alone cannot resolve the pipes plugin zips)
* if you used a generative AI tool: follow the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) (`Generated-by: <tool>` in the commit message), and consider running the pre-flight in `.skills/devs/pr-review/SKILL.md` — fix what it finds; don't paste its report here
* there should be no conflicts when merging the pull request branch into the *recent* `main` branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled `main` branch
* if you add new module that downstream users will depend upon add it to relevant group in `tika-bom/pom.xml`.

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Tika in general, please sign up for the [Tika mailing list](http://tika.apache.org/mail-lists.html). Thanks!
