### PR TITLE
TIKA-4878: never treat a declared Content-Length as a measurement

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,13 @@
 Release 4.1.0 - unreleased
 
+   * A declared Content-Length is no longer treated as a measurement: the
+     zip-bomb ratio counts only measured input bytes (a container-declared
+     size on an embedded document could inflate its denominator), and a
+     re-openable source no longer reserves cache budget or sizes its buffer
+     from the declared length (a lying one could push a small payload to
+     disk or churn the shared budget). Neither is in a release: the
+     exposure arrived with TIKA-4868 and TIKA-4873 (TIKA-4878).
+
    * tika-server: named configuration presets (TIKA-4856).
 
    * Temp files follow -Djava.io.tmpdir on the parent JVM (Tika, its

--- a/tika-core/src/main/java/org/apache/tika/io/ReopenableSource.java
+++ b/tika-core/src/main/java/org/apache/tika/io/ReopenableSource.java
@@ -221,8 +221,11 @@ class ReopenableSource extends InputStream implements TikaInputSource {
     /**
      * Drains a fresh stream into memory if it fits within the per-object floor plus what
      * can be reserved from the shared budget, retaining the buffer (and its reservation)
-     * until {@link #close()}. The declared length is a sizing hint only -- it can lie, so
-     * the cap is enforced during the read. Does not disturb this source's read position.
+     * until {@link #close()}. The declared length is the file's claim: it may skip an
+     * attempt that cannot succeed (a lie there costs a spill, nothing more), but it never
+     * sizes a reservation or an allocation -- the buffer starts at the floor at most and
+     * grows, reserving, on what is actually read. Does not disturb this source's read
+     * position.
      */
     private boolean tryBufferInMemory() throws IOException {
         if (length > MAX_ARRAY_SIZE || (length > IN_MEMORY_FLOOR && budget == null)) {
@@ -230,14 +233,7 @@ class ReopenableSource extends InputStream implements TikaInputSource {
         }
         long reservedHere = 0;
         // Reservation invariant: reservedHere == max(0, data.length - IN_MEMORY_FLOOR)
-        if (length > IN_MEMORY_FLOOR) {
-            long extra = length - IN_MEMORY_FLOOR;
-            if (budget.tryReserve(extra) != extra) {
-                return false;
-            }
-            reservedHere = extra;
-        }
-        byte[] data = new byte[length > 0 ? (int) length : 8192];
+        byte[] data = new byte[(int) Math.max(8192, Math.min(length, IN_MEMORY_FLOOR))];
         int total = 0;
         boolean fits = false;
         try (InputStream in = opener.get()) {

--- a/tika-core/src/main/java/org/apache/tika/sax/SecureContentHandler.java
+++ b/tika-core/src/main/java/org/apache/tika/sax/SecureContentHandler.java
@@ -212,7 +212,9 @@ public class SecureContentHandler extends ContentHandlerDecorator {
 
     private long getByteCount() throws SAXException {
         try {
-            if (stream.hasLength()) {
+            //a declared Content-Length is the file's claim; only a measured length
+            //or the bytes actually read can serve as the ratio's denominator
+            if (stream.hasReliableLength()) {
                 return stream.getLength();
             } else {
                 return stream.getPosition();

--- a/tika-core/src/test/java/org/apache/tika/io/ReopenableSourceTest.java
+++ b/tika-core/src/test/java/org/apache/tika/io/ReopenableSourceTest.java
@@ -245,6 +245,29 @@ public class ReopenableSourceTest {
         }
     }
 
+    /**
+     * A declared length far above the content, against a budget that could never
+     * grant it: the claim must not be what gets reserved, or a 500-byte payload is
+     * pushed to disk by a number the file made up.
+     */
+    @Test
+    public void testLyingDeclaredLengthDoesNotReserveOrSpill() throws Exception {
+        byte[] data = data(500);
+        AtomicInteger opens = new AtomicInteger();
+        CacheMemoryBudget budget = new CacheMemoryBudget(1024);
+        try (ReopenableSource source = new ReopenableSource(countingOpener(data, opens), tmp,
+                50L * 1024 * 1024, null)) {
+            source.enableRewind(budget);
+            try (SeekableByteChannel channel = source.getSeekableByteChannel()) {
+                assertInstanceOf(MemorySeekableByteChannel.class, channel);
+                assertArrayEquals(data, readFully(channel));
+            }
+            assertFalse(source.hasPath());
+            assertEquals(0, budget.getReservedBytes(), "nothing reserved for a 500 byte payload");
+            assertEquals(500, source.getLength());
+        }
+    }
+
     @Test
     public void testLyingDeclaredLengthCorrected() throws Exception {
         byte[] data = data(500);

--- a/tika-core/src/test/java/org/apache/tika/sax/SecureContentHandlerTest.java
+++ b/tika-core/src/test/java/org/apache/tika/sax/SecureContentHandlerTest.java
@@ -29,7 +29,10 @@ import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.DefaultHandler;
 
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.HttpHeaders;
+import org.apache.tika.metadata.Metadata;
 
 /**
  * Tests for the {@link SecureContentHandler} class.
@@ -101,6 +104,31 @@ public class SecureContentHandlerTest {
             for (int i = 0; i < MANY_BYTES; i++) {
                 stream.read();
                 handler.characters(ch, 0, ch.length);
+            }
+            fail("Expected SAXException not thrown");
+        } catch (SAXException e) {
+            // expected
+        }
+    }
+
+    /**
+     * A one-shot stream carrying a declared Content-Length far above what it holds:
+     * the claim must not become the input byte count, or the ratio never trips.
+     */
+    @Test
+    public void testDeclaredLengthDoesNotInflateByteCount() throws IOException {
+        Metadata metadata = new Metadata();
+        //a plausible lie: large enough that no ratio trips, small enough that
+        //byteCount * ratio does not overflow and trip for the wrong reason
+        metadata.set(HttpHeaders.CONTENT_LENGTH, Long.toString(100L * 1024 * 1024 * 1024));
+        try (TikaInputStream lying = TikaInputStream.get(new NullInputStream(MANY_BYTES),
+                new TemporaryResources(), metadata)) {
+            SecureContentHandler lyingHandler =
+                    new SecureContentHandler(new DefaultHandler(), lying);
+            char[] ch = new char[1000];
+            for (int i = 0; i < MANY_BYTES; i++) {
+                lying.read();
+                lyingHandler.characters(ch, 0, ch.length);
             }
             fail("Expected SAXException not thrown");
         } catch (SAXException e) {


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Tika](https://tika.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Tika issue tracker](https://issues.apache.org/jira/projects/TIKA) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`TIKA-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[TIKA-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Tika builds and unit tests pass with `./mvnw clean install` (`clean test` alone cannot resolve the pipes plugin zips)
* if you used a generative AI tool: follow the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) (`Generated-by: <tool>` in the commit message), and consider running the pre-flight in `.skills/devs/pr-review/SKILL.md` — fix what it finds; don't paste its report here
* there should be no conflicts when merging the pull request branch into the *recent* `main` branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled `main` branch
* if you add new module that downstream users will depend upon add it to relevant group in `tika-bom/pom.xml`.

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Tika in general, please sign up for the [Tika mailing list](http://tika.apache.org/mail-lists.html). Thanks!
