### PR TITLE
TIKA-4882: Return default value if the extension is unknown in FilenameUtils

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/io/FilenameUtils.java
+++ b/tika-core/src/main/java/org/apache/tika/io/FilenameUtils.java
@@ -386,7 +386,7 @@ public class FilenameUtils {
      * On parse exception, unknown value or null value, return the default value.
      *
      * @param metadata
-     * @param defaultValue
+     * @param defaultValue, which should include a leading "."
      * @return the extension based on the mime type, including the initial "."
      */
     public static String calculateExtension(Metadata metadata, String defaultValue) {

--- a/tika-core/src/main/java/org/apache/tika/io/FilenameUtils.java
+++ b/tika-core/src/main/java/org/apache/tika/io/FilenameUtils.java
@@ -383,7 +383,7 @@ public class FilenameUtils {
 
     /**
      * Calculate the extension based on the {@link HttpHeaders#CONTENT_TYPE} value.
-     * On parse exception or null value, return the default value.
+     * On parse exception, unknown value or null value, return the default value.
      *
      * @param metadata
      * @param defaultValue
@@ -400,7 +400,7 @@ public class FilenameUtils {
         if (ext != null) {
             return ext;
         }
-        return ".bin";
+        return defaultValue;
     }
 
     private static String lookupExtension(String mime) {

--- a/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
@@ -245,10 +245,11 @@ public class FilenameUtilsTest {
 
     }
 
-    @Test
-    public void testCalculateExtensionUnknownValue() {
-        assertEquals(".pdf", FilenameUtils.calculateExtension(getMetadata("the quick brown fox", "unknown"), ".pdf"));
-    }
+@Test
+public void testCalculateExtensionUnknownValue() {
+    assertEquals(".pdf", FilenameUtils.calculateExtension(
+            getMetadata("the quick brown fox", "application/x-tika-unknown"), ".pdf"));
+}
 
     private String sanitizePath(String name) {
         return FilenameUtils.getSanitizedEmbeddedFilePath(getMetadata(name), ".bin", 50);

--- a/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
@@ -245,6 +245,11 @@ public class FilenameUtilsTest {
 
     }
 
+    @Test
+    public void testCalculateExtensionUnknownValue() {
+        assertEquals(".pdf", FilenameUtils.calculateExtension(getMetadata("the quick brown fox.unknown", "unknown"), ".pdf"));
+    }
+
     private String sanitizePath(String name) {
         return FilenameUtils.getSanitizedEmbeddedFilePath(getMetadata(name), ".bin", 50);
     }

--- a/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
@@ -245,11 +245,11 @@ public class FilenameUtilsTest {
 
     }
 
-@Test
-public void testCalculateExtensionUnknownValue() {
-    assertEquals(".pdf", FilenameUtils.calculateExtension(
-            getMetadata("the quick brown fox", "application/x-tika-unknown"), ".pdf"));
-}
+    @Test
+    public void testCalculateExtensionUnknownValue() {
+        assertEquals(".pdf", FilenameUtils.calculateExtension(
+                getMetadata("the quick brown fox", "application/x-tika-unknown"), ".pdf"));
+    }
 
     private String sanitizePath(String name) {
         return FilenameUtils.getSanitizedEmbeddedFilePath(getMetadata(name), ".bin", 50);

--- a/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/io/FilenameUtilsTest.java
@@ -247,7 +247,7 @@ public class FilenameUtilsTest {
 
     @Test
     public void testCalculateExtensionUnknownValue() {
-        assertEquals(".pdf", FilenameUtils.calculateExtension(getMetadata("the quick brown fox.unknown", "unknown"), ".pdf"));
+        assertEquals(".pdf", FilenameUtils.calculateExtension(getMetadata("the quick brown fox", "unknown"), ".pdf"));
     }
 
     private String sanitizePath(String name) {


### PR DESCRIPTION
Currently the behavior of `FilenameUtils.calculateExtension` only specifies that the `defaultValue` is returned on a parse exception or a null value. The behavior for an unknown value is not specified and silently returns `.bin`. I adjusted the docs and now the `defaultValue` is returned, if the extension is unknown. Also added a corresponding test.