### PR TITLE
TIKA-4886: Do not start subprocess, if granted timeout is <= 0

### DIFF
--- a/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
+++ b/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
@@ -146,6 +146,12 @@ public class ProcessUtils {
         long grantedTimeoutMillis = context == null
                 ? requestedTimeoutMillis
                 : ParseTimeout.getOrCreate(context).budgetFor(requestedTimeoutMillis);
+
+        FileProcessResult result = checkIfExhausted(requestedTimeoutMillis, grantedTimeoutMillis);
+        if (result != null) {
+            return result;
+        }
+
         Process p = null;
         String id = null;
         try {
@@ -191,7 +197,7 @@ public class ProcessUtils {
                 outThread.interrupt();
                 errThread.interrupt();
             }
-            FileProcessResult result = new FileProcessResult();
+            result = new FileProcessResult();
             result.processTimeMillis = elapsed;
             result.stderrLength = errGobbler.getStreamLength();
             result.stdoutLength = outGobbler.getStreamLength();
@@ -442,4 +448,16 @@ public class ProcessUtils {
         }
     }
 
+    private static FileProcessResult checkIfExhausted(long requestedTimeoutMillis, long grantedTimeoutMillis) {
+        if (grantedTimeoutMillis <= 0) {
+            FileProcessResult result = new FileProcessResult();
+            result.isTimeout = true;
+            result.requestedTimeoutMillis = requestedTimeoutMillis;
+            result.grantedTimeoutMillis = grantedTimeoutMillis;
+
+            return result;
+        }
+
+        return null;
+    }
 }

--- a/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
+++ b/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
@@ -268,7 +268,14 @@ public class ProcessUtils {
         long grantedTimeoutMillis = context == null
                 ? requestedTimeoutMillis
                 : ParseTimeout.getOrCreate(context).budgetFor(requestedTimeoutMillis);
+
+        Optional<FileProcessResult> potentiallyFailedResult = failFastIfNoGrantedTimeout(requestedTimeoutMillis, grantedTimeoutMillis);
+        if (potentiallyFailedResult.isPresent()) {
+            return potentiallyFailedResult.get();
+        }
+
         pb.redirectOutput(stdoutRedirect.toFile());
+
         Process p = null;
         String id = null;
         try {
@@ -449,12 +456,22 @@ public class ProcessUtils {
         }
     }
 
+    /**
+     * Guards against both 0 and negative grants.
+     *
+     * @param requestedTimeoutMillis
+     * @param grantedTimeoutMillis
+     * @return result, if the process shouldn't be started, otherwise empty optional
+     */
     private static Optional<FileProcessResult> failFastIfNoGrantedTimeout(long requestedTimeoutMillis, long grantedTimeoutMillis) {
         if (grantedTimeoutMillis <= 0) {
             FileProcessResult result = new FileProcessResult();
             result.isTimeout = true;
             result.requestedTimeoutMillis = requestedTimeoutMillis;
             result.grantedTimeoutMillis = grantedTimeoutMillis;
+            result.processTimeMillis = 0;
+            result.stdoutLength = 0;
+            result.stderrLength = 0;
 
             return Optional.of(result);
         }

--- a/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
+++ b/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
@@ -20,6 +20,7 @@ package org.apache.tika.utils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -147,9 +148,9 @@ public class ProcessUtils {
                 ? requestedTimeoutMillis
                 : ParseTimeout.getOrCreate(context).budgetFor(requestedTimeoutMillis);
 
-        FileProcessResult result = failFastIfNoGrantedTimeout(requestedTimeoutMillis, grantedTimeoutMillis);
-        if (result != null) {
-            return result;
+        Optional<FileProcessResult> potentiallyFailedResult = failFastIfNoGrantedTimeout(requestedTimeoutMillis, grantedTimeoutMillis);
+        if (potentiallyFailedResult.isPresent()) {
+            return potentiallyFailedResult.get();
         }
 
         Process p = null;
@@ -197,7 +198,7 @@ public class ProcessUtils {
                 outThread.interrupt();
                 errThread.interrupt();
             }
-            result = new FileProcessResult();
+            FileProcessResult result = new FileProcessResult();
             result.processTimeMillis = elapsed;
             result.stderrLength = errGobbler.getStreamLength();
             result.stdoutLength = outGobbler.getStreamLength();
@@ -448,16 +449,16 @@ public class ProcessUtils {
         }
     }
 
-    private static FileProcessResult failFastIfNoGrantedTimeout(long requestedTimeoutMillis, long grantedTimeoutMillis) {
+    private static Optional<FileProcessResult> failFastIfNoGrantedTimeout(long requestedTimeoutMillis, long grantedTimeoutMillis) {
         if (grantedTimeoutMillis <= 0) {
             FileProcessResult result = new FileProcessResult();
             result.isTimeout = true;
             result.requestedTimeoutMillis = requestedTimeoutMillis;
             result.grantedTimeoutMillis = grantedTimeoutMillis;
 
-            return result;
+            return Optional.of(result);
         }
 
-        return null;
+        return Optional.empty();
     }
 }

--- a/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
+++ b/tika-core/src/main/java/org/apache/tika/utils/ProcessUtils.java
@@ -147,7 +147,7 @@ public class ProcessUtils {
                 ? requestedTimeoutMillis
                 : ParseTimeout.getOrCreate(context).budgetFor(requestedTimeoutMillis);
 
-        FileProcessResult result = checkIfExhausted(requestedTimeoutMillis, grantedTimeoutMillis);
+        FileProcessResult result = failFastIfNoGrantedTimeout(requestedTimeoutMillis, grantedTimeoutMillis);
         if (result != null) {
             return result;
         }
@@ -448,7 +448,7 @@ public class ProcessUtils {
         }
     }
 
-    private static FileProcessResult checkIfExhausted(long requestedTimeoutMillis, long grantedTimeoutMillis) {
+    private static FileProcessResult failFastIfNoGrantedTimeout(long requestedTimeoutMillis, long grantedTimeoutMillis) {
         if (grantedTimeoutMillis <= 0) {
             FileProcessResult result = new FileProcessResult();
             result.isTimeout = true;

--- a/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
@@ -27,6 +27,8 @@ import org.apache.tika.config.ParseTimeout;
 import org.apache.tika.config.TimeoutLimits;
 import org.apache.tika.parser.ParseContext;
 
+import java.io.IOException;
+
 /**
  * These tests spawn the OS {@code sleep} command directly (unavailable on Windows) rather
  * than mocking {@link Process}, because the property under test -- that a checkpoint fires
@@ -139,16 +141,16 @@ public class ProcessUtilsTest {
     public void testExecuteFailsFastIfTimeoutIsZero() throws Exception {
         assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
-        ProcessBuilder pb = new ProcessBuilder("sleep", "5");
+        ProcessBuilder pb = new ProcessBuilder("non-existing-command-throwing-exception-if-executed");
         ParseContext context = new ParseContext();
         context.set(TimeoutLimits.class, new TimeoutLimits(0, 0));
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         FileProcessResult result = ProcessUtils.execute(pb, context, 5_000L, 1000, 1000);
-        long elapsed = System.currentTimeMillis() - start;
+        long elapsed = System.nanoTime() - start;
 
         assertTrue(result.isTimeout(), "a process with a 0 timeout should timeout immediately without starting");
         assertEquals(0, result.getGrantedTimeoutMillis(), "the process should not have been granted any timeout; got " + result.getGrantedTimeoutMillis() + "ms");
-        assertTrue(elapsed < 4_000, "fast path should return without spawning; took " +  elapsed + "ms");
+        assertTrue(elapsed < 4_000_000_000L, "fast path should return without spawning; took " +  elapsed + "ms");
     }
 }

--- a/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
@@ -149,6 +149,6 @@ public class ProcessUtilsTest {
 
         assertTrue(result.isTimeout(), "a process with a 0 timeout should timeout immediately without starting");
         assertEquals(0, result.getGrantedTimeoutMillis(), "the process should not have been granted any timeout; got " + result.getGrantedTimeoutMillis() + "ms");
-        assertTrue(elapsed < 1000, "fast path should return without spawning; took " +  elapsed + "ms");
+        assertTrue(elapsed < 4_000, "fast path should return without spawning; took " +  elapsed + "ms");
     }
 }

--- a/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
@@ -18,6 +18,7 @@ package org.apache.tika.utils;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.junit.jupiter.api.Test;
@@ -132,5 +133,22 @@ public class ProcessUtilsTest {
         assertFalse(result, "a command that outlives its timeout must report failure");
         assertTrue(elapsed < 4_000,
                 "checkCommandWithTimeout must honor its own timeout, not the default; took " + elapsed + "ms");
+    }
+
+    @Test
+    public void testExecuteFailsFastIfTimeoutIsZero() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+
+        ProcessBuilder pb = new ProcessBuilder("sleep", "5");
+        ParseContext context = new ParseContext();
+        context.set(TimeoutLimits.class, new TimeoutLimits(0, 0));
+
+        long start = System.currentTimeMillis();
+        FileProcessResult result = ProcessUtils.execute(pb, context, 5_000L, 1000, 1000);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result.isTimeout(), "a process with a 0 timeout should timeout immediately without starting");
+        assertEquals(0, result.getGrantedTimeoutMillis(), "the process should not have been granted any timeout; got " + result.getGrantedTimeoutMillis() + "ms");
+        assertTrue(elapsed < 1000, "fast path should return without spawning; took " +  elapsed + "ms");
     }
 }

--- a/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
@@ -21,13 +21,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 import org.apache.tika.config.ParseTimeout;
 import org.apache.tika.config.TimeoutLimits;
 import org.apache.tika.parser.ParseContext;
-
-import java.io.IOException;
 
 /**
  * These tests spawn the OS {@code sleep} command directly (unavailable on Windows) rather
@@ -149,8 +152,37 @@ public class ProcessUtilsTest {
         FileProcessResult result = ProcessUtils.execute(pb, context, 5_000L, 1000, 1000);
         long elapsed = System.nanoTime() - start;
 
+        assertSubprocessDidNotStart(result, elapsed);
+    }
+
+    @Test
+    public void testExecuteWithRedirectFailsFastIfTimeoutIsZero() throws Exception {
+        ParseContext context = new ParseContext();
+        context.set(TimeoutLimits.class, new TimeoutLimits(0, 0));
+        ProcessBuilder pb = new ProcessBuilder("non-existing-command-throwing-exception-if-executed");
+        Path stdoutRedirect = createTmpRedirect();
+
+        long start = System.nanoTime();
+        FileProcessResult result = ProcessUtils.execute(pb, context, 5_000L, stdoutRedirect, 1000);
+        long elapsed = System.nanoTime() - start;
+
+        assertSubprocessDidNotStart(result, elapsed);
+    }
+
+    private static @NonNull Path createTmpRedirect() throws IOException {
+        Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
+        Files.createDirectories(tmpDir);
+        Path stdoutRedirect = Files.createTempFile(tmpDir, "tika-test-", ".out");
+        stdoutRedirect.toFile().deleteOnExit();
+        return stdoutRedirect;
+    }
+
+    private static void assertSubprocessDidNotStart(FileProcessResult result, long elapsed) {
         assertTrue(result.isTimeout(), "a process with a 0 timeout should timeout immediately without starting");
         assertEquals(0, result.getGrantedTimeoutMillis(), "the process should not have been granted any timeout; got " + result.getGrantedTimeoutMillis() + "ms");
-        assertTrue(elapsed < 4_000_000_000L, "fast path should return without spawning; took " +  elapsed + "ms");
+        assertEquals(0, result.getProcessTimeMillis(), "processTimeMillis should be 0 on fast path");
+        assertEquals(0, result.getStdoutLength(), "stdoutLength should be 0 on fast path");
+        assertEquals(0, result.getStderrLength(), "stderrLength should be 0 on fast path");
+        assertTrue(elapsed < 4_000_000_000L, "fast path should return without spawning; took " + elapsed + "ms");
     }
 }

--- a/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
+++ b/tika-core/src/test/java/org/apache/tika/utils/ProcessUtilsTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.tika.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Currently `ProcessUtils.execute` starts and then immediately kills a subprocess, even if the granted timeout is <= `0`. `TikaHttpClient` has a similar scenario and handles that [fast-path failure scenario explicitly](https://github.com/apache/tika/blob/7b36986bb7ce035aca23892052cbdff3e5a1f4e6/tika-parsers/tika-http-jdk/src/main/java/org/apache/tika/http/TikaHttpClient.java#L137), so a similar mechanism is added to `ProcessUtils.execute`.