### PR TITLE
[TIKA-4836] Fix typos in comments/javadoc

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/metadata/IPTC.java
+++ b/tika-core/src/main/java/org/apache/tika/metadata/IPTC.java
@@ -582,7 +582,7 @@ public interface IPTC {
      * Any algorithm to create this identifier has to comply with the technical
      * requirements to create a globally unique id. Any device creating digital
      * images - e.g. still image cameras, video cameras, scanners - should
-     * create such an identifer right at the time of the creation of the digital
+     * create such an identifier right at the time of the creation of the digital
      * data and add the id to the set of metadata without compromising
      * performance. It is recommended that this image identifier allows
      * identifying the device by which the image data and the GUID were created.
@@ -945,7 +945,7 @@ public interface IPTC {
      * <p>
      * This age should not be displayed to the public on open web portals and
      * the like. But it may be used by image repositories in a
-     * B2B enviroment.
+     * B2B environment.
      * <p>
      * This is a PLUS version 1.2 property included in the IPTC Extension
      * schema.

--- a/tika-eval/tika-eval-app/src/main/java/org/apache/tika/eval/app/ProfilerBase.java
+++ b/tika-eval/tika-eval-app/src/main/java/org/apache/tika/eval/app/ProfilerBase.java
@@ -151,7 +151,7 @@ public abstract class ProfilerBase {
     /**
      * @param p               path to the common_tokens directory.  If this is null, try to load from classPath
      * @param defaultLangCode this is the language code to use if a common_words list doesn't exist for the
-     *                        detected langauge; can be <code>null</code>
+     *                        detected language; can be <code>null</code>
      * @throws IOException
      */
     public static void loadCommonTokens(Path p, String defaultLangCode) throws IOException {


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.