### PR TITLE
TIKA-4867 -- parallelize CI reactors with -T1C, run apache-rat serially

### DIFF
--- a/.github/workflows/main-jdk17-build.yml
+++ b/.github/workflows/main-jdk17-build.yml
@@ -75,11 +75,16 @@ jobs:
           mvn apache-rat:check -Pci \
             -pl "$(echo "$IT_MODULES" | sed 's/:/!:/g')" \
             -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+      # Pre-install tika-annotation-processor before any -T1C invocation:
+      # annotationProcessorPaths resolves from the LOCAL REPO, not the reactor,
+      # so parallel Maven schedules consumers before the processor's install
+      # and the build races to "Could not find artifact tika-annotation-processor".
       # javadoc:aggregate is push-only: it is an aggregate-docs artifact, is
       # single-threaded, and javadoc breakage is caught on main within the hour;
       # PR pushes should not wait on it.
       - name: Build with Maven
         run: |
+          mvn install -Pfast -pl :tika-annotation-processor -am -B -q
           mvn clean test install ${{ github.event_name == 'push' && 'javadoc:aggregate' || '' }} -Pci -T1C \
             -pl "$(echo "$IT_MODULES" | sed 's/:/!:/g')" \
             -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
@@ -108,7 +113,7 @@ jobs:
       # jar-packaging reactor module, so -am cannot supply them. -Pfast keeps it
       # to ~3 min; the tests themselves run in the next step.
       - name: Install all modules (produces the plugin zips)
-        run: mvn clean install -Pfast -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn install -Pfast -pl :tika-annotation-processor -am -B -q && mvn clean install -Pfast -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
       # apache-rat:check here too -- the build job no longer sees these modules,
       # so without this they would drop out of license checking entirely.
       - name: Run integration tests
@@ -143,7 +148,7 @@ jobs:
       # what puts each zip in the local repo. -Pfast (skipTests + rat/checkstyle/spotless
       # off) because the build job owns all of that; this job only needs the artifacts.
       - name: Install all modules (produces the plugin zips)
-        run: mvn clean install -Pfast -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn install -Pfast -pl :tika-annotation-processor -am -B -q && mvn clean install -Pfast -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
       # -pl must name the leaf modules: tika-e2e-tests is an aggregator pom, and Maven does
       # not pull in a selected aggregator's children, so this job built two pom-only modules
       # and ran zero tests while reporting green.

--- a/.github/workflows/main-jdk17-build.yml
+++ b/.github/workflows/main-jdk17-build.yml
@@ -67,9 +67,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ffmpeg libimage-exiftool-perl
       # Everything except $IT_MODULES, which the integration-tests job owns.
       # sed turns each ':artifactId' into the '!:artifactId' exclusion form.
+      # rat runs in its own SERIAL invocation: apache-rat-plugin 0.18 is not
+      # thread-safe (ConcurrentModificationException / corrupted counters under
+      # -T), so it must never share a -T1C command line.
+      - name: License check (apache-rat, serial)
+        run: |
+          mvn apache-rat:check -Pci \
+            -pl "$(echo "$IT_MODULES" | sed 's/:/!:/g')" \
+            -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+      # javadoc:aggregate is push-only: it is an aggregate-docs artifact, is
+      # single-threaded, and javadoc breakage is caught on main within the hour;
+      # PR pushes should not wait on it.
       - name: Build with Maven
         run: |
-          mvn clean apache-rat:check test install javadoc:aggregate -Pci \
+          mvn clean test install ${{ github.event_name == 'push' && 'javadoc:aggregate' || '' }} -Pci -T1C \
             -pl "$(echo "$IT_MODULES" | sed 's/:/!:/g')" \
             -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
@@ -97,7 +108,7 @@ jobs:
       # jar-packaging reactor module, so -am cannot supply them. -Pfast keeps it
       # to ~3 min; the tests themselves run in the next step.
       - name: Install all modules (produces the plugin zips)
-        run: mvn clean install -Pfast -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean install -Pfast -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
       # apache-rat:check here too -- the build job no longer sees these modules,
       # so without this they would drop out of license checking entirely.
       - name: Run integration tests
@@ -132,7 +143,7 @@ jobs:
       # what puts each zip in the local repo. -Pfast (skipTests + rat/checkstyle/spotless
       # off) because the build job owns all of that; this job only needs the artifacts.
       - name: Install all modules (produces the plugin zips)
-        run: mvn clean install -Pfast -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean install -Pfast -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
       # -pl must name the leaf modules: tika-e2e-tests is an aggregator pom, and Maven does
       # not pull in a selected aggregator's children, so this job built two pom-only modules
       # and ran zero tests while reporting green.

--- a/.github/workflows/main-jdk17-locale-build.yml
+++ b/.github/workflows/main-jdk17-locale-build.yml
@@ -59,6 +59,7 @@ jobs:
       # forgetting only makes this job slower, it does not weaken it.
       - name: Build with Maven (tr_TR locale)
         run: |
+          mvn install -Pfast -pl :tika-annotation-processor -am -B -q
           mvn clean test install -Pci -T1C \
             -pl '!:tika-pipes-es-integration-tests,!:tika-pipes-kafka-integration-tests,!:tika-pipes-opensearch-integration-tests,!:tika-pipes-s3-integration-tests,!:tika-pipes-solr-integration-tests' \
             -Duser.language=tr -Duser.country=TR \

--- a/.github/workflows/main-jdk17-locale-build.yml
+++ b/.github/workflows/main-jdk17-locale-build.yml
@@ -59,7 +59,7 @@ jobs:
       # forgetting only makes this job slower, it does not weaken it.
       - name: Build with Maven (tr_TR locale)
         run: |
-          mvn clean test install -Pci \
+          mvn clean test install -Pci -T1C \
             -pl '!:tika-pipes-es-integration-tests,!:tika-pipes-kafka-integration-tests,!:tika-pipes-opensearch-integration-tests,!:tika-pipes-s3-integration-tests,!:tika-pipes-solr-integration-tests' \
             -Duser.language=tr -Duser.country=TR \
             -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-windows-build.yml
+++ b/.github/workflows/main-jdk17-windows-build.yml
@@ -61,4 +61,4 @@ jobs:
         # The -Duser.* args MUST stay quoted: PowerShell splits an unquoted dotted
         # -D property before it reaches mvn, so the locale silently never applies
         # and the leftover fragment fails the build as an unknown lifecycle phase.
-        run: mvn clean test install javadoc:aggregate -Pci -Pe2e -T1C "-Duser.language=de" "-Duser.country=DE" -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn install -Pfast -pl ":tika-annotation-processor" -am -B -q; mvn clean test install javadoc:aggregate -Pci -Pe2e -T1C "-Duser.language=de" "-Duser.country=DE" -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk17-windows-build.yml
+++ b/.github/workflows/main-jdk17-windows-build.yml
@@ -61,4 +61,4 @@ jobs:
         # The -Duser.* args MUST stay quoted: PowerShell splits an unquoted dotted
         # -D property before it reaches mvn, so the locale silently never applies
         # and the leftover fragment fails the build as an unknown lifecycle phase.
-        run: mvn clean test install javadoc:aggregate -Pci -Pe2e "-Duser.language=de" "-Duser.country=DE" -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean test install javadoc:aggregate -Pci -Pe2e -T1C "-Duser.language=de" "-Duser.country=DE" -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk21-build.yml
+++ b/.github/workflows/main-jdk21-build.yml
@@ -40,4 +40,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean test install javadoc:aggregate -Pci -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean test install javadoc:aggregate -Pci -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk21-build.yml
+++ b/.github/workflows/main-jdk21-build.yml
@@ -40,4 +40,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean test install javadoc:aggregate -Pci -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn install -Pfast -pl :tika-annotation-processor -am -B -q && mvn clean test install javadoc:aggregate -Pci -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk25-build.yml
+++ b/.github/workflows/main-jdk25-build.yml
@@ -40,4 +40,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean test install javadoc:aggregate -Pci -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn clean test install javadoc:aggregate -Pci -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/main-jdk25-build.yml
+++ b/.github/workflows/main-jdk25-build.yml
@@ -40,4 +40,4 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean test install javadoc:aggregate -Pci -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn install -Pfast -pl :tika-annotation-processor -am -B -q && mvn clean test install javadoc:aggregate -Pci -T1C -B "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Tika](https://tika.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Tika issue tracker](https://issues.apache.org/jira/projects/TIKA) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`TIKA-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[TIKA-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Tika builds and unit tests pass with `./mvnw clean install` (`clean test` alone cannot resolve the pipes plugin zips)
* if you used a generative AI tool: follow the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) (`Generated-by: <tool>` in the commit message), and consider running the pre-flight in `.skills/devs/pr-review/SKILL.md` — fix what it finds; don't paste its report here
* there should be no conflicts when merging the pull request branch into the *recent* `main` branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled `main` branch
* if you add new module that downstream users will depend upon add it to relevant group in `tika-bom/pom.xml`.

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Tika in general, please sign up for the [Tika mailing list](http://tika.apache.org/mail-lists.html). Thanks!
